### PR TITLE
Add Gene/Cluster search and UX improvements to Cluster page (v3)

### DIFF
--- a/visualization/pages/3_Quality_Control.py
+++ b/visualization/pages/3_Quality_Control.py
@@ -43,7 +43,9 @@ def apply_all_filters(df, sidebar):
     selected_values = {}
 
     for column, label in filters:
-        selected_value = create_filter_radio(filtered_df, column, sidebar, label)
+        # Create a unique key for each filter based on the column name
+        key = f"filter_{column}"
+        selected_value = create_filter_radio(filtered_df, column, sidebar, label, key=key)
         filtered_df = apply_filter(filtered_df, column, selected_value)
         selected_values[column] = selected_value
 

--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -11,7 +11,6 @@ import glob
 import os
 import json
 
-import plotly.express as px
 import plotly.graph_objects as go
 
 import matplotlib.pyplot as plt
@@ -36,7 +35,6 @@ SOURCE_INDEX = 3
 
 # =====================
 # FUNCTIONS
-
 
 # Load and merge cluster TSV files
 @st.cache_data
@@ -73,39 +71,6 @@ def load_cluster_data():
     # Concatenate all dataframes
     return pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
 
-
-# Create a scatter plot with consistent settings
-def create_scatter_plot(
-    data, color_column, color_discrete_sequence, color_discrete_map=None
-):
-    fig = px.scatter(
-        data,
-        x="PHATE_0",
-        y="PHATE_1",
-        color=color_column,
-        hover_data=HOVER_COLUMNS,
-        title="PHATE Visualization",
-        width=1000,
-        height=800,
-        color_discrete_sequence=color_discrete_sequence,
-        color_discrete_map=color_discrete_map or {},
-    )
-
-    # Apply hover template to all traces
-    for trace in fig.data:
-        trace.hovertemplate = (
-            "PHATE_0=%{x}<br>"
-            "PHATE_1=%{y}<br>"
-            f"gene_symbol_0=%{{customdata[{GENE_SYMBOL_INDEX}]}}<br>"
-            f"cluster=%{{customdata[{CLUSTER_INDEX}]}}<br>"
-            f"cell_count=%{{customdata[{CELL_COUNT_INDEX}]}}<br>"
-            f"source=%{{customdata[{SOURCE_INDEX}]}}<br>"
-            "<extra></extra>"
-        )
-
-    return fig
-
-
 # Extract item value from selected point
 def get_item_value_from_point(selected_point, groupby_column):
     # Get value from customdata which contains the hover_data values
@@ -120,7 +85,6 @@ def get_item_value_from_point(selected_point, groupby_column):
         return selected_point["legendgroup"]
 
     return None
-
 
 # Helper function to create a scatter trace
 def make_scatter_trace(x, y, marker, text, customdata, name, showlegend, color=None):
@@ -148,7 +112,6 @@ def make_scatter_trace(x, y, marker, text, customdata, name, showlegend, color=N
         showlegend=False,
     )
 
-
 @st.cache_data
 def load_montage_data(root_dir, gene_name):
     # Find all montage files
@@ -167,7 +130,6 @@ def load_montage_data(root_dir, gene_name):
     )
 
     return filtered_df
-
 
 def display_gene_montages(gene_montages_root, gene):
     gene_dir = os.path.join(gene_montages_root, gene)
@@ -249,7 +211,6 @@ def display_gene_montages(gene_montages_root, gene):
                     st.warning(f"No overlay tiff found: {overlay_tiff_path}")
             else:
                 st.warning(f"No image found for {gene} - {selected_guide}")
