### PR TITLE
Update split_datasets due to pretty substantial bug.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BrieFlow"
-version = "1.1.1"
+version = "1.1.3"
 description = "Package for processing data from optical poooled screens."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/workflow/lib/aggregate/eval_aggregate.py
+++ b/workflow/lib/aggregate/eval_aggregate.py
@@ -146,6 +146,7 @@ def plot_feature_distributions(
         2,
         figsize=(16, 3 * len(original_feature_cols)),
         sharey=False,
+        squeeze=False,
     )
     fig.suptitle("Original vs Aligned Feature Distributions")
 

--- a/workflow/scripts/aggregate/split_datasets.py
+++ b/workflow/scripts/aggregate/split_datasets.py
@@ -35,6 +35,7 @@ for cell_class in snakemake.params.cell_classes:
 
     # split features into channel combos
     for channel_combo in snakemake.params.channel_combos:
+        print(f"Processing cell class: {cell_class}, channel combo: {channel_combo}")
         channel_combo_list = channel_combo.split("_")
         channel_combo_features = channel_combo_subset(
             cell_class_features, channel_combo_list, all_channels
@@ -47,6 +48,8 @@ for cell_class in snakemake.params.cell_classes:
 
         # Save data
         dataset_fp = [
-            f for f in snakemake.output if cell_class in f and channel_combo in f
+            f for f in snakemake.output 
+            if f"CeCl-{cell_class}_ChCo-{channel_combo}__" in f
         ][0]
+        print(f"Saving dataset to {dataset_fp}")
         cell_class_data.to_parquet(dataset_fp, index=False)

--- a/workflow/scripts/aggregate/split_datasets.py
+++ b/workflow/scripts/aggregate/split_datasets.py
@@ -35,7 +35,6 @@ for cell_class in snakemake.params.cell_classes:
 
     # split features into channel combos
     for channel_combo in snakemake.params.channel_combos:
-        print(f"Processing cell class: {cell_class}, channel combo: {channel_combo}")
         channel_combo_list = channel_combo.split("_")
         channel_combo_features = channel_combo_subset(
             cell_class_features, channel_combo_list, all_channels
@@ -48,8 +47,8 @@ for cell_class in snakemake.params.cell_classes:
 
         # Save data
         dataset_fp = [
-            f for f in snakemake.output 
+            f
+            for f in snakemake.output
             if f"CeCl-{cell_class}_ChCo-{channel_combo}__" in f
         ][0]
-        print(f"Saving dataset to {dataset_fp}")
         cell_class_data.to_parquet(dataset_fp, index=False)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

Thank you for your contribution to Brieflow!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Please also link to any relevant issues that your code is associated with.

The following line:
```
dataset_fp = [
    f for f in snakemake.output if cell_class in f and channel_combo in f
][0]
```
Caused issues when one channel was a subset of other channel combos. E.g. (with added print statements)

I found:

```
Processing channel combo: DAPI
  Channel list: ['DAPI']
  ...
  Saving to: brieflow_output/aggregate/parquets/P-1_W-B2_CeCl-Interphase_ChCo-DAPI_ACA_MITOTRACKER_VIMENTIN_CENPT_ITGB1_PHALLOIDIN_WGA__merge_data.parquet
  ✅ Successfully saved Interphase_DAPI
```
However, not sure if this fix, although it works, is clean enough. Happy to try other things out.
```
dataset_fp = [
    f for f in snakemake.output 
    if f"CeCl-{cell_class}_ChCo-{channel_combo}__" in f
][0]
```
This is a priority fix given that this may lead to incorrect combinations of dataset splits, which makes me a bit worried. Want to find a solution ASAP to re-run analyses.

Furthermore, there is a small bug in plotting eval aggregate if you only have one channel retained, this also fixes that.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [x] I have updated the `pyproject.toml` to reflect the change as designated by [semantic versioning](https://semver.org/).
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have deleted all non-relevant text in this pull request template.
