### PR TITLE
Fix montage generation issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BrieFlow"
-version = "1.1.0"
+version = "1.1.1"
 description = "Package for processing data from optical poooled screens."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/workflow/lib/shared/rule_utils.py
+++ b/workflow/lib/shared/rule_utils.py
@@ -1,6 +1,7 @@
 """Helper functions for using Snakemake rules for use with Brieflow."""
 
 from pathlib import Path
+import re
 
 from lib.shared.file_utils import parse_filename
 
@@ -242,9 +243,9 @@ def get_montage_inputs(
     output_files = []
     for montage_data_file in montage_data_files:
         # parse gene, sgrna from filename
-        file_metadata = parse_filename(montage_data_file)[0]
-        gene = file_metadata["gene"]
-        sgrna = file_metadata["sgrna"]
+        match = re.match(r".*G-(.+?)_SG-(.+?)__montage_data.*", montage_data_file.name)
+        gene = match.group(1)
+        sgrna = match.group(2)
 
         for channel in channels:
             # Generate the output file path using the template

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -194,4 +194,4 @@ rule initiate_montage:
 rule all_aggregate:
     input:
         AGGREGATE_TARGETS_ALL,
-        # MONTAGE_TARGETS_ALL,
+        MONTAGE_TARGETS_ALL,


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

Fix issue described in #136

Note that this bug resulted from using a `_` in the "gene name" of `nontargeting_AGTACCCCT`. We parse filenames to get information (like gene, sgrna, etc), so this separator in the "gene name" caused an issue. 

While this PR does fix montage generation, we should be careful to make sure this naming does not mess up other parts of brieflow. If possible, gene names should be changed to use a separator we do not parse with like `nontargeting~AGTACCCCT`.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [x] I have updated the `pyproject.toml` to reflect the change as designated by [semantic versioning](https://semver.org/).
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have deleted all non-relevant text in this pull request template.