-
 
 def display_cluster(cluster_data, cell_class=None, channel_combo=None):
     r"""
@@ -569,7 +530,6 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
     else:
         st.write("No cluster data files found.")
 
-
 def display_cluster_json(cluster_data, container=st.container()):
     if (
         "selected_item" in st.session_state
@@ -667,7 +627,6 @@ def display_cluster_json(cluster_data, container=st.container()):
                 )
                 return
 
-
 def display_uniprot_info():
     if st.session_state.selected_gene:
         source_tsv = cluster_data["source_full_path"].unique()[0]
@@ -685,7 +644,6 @@ def display_uniprot_info():
                     st.markdown(f"Uniprot Function:\n>{function_text}")
                 else:
                     st.write("Uniprot Function: Not available")
-
 
 def initialize_session_state() -> None:
     """Initialize all session state variables used in the cluster analysis.
@@ -733,20 +691,6 @@ def initialize_session_state() -> None:
     # Initialize filter counter for unique keys
     if "filter_counter" not in st.session_state:
         st.session_state.filter_counter = 0
-
-def get_filter_key(base_key: str) -> str:
-    """Generate a unique but stable key for filter elements.
-
-    Args:
-        base_key: The base key to use for the filter element
-
-    Returns:
-        A unique key string that includes a counter
-    """
-    key = f"{base_key}_{st.session_state.filter_counter}"
-    st.session_state.filter_counter += 1
-    return key
-
 
 # --- Widget Callbacks ---
 def on_global_gene_select() -> None:

--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -788,13 +788,25 @@ else:
                 None  # Reset selected gene when cluster changes
             )
 
