### PR TITLE
deduplication in vacuole phenotype extraction for vacuole area

### DIFF
--- a/workflow/scripts/phenotype/extract_phenotype_vacuoles.py
+++ b/workflow/scripts/phenotype/extract_phenotype_vacuoles.py
@@ -38,8 +38,8 @@ print("Final columns:", vacuole_cell_mapping_df.columns.tolist())
 vacuole_phenotype = extract_phenotype_vacuoles(
     data_phenotype=data_phenotype,
     vacuoles=vacuole_masks,
-    vacuole_cell_mapping_df=vacuole_cell_mapping_df,
     wildcards=snakemake.wildcards,
+    vacuole_cell_mapping_df=vacuole_cell_mapping_df,
     foci_channel=snakemake.params.foci_channel,
     channel_names=snakemake.params.channel_names,
 )


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

Thank you for your contribution to Brieflow!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

extract_phenotype_vacuoles contains a function extract_phenotype_vacuoles that merges extracted features with vacuole_cell_mappin_df. However, both vacuole_cell_mapping_df and the extracted phenotype df contain measurement for vacuole_area, which are duplicated in the output data frame as vacuole_area_x and vacuole_area_y. This bug fix removes the duplication and only saving the value from the feature extraction df. 

In certain analysis pipeline such as training a ML model, vacuole_cell_mapping_df may not be present, this fix also assigns vacuole_cell_mapping_df to be optional for these workflows.

Please also link to any relevant issues that your code is associated with.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [x] I have updated the `pyproject.toml` to reflect the change as designated by [semantic versioning](https://semver.org/).
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have deleted all non-relevant text in this pull request template.
