### PR TITLE
Add static asset handling for the webserver

### DIFF
--- a/visualization/pages/4_Cluster_Analysis.py
+++ b/visualization/pages/4_Cluster_Analysis.py
@@ -18,7 +18,7 @@ import matplotlib.colors as mcolors
 
 from src.filesystem import FileSystem
 from src.filtering import create_filter_radio, apply_filter
-from src.config import BRIEFLOW_OUTPUT_PATH
+from src.config import BRIEFLOW_OUTPUT_PATH, STATIC_ASSET_URL_ROOT, STATIC_ASSET_PATH
 
 # =====================
 # CONSTANTS
@@ -203,13 +203,20 @@ def display_gene_montages(gene_montages_root, gene):
                 )
 
                 if os.path.exists(overlay_tiff_path):
-                    with open(overlay_tiff_path, "rb") as f:
-                        st.download_button(
-                            label="Download Overlay TIFF",
-                            data=f,
-                            file_name=f"{gene}_{selected_guide}_{row['channel']}_overlay.tiff",
-                            key=f"download_{gene}_{selected_guide}_{row['channel']}_{uuid.uuid4()}",
-                        )
+                    if STATIC_ASSET_URL_ROOT and STATIC_ASSET_PATH:
+                        # Use nginx-served static files when configured
+                        relative_path = overlay_tiff_path.replace(STATIC_ASSET_PATH, "")
+                        static_url = f"{STATIC_ASSET_URL_ROOT}{relative_path}"
+                        st.markdown(f"[Download Overlay TIFF]({static_url})")
+                    else:
+                        # Fall back to direct download when running locally
+                        with open(overlay_tiff_path, "rb") as f:
+                            st.download_button(
+                                label="Download Overlay TIFF",
+                                data=f,
+                                file_name=f"{gene}_{selected_guide}_{row['channel']}_overlay.tiff",
+                                key=f"download_{gene}_{selected_guide}_{row['channel']}_{uuid.uuid4()}",
+                            )
                 else:
                     st.warning(f"No overlay tiff found: {overlay_tiff_path}")
             else:

--- a/visualization/src/config.py
+++ b/visualization/src/config.py
@@ -11,6 +11,10 @@ BRIEFLOW_OUTPUT_PATH = os.environ["BRIEFLOW_OUTPUT_PATH"]
 CONFIG_PATH = os.environ["CONFIG_PATH"]
 SCREEN_PATH = os.environ["SCREEN_PATH"]
 
+# Static asset configuration - these can be None for local development
+STATIC_ASSET_URL_ROOT = os.environ.get("STATIC_ASSET_URL_ROOT", None)  # e.g. "/aconcagua_dataset_static/"
+STATIC_ASSET_PATH = os.environ.get("STATIC_ASSET_PATH", None)  # e.g. "/disk1/brieflow_datasets/aconcagua/"
+
 logger.info(f"CONFIG_PATH: {os.path.abspath(CONFIG_PATH)}")
 logger.info(f"SCREEN_PATH: {os.path.abspath(SCREEN_PATH)}")
 

--- a/visualization/src/rendering.py
+++ b/visualization/src/rendering.py
@@ -6,6 +6,7 @@ import uuid
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 from workflow.lib.shared.file_utils import parse_filename
+from src.config import STATIC_ASSET_URL_ROOT, STATIC_ASSET_PATH
 
 
 class VisualizationRenderer:
@@ -65,13 +66,20 @@ class VisualizationRenderer:
                             if has_tsv:
                                 tsv_row = group_df[group_df["ext"] == "tsv"].iloc[0]
                                 tsv_path = os.path.join(root_dir, tsv_row["file_path"])
-                                with open(tsv_path, "rb") as f:
-                                    st.download_button(
-                                        label="Download TSV data",
-                                        data=f,
-                                        file_name=os.path.basename(tsv_path),
-                                        key=f"download_{str(uuid.uuid4())}",
-                                    )
+                                if STATIC_ASSET_URL_ROOT and STATIC_ASSET_PATH:
+                                    # Use nginx-served static files when configured
+                                    relative_path = tsv_path.replace(STATIC_ASSET_PATH, "")
+                                    static_url = f"{STATIC_ASSET_URL_ROOT}{relative_path}"
+                                    st.markdown(f"[Download TSV data]({static_url})")
+                                else:
+                                    # Fall back to direct download when running locally
+                                    with open(tsv_path, "rb") as f:
+                                        st.download_button(
+                                            label="Download TSV data",
+                                            data=f,
+                                            file_name=os.path.basename(tsv_path),
+                                            key=f"download_{str(uuid.uuid4())}",
+                                        )
 
                         elif row["ext"] == "tsv" and not has_png:
                             # Only show TSV if there's no PNG


### PR DESCRIPTION
# Description

Locally using st.download_button is fine. It does load the entire TIFF into memory, but it is only doing them one at a time.

On the web server, it is more performant to let it handle the static assets.

So here we define two environment variables, the URL to where we've mounted the assets in the nginx configuration. And a path to the files on disk (which we still need to check if they are there, and as a way to chop up the path appropriately for the URL.

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [?] My code follows the style guidelines of this project.
- [X] I have checked linting and formatting with `ruff check` and `ruff format`.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [-] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have deleted all non-relevant text in this pull request template.