-        st.selectbox(
-            "Select a cluster to view",
-            options=cluster_options,
-            index=selected_index,
-            key="cluster_dropdown",
-            on_change=on_cluster_select,
-        )
+        # Create a container with an outline for the cluster selection
+        with st.container():
+            st.write("""
+                <style>
+                div[data-testid="stElementContainer"][data-stale="false"][class*="st-key-cluster_dropdown"] {
+                    border: 1px solid #4a4a4a;
+                    border-radius: 5px;
+                    padding: 1rem;
+                    margin-bottom: 1rem;
+                }
+                </style>
+            """, unsafe_allow_html=True)
+            st.selectbox(
+                "Select a cluster to view",
+                options=cluster_options,
+                index=selected_index,
+                key="cluster_dropdown",
+                on_change=on_cluster_select,
+            )
 
         selected_gene_info_df = cluster_data[
             cluster_data[groupby_column] == selected_item

--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -806,12 +806,23 @@ else:
 
         ## Cluster Info
         # Create two columns for the title and clear button
-        title_col, button_col = st.columns([7, 1])
+        title_col, button_col = st.columns([2, 1])
         with title_col:
             st.write(f"## Cluster {selected_item}: {len(genes)} genes")
         with button_col:
+            # Add float styling and red color specifically for the Close Cluster button
+            st.markdown("""
+                <style>
+                div[data-testid="stButton"] button {
+                    float: right;
+                    background-color: #dc2626 !important;
+                    border-color: #dc2626 !important;
+                    color: white !important;
+                }
+                </style>
+            """, unsafe_allow_html=True)
             # Show selected item and clear button if an item is selected
-            if st.button("X"):
+            if st.button("Close Cluster"):
                 st.session_state.selected_item = None
                 st.session_state.selected_gene = None
                 st.rerun()

--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -856,7 +856,7 @@ def apply_all_filters(data):
     data = apply_filter(data, "cell_class", selected_cell_class)
 
     # Leiden Resolution filter - handle directly
-    leiden_options = sorted(data["leiden_resolution"].unique().tolist())
+    leiden_options = sorted(data["leiden_resolution"].unique().tolist(), key=lambda x: float(x))
     # Initialize leiden resolution in session state if needed
     if "leiden_resolution" not in st.session_state:
         st.session_state.leiden_resolution = leiden_options[0] if leiden_options else None

--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -799,7 +799,7 @@ else:
         selected_gene_info_df = cluster_data[
             cluster_data[groupby_column] == selected_item
         ]
-        genes = selected_gene_info_df["gene_symbol_0"].tolist()
+        genes = sorted(selected_gene_info_df["gene_symbol_0"].tolist())
         gene_montages_root = os.path.join(
             BRIEFLOW_OUTPUT_PATH, "aggregate", "montages", f"{cell_class}__montages"
         )

--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import uuid
 
 st.set_page_config(
     page_title="Cluster Analysis - Brieflow Analysis",
@@ -8,7 +9,6 @@ st.set_page_config(
 import pandas as pd
 import glob
 import os
-import uuid
 import json
 
 import plotly.express as px
@@ -251,9 +251,11 @@ def display_gene_montages(gene_montages_root, gene):
                 st.warning(f"No image found for {gene} - {selected_guide}")
 
 
-def display_cluster(cluster_data, container=st.container()):
+def display_cluster(cluster_data, cell_class=None, channel_combo=None):
     r"""
     :param cluster_data: a dataframe from load_cluster_data
+    :param cell_class: the selected cell class filter value
+    :param channel_combo: the selected channel combo filter value
     :param container: an st.container or equivalent that UI elements will be added to
     """
     global st
@@ -540,7 +542,7 @@ def display_cluster(cluster_data, container=st.container()):
             BRIEFLOW_OUTPUT_PATH,
             "aggregate",
             "tsvs",
-            f"CeCl-{selected_cell_class}_ChCo-{selected_channel_combo}__feature_table.tsv",
+            f"CeCl-{cell_class}_ChCo-{channel_combo}__feature_table.tsv",
         )
 
         # Load and display the feature table if it exists
@@ -685,131 +687,285 @@ def display_uniprot_info():
                     st.write("Uniprot Function: Not available")
 
 
-# =====================
-# MAIN CODE
+def initialize_session_state() -> None:
+    """Initialize all session state variables used in the cluster analysis.
 
-# Initialize session state for selected item and grouping column if they don't exist
-if "selected_item" not in st.session_state:
-    st.session_state.selected_item = None
+    This function sets up all the necessary session state variables with their default values.
+    It should be called at the start of the script to ensure all required state variables
+    are properly initialized.
+    """
+    # Initialize basic selection states
+    if "selected_item" not in st.session_state:
+        st.session_state.selected_item = None
+    if "groupby_column" not in st.session_state:
+        st.session_state.groupby_column = "cluster"
+    if "selected_gene" not in st.session_state:
+        st.session_state.selected_gene = None
+    if "selected_guide" not in st.session_state:
+        st.session_state.selected_guide = None
 
-if "groupby_column" not in st.session_state:
-    st.session_state.groupby_column = "cluster"
+    # Initialize zoom coordinates
+    if "zoom_xrange" not in st.session_state:
+        st.session_state.zoom_xrange = None
+    if "zoom_yrange" not in st.session_state:
+        st.session_state.zoom_yrange = None
 
-# Initialize session state for selected gene if it doesn't exist
-if "selected_gene" not in st.session_state:
+    # Initialize search state
+    if "last_gene_search" not in st.session_state:
+        st.session_state.last_gene_search = ""
+    if "last_cluster_search" not in st.session_state:
+        st.session_state.last_cluster_search = ""
+
+    # Initialize gene selection dropdowns
+    if "selected_gene_global" not in st.session_state:
+        st.session_state.selected_gene_global = None
+    if "selected_gene_cluster" not in st.session_state:
+        st.session_state.selected_gene_cluster = None
+
+    # Initialize cell class
+    if "cell_class" not in st.session_state:
+        st.session_state.cell_class = "all"
+
+    # Initialize cluster dropdown
+    if "cluster_dropdown" not in st.session_state:
+        st.session_state.cluster_dropdown = None
+
+    # Initialize filter counter for unique keys
+    if "filter_counter" not in st.session_state:
+        st.session_state.filter_counter = 0
+
+def get_filter_key(base_key: str) -> str:
+    """Generate a unique but stable key for filter elements.
+
+    Args:
+        base_key: The base key to use for the filter element
+
+    Returns:
+        A unique key string that includes a counter
+    """
+    key = f"{base_key}_{st.session_state.filter_counter}"
+    st.session_state.filter_counter += 1
+    return key
+
+
+# --- Widget Callbacks ---
+def on_global_gene_select() -> None:
+    """Callback function for global gene selection.
+
+    Updates the selected gene and its associated cluster in the session state.
+    When a gene is selected globally, it also updates the cluster selection to match
+    the cluster containing the selected gene.
+    """
+    gene = st.session_state.selected_gene_global
+    st.session_state.selected_gene = gene
+    # Set cluster to the gene's cluster
+    gene_row = cluster_data[cluster_data["gene_symbol_0"] == gene]
+    if not gene_row.empty:
+        cluster_num = str(gene_row["cluster"].iloc[0])
+        st.session_state.selected_item = cluster_num
+        st.session_state.cluster_dropdown = cluster_num
+        st.session_state.selected_gene_cluster = gene
+    else:
+        st.session_state.selected_item = None
+        st.session_state.cluster_dropdown = None
+        st.session_state.selected_gene_cluster = None
+
+def on_cluster_select() -> None:
+    """Callback function for cluster selection.
+
+    Updates the selected cluster and its associated gene in the session state.
+    When a cluster is selected, it automatically selects the first gene in that cluster.
+    If 'Select a cluster to view' is chosen, it clears all selections.
+    """
+    cluster = st.session_state.cluster_dropdown
+    if cluster == "Select a cluster...":
+        st.session_state.selected_item = None
+        st.session_state.selected_gene = None
+        st.session_state.selected_gene_global = None
+        st.session_state.selected_gene_cluster = None
+    else:
+        st.session_state.selected_item = cluster
+        # Find the first gene in this cluster
+        cluster_genes = get_cluster_genes(cluster_data, cluster)
+        if cluster_genes:
+            first_gene = cluster_genes[0]
+            st.session_state.selected_gene = first_gene
+            st.session_state.selected_gene_global = first_gene
+            st.session_state.selected_gene_cluster = first_gene
+        else:
+            st.session_state.selected_gene = None
+            st.session_state.selected_gene_global = None
+            st.session_state.selected_gene_cluster = None
+
+def on_cluster_gene_select() -> None:
+    """Callback function for gene selection within a cluster.
+
+    Updates the selected gene in both global and cluster contexts.
+    This ensures that gene selection is synchronized between the global
+    and cluster-specific views.
+    """
+    gene = st.session_state.selected_gene_cluster
+    st.session_state.selected_gene = gene
+    st.session_state.selected_gene_global = gene
+
+def on_channel_combo_change():
+    """Callback function for channel combo selection."""
+    st.session_state.channel_combo = st.session_state.channel_combo_radio_main
+    # Reset gene selections when filter changes
     st.session_state.selected_gene = None
+    st.session_state.selected_gene_global = None
+    st.session_state.selected_gene_cluster = None
 
-# Initialize session state for selected guide if it doesn't exist
-if "selected_guide" not in st.session_state:
-    st.session_state.selected_guide = None
+def on_cell_class_change():
+    """Callback function for cell class selection."""
+    st.session_state.cell_class = st.session_state.cell_class_radio_main
+    # Reset gene selections when filter changes
+    st.session_state.selected_gene = None
+    st.session_state.selected_gene_global = None
+    st.session_state.selected_gene_cluster = None
 
-# Initialize session state for zoom coordinates if they don't exist
-if "zoom_xrange" not in st.session_state:
-    st.session_state.zoom_xrange = None
-if "zoom_yrange" not in st.session_state:
-    st.session_state.zoom_yrange = None
+def on_leiden_resolution_change():
+    """Callback function for leiden resolution selection."""
+    st.session_state.leiden_resolution = st.session_state.leiden_resolution_radio_main
+    # Reset gene selections when filter changes
+    st.session_state.selected_gene = None
+    st.session_state.selected_gene_global = None
+    st.session_state.selected_gene_cluster = None
 
+# Apply filters
+def apply_all_filters(data):
+    """Apply all filters to the cluster data in the correct order."""
+    # Channel Combo filter - handle directly
+    channel_combo_options = sorted(data["channel_combo"].unique().tolist())
+    # Initialize channel combo in session state if needed
+    if "channel_combo" not in st.session_state:
+        st.session_state.channel_combo = channel_combo_options[0] if channel_combo_options else None
 
-# Load cluster data
+    # Create the radio button with a stable key
+    selected_channel_combo = st.sidebar.radio(
+        "**Channel Combo** - *Used to subset features during aggregation*",
+        channel_combo_options,
+        index=channel_combo_options.index(st.session_state.channel_combo) if st.session_state.channel_combo in channel_combo_options else 0,
+        key="channel_combo_radio_main",
+        on_change=on_channel_combo_change
+    )
+    data = apply_filter(data, "channel_combo", selected_channel_combo)
+
+    # Cell Class filter - handle directly
+    cell_class_options = ["all", "Mitotic", "Interphase"]
+    # Initialize cell class in session state if needed
+    if "cell_class" not in st.session_state:
+        st.session_state.cell_class = "all"
+
+    # Create the radio button with a stable key
+    selected_cell_class = st.sidebar.radio(
+        "**Cell Class** - *Used to subset single cell data with classifier provided during aggregation*",
+        cell_class_options,
+        index=cell_class_options.index(st.session_state.cell_class),
+        key="cell_class_radio_main",
+        on_change=on_cell_class_change
+    )
+    data = apply_filter(data, "cell_class", selected_cell_class)
+
+    # Leiden Resolution filter - handle directly
+    leiden_options = sorted(data["leiden_resolution"].unique().tolist())
+    # Initialize leiden resolution in session state if needed
+    if "leiden_resolution" not in st.session_state:
+        st.session_state.leiden_resolution = leiden_options[0] if leiden_options else None
+
+    # Create the radio button with a stable key
+    selected_lr = st.sidebar.radio(
+        """**Leiden Resolution** - *Used in the Leiden clustering algorithm to determine gene clusters*""",
+        leiden_options,
+        index=leiden_options.index(st.session_state.leiden_resolution) if st.session_state.leiden_resolution in leiden_options else 0,
+        key="leiden_resolution_radio_main",
+        on_change=on_leiden_resolution_change
+    )
+    data = apply_filter(data, "leiden_resolution", selected_lr)
+
+    return data
+
+# Calculate cluster_genes after all filters are applied
+def get_cluster_genes(data, cluster_id):
+    """Get sorted list of genes for a given cluster."""
+    if not cluster_id:
+        return []
+    try:
+        cluster_val = int(cluster_id)
+    except Exception:
+        cluster_val = cluster_id
+    return sorted(data[data["cluster"] == cluster_val]["gene_symbol_0"].unique())
+
+# Call initialize_session_state at the start of the script
+initialize_session_state()
+
+# Load and filter cluster data
 cluster_data = load_cluster_data()
 
-# Initialize cell_class in session state if it doesn't exist
-if "cell_class" not in st.session_state:
-    st.session_state.cell_class = "all"
+# Sort clusters numerically instead of alphabetically
+all_genes = sorted(cluster_data["gene_symbol_0"].unique())
+all_clusters = sorted([str(c) for c in cluster_data["cluster"].unique()], key=lambda x: int(x))
 
-# Set up the page layout with two columns
-st.title("Cluster Analysis")
-
-# Add cell class filter in the sidebar
 st.sidebar.title("Filters")
+cluster_data = apply_all_filters(cluster_data)
+cluster_genes = get_cluster_genes(cluster_data, st.session_state.selected_item)
 
-# Channel Combo
-selected_channel_combo = create_filter_radio(
-    cluster_data,
-    "channel_combo",
-    st.sidebar,
-    label="**Channel Combo** - *Used to subset features during aggregation*",
-    include_all=False,
-)
-cluster_data = apply_filter(cluster_data, "channel_combo", selected_channel_combo)
+# --- UI Layout ---
+st.title("Cluster Analysis")
+st.markdown("*Click a cluster to see details, panning and zooming is easily done through the top right of the cluster panel*")
 
-# Cell Class
-cell_class_options = ["all", "Mitotic", "Interphase"]
-selected_cell_class = st.sidebar.radio(
-    "**Cell Class** - *Used to subset single cell data with classifier provided during aggregation*",
-    cell_class_options,
-    index=cell_class_options.index(st.session_state.cell_class)
-    if st.session_state.cell_class in cell_class_options
-    else 0,
-)
-cluster_data = apply_filter(cluster_data, "cell_class", selected_cell_class)
-st.session_state.cell_class = selected_cell_class
+# Add filters section in sidebar FIRST
+# Remove duplicate call to apply_all_filters since it's already called above
+# cluster_data = apply_all_filters(cluster_data)  # This line is removed
 
+# --- Widget Rendering ---
+col1, col2 = st.columns(2)
+with col1:
+    # Global gene dropdown with placeholder
+    gene_placeholder = "Select a gene..."
+    gene_options = [gene_placeholder] + all_genes
+    gene_val = st.session_state.selected_gene if st.session_state.selected_gene in all_genes else gene_placeholder
+    st.session_state.selected_gene_global = gene_val
+    selected_gene = st.selectbox(
+        "Gene Search",
+        options=gene_options,
+        index=gene_options.index(gene_val) if gene_val in gene_options else 0,
+        key="selected_gene_global",
+        on_change=on_global_gene_select,
+    )
+    # Only update if a real gene is selected
+    if selected_gene != gene_placeholder:
+        st.session_state.selected_gene = selected_gene
 
-# Leiden Resolution
-selected_lr = create_filter_radio(
-    cluster_data,
-    "leiden_resolution",
-    st.sidebar,
-    """**Leiden Resolution** - *Used in the Leiden clustering algorithm to determine gene clusters*""",
-    include_all=False,
-)
-cluster_data = apply_filter(cluster_data, "leiden_resolution", selected_lr)
+with col2:
+    # Cluster dropdown
+    cluster_options = ["Select a cluster..."] + all_clusters
+    cluster_val = st.session_state.selected_item if st.session_state.selected_item in all_clusters else "Select a cluster..."
+    st.session_state.cluster_dropdown = cluster_val
+    st.selectbox(
+        "Cluster Search",
+        options=cluster_options,
+        index=cluster_options.index(cluster_val) if cluster_val in cluster_options else 0,
+        key="cluster_dropdown",
+        on_change=on_cluster_select,
+    )
 
-
-if ("selected_item" not in st.session_state) or (
-    st.session_state.selected_item is None
-):
+# --- Main Display ---
+if not st.session_state.selected_item:
     # No cluster selected: Just show the full width cluster plot
-    display_cluster(cluster_data)
+    display_cluster(cluster_data, cell_class=st.session_state.cell_class, channel_combo=st.session_state.channel_combo)
 else:
     # Cluster selected: Two columns: plot | detail.
     col1, col2 = st.columns([1, 1])
     with col1:
-        display_cluster(cluster_data)
+        display_cluster(cluster_data, cell_class=st.session_state.cell_class, channel_combo=st.session_state.channel_combo)
 
     with col2:
         # Selected Gene info
         cell_class = st.session_state.get("cell_class", "all")
 
-        selected_item = st.session_state.get("selected_item", None)
-        selected_gene = st.session_state.get("selected_gene", None)
-        groupby_column = "cluster"
-
-        # Cluster section dropdown
-        cluster_options = cluster_data[groupby_column].unique()
-        selected_index = 0
-        if selected_item in cluster_options:
-            selected_index = list(cluster_options).index(selected_item)
-
-        def on_cluster_select():
-            st.session_state.selected_item = st.session_state.cluster_dropdown
-            st.session_state.selected_gene = (
-                None  # Reset selected gene when cluster changes
-            )
-
-        # Create a container with an outline for the cluster selection
-        with st.container():
-            st.write("""
-                <style>
-                div[data-testid="stElementContainer"][data-stale="false"][class*="st-key-cluster_dropdown"] {
-                    border: 1px solid #4a4a4a;
-                    border-radius: 5px;
-                    padding: 1rem;
-                    margin-bottom: 1rem;
-                }
-                </style>
-            """, unsafe_allow_html=True)
-            st.selectbox(
-                "Select a cluster to view",
-                options=cluster_options,
-                index=selected_index,
-                key="cluster_dropdown",
-                on_change=on_cluster_select,
-            )
-
         selected_gene_info_df = cluster_data[
-            cluster_data[groupby_column] == selected_item
+            cluster_data['cluster'] == st.session_state.selected_item
         ]
         genes = sorted(selected_gene_info_df["gene_symbol_0"].tolist())
         gene_montages_root = os.path.join(
@@ -820,7 +976,7 @@ else:
         # Create two columns for the title and clear button
         title_col, button_col = st.columns([2, 1])
         with title_col:
-            st.write(f"## Cluster {selected_item}: {len(genes)} genes")
+            st.write(f"## Cluster {st.session_state.selected_item}: {len(genes)} genes")
         with button_col:
             # Add float styling and red color specifically for the Close Cluster button
             st.markdown("""
@@ -846,31 +1002,25 @@ else:
         if os.path.exists(gene_montages_root):
             st.markdown("#### Gene Montages")
 
-            # Define a callback for when the dropdown changes
-            def on_gene_select():
-                st.session_state.selected_gene = st.session_state[
-                    f"gene_dropdown_{selected_item}"
-                ]
-
-            # Determine the index of the selected gene in the dropdown
-            selected_index = 0
-            if selected_gene in genes:
-                selected_index = genes.index(selected_gene)
-
-            # Create a dropdown to select a gene
-            st.selectbox(
-                "Select a gene to view",
-                options=genes,
-                index=selected_index,
-                key=f"gene_dropdown_{selected_item}",  # Use a stable key based on the selected cluster
-                on_change=on_gene_select,
-            )
+            # Cluster gene dropdown
+            if cluster_genes:
+                gene_val = st.session_state.selected_gene if st.session_state.selected_gene in cluster_genes else cluster_genes[0]
+                st.session_state.selected_gene_cluster = gene_val
+                st.selectbox(
+                    "Select a gene to view (within this cluster)",
+                    options=cluster_genes,
+                    index=cluster_genes.index(gene_val),
+                    key="selected_gene_cluster",
+                    on_change=on_cluster_gene_select,
+                )
+            else:
+                st.write("No genes found in this cluster.")
 
             display_uniprot_info()
 
             # Display montages only for the selected gene
-            if selected_gene:
-                display_gene_montages(gene_montages_root, selected_gene)
+            if st.session_state.selected_gene:
+                display_gene_montages(gene_montages_root, st.session_state.selected_gene)
             else:
                 # If no gene is selected yet, select the first one
                 if genes:

--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -533,6 +533,46 @@ def feature_table(cell_class, channel_combo):
     else:
         st.warning(f"⚠️ WARNING: Feature table not found at: {feature_table_path}")
 
+def cluster_size_charts(channel_combo, cell_class, leiden_resolution):
+    # Create two equal-sized columns
+    col1, col2 = st.columns([1, 1])
+    
+    with col1:
+        st.markdown("### Cluster Sizes")
+        # Construct the path to the cluster sizes plot
+        cluster_sizes_path = os.path.join(
+            BRIEFLOW_OUTPUT_PATH,
+            "cluster",
+            channel_combo,
+            cell_class,
+            leiden_resolution,
+            "cluster_sizes.png"
+        )
+        
+        # Display the plot if it exists
+        if os.path.exists(cluster_sizes_path):
+            st.image(cluster_sizes_path, use_container_width=True)
+        else:
+            st.warning(f"Cluster sizes plot not found at: {cluster_sizes_path}")
+        
+    with col2:
+        st.markdown("### Cluster Enrichment")
+        # Construct the path to the enrichment pie chart
+        enrichment_pie_path = os.path.join(
+            BRIEFLOW_OUTPUT_PATH,
+            "cluster",
+            channel_combo,
+            cell_class,
+            leiden_resolution,
+            "CB-Real__pie_chart.png"
+        )
+        
+        # Display the plot if it exists
+        if os.path.exists(enrichment_pie_path):
+            st.image(enrichment_pie_path, use_container_width=True)
+        else:
+            st.warning(f"Cluster enrichment pie chart not found at: {enrichment_pie_path}")
+
 def display_cluster_json(cluster_data, container=st.container()):
     if (
         "selected_item" in st.session_state
@@ -909,6 +949,7 @@ if not st.session_state.selected_item:
     display_cluster(cluster_data, cell_class=st.session_state.cell_class, channel_combo=st.session_state.channel_combo)
     cluster_table(cluster_data)
     feature_table(cell_class, channel_combo)
+    cluster_size_charts(channel_combo, cell_class, leiden_resolution)
 
 else:
     # Cluster selected: Two columns: plot | detail.
@@ -917,6 +958,7 @@ else:
         display_cluster(cluster_data, cell_class=cell_class, channel_combo=channel_combo)
         cluster_table(cluster_data)
         feature_table(cell_class, channel_combo)
+        cluster_size_charts(channel_combo, cell_class, leiden_resolution)
 
     with col2:
         # Selected Gene info

--- a/visualization/src/filesystem.py
+++ b/visualization/src/filesystem.py
@@ -2,6 +2,7 @@ import glob
 import os
 import re
 import pandas as pd
+import streamlit as st
 
 
 class FileSystem:
@@ -10,6 +11,7 @@ class FileSystem:
     """
 
     @staticmethod
+    @st.cache_data
     def find_files(root_dir, include_any=None, include_all=None, extensions=None):
         """
         Find all files with specified extensions in the directory tree with optional path filtering.

--- a/visualization/src/filtering.py
+++ b/visualization/src/filtering.py
@@ -24,7 +24,9 @@ def create_filter_radio(df, column, container, label=None, include_all=True, key
         st.session_state[state_key] = "All" if include_all else None
 
     def on_change():
-        st.session_state[state_key] = st.session_state[key]
+        # Only update if the key exists in session state
+        if key in st.session_state:
+            st.session_state[state_key] = st.session_state[key]
 
     if column in df.columns:
         values = df[column].dropna().unique().tolist()


### PR DESCRIPTION
This PR implements several requested UX improvements to enhance the Cluster Analysis page:

1. Added Gene/Cluster search functionality:
   - Implemented search field with autocomplete between Cluster Analysis header and cluster view
   - Search supports both gene and cluster selection
   - Selecting a gene opens it as if clicked with mouse
   - Selecting a cluster sets the first gene of that cluster

2. Added instructional text:
   - Added italic helper text under Cluster Analysis: "*Click a cluster to see details, panning and zooming is easily done through the top right of the cluster panel*"
   - This addresses user confusion about how to interact with the clustering analysis

3. Improved sorting:
   - Maintained existing alphabetical sorting for guides
   - Added alphabetical sorting for genes within clusters

4. Enhanced sidebar close button:
   - Changed the cluster sidebar close button to red
   - Makes the "X" close action more intuitive and visible
   - Addresses reported user confusion with closing the sidebar

Behavior notes:
- When selecting a gene, the appropriate cluster is automatically set
- When selecting a cluster, the first gene in that cluster is selected
- When changing sidebar filters:
  - The cluster selection is retained where possible
  - Gene selection resets to first available gene
  - Cluster may have no genes after filtering

The current implementation maintains synchronization between the global gene selection and the cluster-specific gene selection.