### PR TITLE
change to nd2 package for read in

### DIFF
--- a/workflow/envs/preprocess.yml
+++ b/workflow/envs/preprocess.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - nd2reader
+  - nd2
+  - xarray
   - scikit-image
   - joblib

--- a/workflow/lib/preprocess/preprocess.py
+++ b/workflow/lib/preprocess/preprocess.py
@@ -78,8 +78,7 @@ def extract_metadata_tile(files: list[str], z_interval: int = 4, verbose: bool =
 
 
 def nd2_to_tiff(file: str, channel_order_flip: bool = False, verbose: bool = False) -> np.ndarray:
-    """Converts a single ND2 file with one field of view and multiple channels to a multidimensional numpy array, 
-    ensuring the structure is CYX.
+    """Converts a single ND2 file with one field of view and multiple channels to a multidimensional numpy array, ensuring the structure is CYX.
 
     Args:
         file (str): Path to the ND2 file.

--- a/workflow/lib/preprocess/preprocess.py
+++ b/workflow/lib/preprocess/preprocess.py
@@ -2,94 +2,111 @@
 
 import pandas as pd
 import numpy as np
-from nd2reader import ND2Reader
+import nd2
 
 from lib.preprocess.file_utils import extract_tile_from_filename
 
 
-def extract_metadata_tile(files: list[str]) -> pd.DataFrame:
+def extract_metadata_tile(files: list[str], z_interval: int = 4, verbose: bool = False) -> pd.DataFrame:
     """Extracts metadata from a list of ND2 files.
 
     Args:
         files (list[str]): List of file paths pointing to ND2 files.
+        z_interval (int, optional): If set, samples z-planes at this interval to ensure metadata is one line per position. Defaults to 4.
+        verbose (bool, optional): If True, prints metadata information. Defaults to False.
 
     Returns:
         pd.DataFrame: Combined extracted metadata from all provided ND2 files.
     """
     all_metadata = []
 
-    # Iterate through all provided files
     for file_path in files:
+        if verbose:
+            print(f"Processing {file_path}")
+            
         tile = extract_tile_from_filename(file_path)
+        
+        try:
+            with nd2.ND2File(file_path) as images:
+                # Get coordinate data with error handling
+                metadata = {
+                    "x_data": getattr(images.experiment[0], 'position_x', []),
+                    "y_data": getattr(images.experiment[0], 'position_y', []),
+                    "z_data": getattr(images.experiment[0], 'position_z', []),
+                    "field_of_view": tile,
+                    "filename": file_path,
+                }
+                
+                # Add additional metadata if available
+                try:
+                    metadata["pfs_offset"] = images.metadata.channels[0].pfs_offset
+                except (AttributeError, IndexError):
+                    metadata["pfs_offset"] = None
+                    
+                # Add more metadata fields
+                metadata.update({
+                    "channels": images.channel_count(),
+                    "pixel_size_x": getattr(images.metadata, 'pixel_size_x', None),
+                    "pixel_size_y": getattr(images.metadata, 'pixel_size_y', None),
+                    "z_step": getattr(images.metadata, 'z_step', None),
+                })
 
-        with ND2Reader(file_path) as images:
-            raw_metadata = images.parser._raw_metadata
+                df = pd.DataFrame(metadata)
 
-            data = {
-                "x_data": raw_metadata.x_data,
-                "y_data": raw_metadata.y_data,
-                "z_data": images.metadata["z_coordinates"],
-                "pfs_offset": raw_metadata.pfs_offset,
-                "field_of_view": tile,
-                "filename": file_path,
-            }
+                # Sample z-planes if interval is specified and z_data exists
+                if z_interval and len(metadata["z_data"]) > 0:
+                    df = df.iloc[::z_interval, :]
+                
+                if verbose:
+                    print(f"Found {len(df)} positions for tile {tile}")
+                
+                all_metadata.append(df)
+                
+        except Exception as e:
+            print(f"Error processing {file_path}: {str(e)}")
+            continue
 
-            df = pd.DataFrame(data)
-
-            if "z_levels" in images.metadata and set(
-                images.metadata["z_levels"]
-            ) == set(range(0, 4)):
-                df = df.iloc[::4, :]
-            all_metadata.append(df)
-
-    # Combine all metadata
     if all_metadata:
         combined_metadata = pd.concat(all_metadata, ignore_index=True)
-
-        # Convert 'field_of_view' to numeric, coercing any non-numeric values to NaN
         combined_metadata["field_of_view"] = pd.to_numeric(
             combined_metadata["field_of_view"], errors="coerce"
         )
-        # Sort by 'field_of_view' in ascending order
-        combined_metadata = combined_metadata.sort_values("field_of_view").reset_index(
-            drop=True
-        )
-        return combined_metadata
-    else:
-        print("No valid ND2 files found in the provided list.")
-        return pd.DataFrame()  # Return an empty DataFrame if no files were processed
+        return combined_metadata.sort_values("field_of_view").reset_index(drop=True)
+    
+    print("No valid ND2 files found in the provided list.")
+    return pd.DataFrame()
 
 
-def nd2_to_tiff(file: str, channel_order_flip: bool = False) -> np.ndarray:
-    """Converts a single ND2 file with one field of view and multiple channels to a multidimensional numpy array.
+def nd2_to_tiff(file: str, channel_order_flip: bool = False, verbose: bool = False) -> np.ndarray:
+    """Converts a single ND2 file with one field of view and multiple channels to a multidimensional numpy array, 
+    ensuring the structure is CYX.
 
     Args:
         file (str): Path to the ND2 file.
-        channel_order_flip (bool, optional): If True, reverses the order of channels. Defaults to False.
+        channel_order_flip (bool, optional): If True, flips the channel order. Defaults to False.
+        verbose (bool, optional): If True, prints dimension information. Defaults to False.
 
     Returns:
         np.ndarray: Image data as a multidimensional numpy array.
     """
-    with ND2Reader(file) as images:
-        # Determine the axes order (always include 'c' for channels)
-        axes = "cyx"
-        if "z" in images.axes:
-            axes = "zcyx"
+    # Load with xarray to keep dimension labels
+    image = nd2.imread(file, xarray=True)
+    
+    if verbose:
+        print(f"Original dimensions: {image.dims}")
+       
+    # Handle Z-stack if present
+    if 'Z' in image.dims:
+        image = image.max(dim='Z')
+    
+    # Convert to numpy array in CYX order
+    image_array = image.transpose('C', 'Y', 'X').values
 
-        images.bundle_axes = axes
+    # Flip channel order on C axis if requested
+    if channel_order_flip:
+        image_array = np.flip(image_array, axis=0)  # axis 0 is the C axis
 
-        # Get the single image (all channels)
-        image = images[0]
-
-        # Handle z-stacks: max project if 'z' is in axes
-        if "z" in axes:
-            image = np.max(image, axis=0)  # Max projection along z-axis
-
-        # Flip channel order if specified
-        if channel_order_flip:
-            image = np.flip(image, axis=0)  # Flip along first axis (channels)
-
-        # Ensure the image is uint16
-        image_array = np.array(image, dtype=np.uint16)
-
-    return image_array
+    if verbose:
+        print(f"Final dimensions: {image_array.shape}")
+    
+    return image_array.astype(np.uint16)

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -28,6 +28,8 @@ rule extract_metadata_sbs:
         / "metadata"
         / "sbs"
         / get_filename({"well": "{well}", "cycle": "{cycle}"}, "metadata", "tsv"),
+    params:
+        z_interval=None,
     script:
         "../scripts/preprocess/extract_metadata_tile.py"
 
@@ -43,6 +45,8 @@ rule extract_metadata_phenotype:
         / "metadata"
         / "phenotype"
         / get_filename({"well": "{well}"}, "metadata", "tsv"),
+    params:
+        z_interval=4,
     script:
         "../scripts/preprocess/extract_metadata_tile.py"
 

--- a/workflow/scripts/preprocess/extract_metadata_tile.py
+++ b/workflow/scripts/preprocess/extract_metadata_tile.py
@@ -1,7 +1,9 @@
 from lib.preprocess.preprocess import extract_metadata_tile
 
 # Extract metadata from ND2 file paths using the _extract_metadata_tile function
-metadata_df = extract_metadata_tile(snakemake.input)
+metadata_df = extract_metadata_tile(
+    snakemake.input, z_interval=snakemake.params.z_interval
+)
 
 # Save the extracted metadata to the output path
 metadata_df.to_csv(snakemake.output[0], index=False, sep="\t")


### PR DESCRIPTION
Not much of a change, but eliminated nd2reader and added nd2 as the default file read in. Some changes to the preprocessing scripts. Also added functionality to specify the number of z dimensions to flatten on, this will make metadata generation easier.