### PR TITLE
Trivial documentation tweaks

### DIFF
--- a/docs/source/1.before_you_screen.md
+++ b/docs/source/1.before_you_screen.md
@@ -8,7 +8,7 @@ We highly recommend reviewing the following materials before screening:
 - Walton, R. T., Singh, A., Blainey, P. C. et al. Pooled genetic screens with image‑based profiling. *Mol Syst Biol* 18, e10768 (2022). [doi.org/10.15252/msb.202110768](https://doi.org/10.15252/msb.202110768)
 - Feldman, D., Singh, A., Schmid‑Burgk, J. L. et al. Optical pooled screens in human cells. *Cell* 179, 787–799.e17 (2019). [doi.org/10.1016/j.cell.2019.09.016](https://doi.org/10.1016/j.cell.2019.09.016)
 - Blainey Lab [OPS Protocols](https://blainey.mit.edu/protocols/).
-**Note**: Ignore the GitHub Repository as this is outdated!
+**Note:** Ignore the GitHub Repository as this is outdated!
 
 ## OPS Data Collection
 

--- a/docs/source/2.installation_analysis_setup.md
+++ b/docs/source/2.installation_analysis_setup.md
@@ -83,7 +83,7 @@ This data is uploaded to Zenodo at https://zenodo.org/records/15276612. We also 
 
 This minimal test analysis data can be used to test your installation of Brieflow as well as any update Brieflow code. 
 
-**Note**: the test analysis folder is NOT the location for actual analysis data.
+**Note:** the test analysis folder is NOT the location for actual analysis data.
 
 You can run the following commands to download/unpack the test analysis data from Zenodo and perform a Brieflow run.
 On our local machine, this takes about 15 minutes.
@@ -109,7 +109,7 @@ See [3. Running Modules](https://brieflow.readthedocs.io/en/latest/3.running_mod
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/qKhM52VQHNg" frameborder="0" allowfullscreen title="Video: Analysis Setup"></iframe>
 
-Note: This video is a little outdated but still shows the general installation and setup processes.
+**Note:** This video is a little outdated but still shows the general installation and setup processes.
 
 ## Developer Workflow
 
@@ -143,7 +143,7 @@ If you are contributing new features or fixes back to the core Brieflow codebase
 
 5. Contribute changes back: Track changes to computational processing in a new branch on your fork. Contribute these changes to `cheeseman-lab/brieflow` with a pull request. See GitHub's documentation for [contributing to a project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project) and Brieflow's [development guide](https://brieflow.readthedocs.io/en/latest/4.development.html) for more info.
 
-Note: We highly recommend reading the GitHub documentation for explanation of forks to understand how your fork of brieflow syncs with the `cheeseman-lab` brieflow. From the documentation:
+**Note:** We highly recommend reading the GitHub documentation for explanation of forks to understand how your fork of brieflow syncs with the `cheeseman-lab` brieflow. From the documentation:
 
 > A fork is a new repository that shares code and visibility settings with the original "upstream" repository. Forks are often used to iterate on ideas or changes before they are proposed back to the upstream repository, such as in open source projects or when a user does not have write access to the upstream repository. For more information, see [Working with forks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks).
 

--- a/docs/source/3.running_modules.md
+++ b/docs/source/3.running_modules.md
@@ -12,12 +12,12 @@ The main `Snakefile` (at `brieflow/workflow/Snakefile`) connects each of these m
 
 Navigate to the analysis directory and activate the conda environment:
 
-```sh
+```bash
 cd analysis/
 conda activate brieflow_SCREEN_NAME
 ```
 
-**Note**: Use the `brieflow_SCREEN_NAME` conda environment for all configuration notebooks.
+**Note:** Use the `brieflow_SCREEN_NAME` conda environment for all configuration notebooks.
 
 
 <details>
@@ -81,7 +81,7 @@ A typical module execution follows these steps:
    - **Slurm**: Use `_slurm.sh` script in a tmux session for HPC compute
      - Example: `bash 1.run_preprocessing_slurm.sh`
 
-**Note**: Preprocessing, SBS, and phenotype modules include special slurm scripts that split runs by plate for optimization.
+**Note:** Preprocessing, SBS, and phenotype modules include special slurm scripts that split runs by plate for optimization.
 
 ## HPC Integrations
 
@@ -90,7 +90,7 @@ To use the Slurm integration for Brieflow configure the Slurm resources in [anal
 The `slurm_partition` and `slurm_account` in `default-resources` need to be configured while the other resource requirements have suggested values.
 These can be adjusted as necessary.
 
-**Note**: Other Snakemake HPC integrations can be found in the [Snakemake plugin catalog](https://snakemake.github.io/snakemake-plugin-catalog/index.html#snakemake-plugin-catalog).
+**Note:** Other Snakemake HPC integrations can be found in the [Snakemake plugin catalog](https://snakemake.github.io/snakemake-plugin-catalog/index.html#snakemake-plugin-catalog).
 Only the `slurm` plugin has been tested. It is important to understand that these plugins assume that the Snakemake scheduler will operate on the head HPC node, and *only the individual jobs* are submitted to the various nodes available to the HPC. Therefore, the Snakefile should be run through bash on the head node (with `slurm` or other HPC configurations). We recommend starting a tmux session for this, especially for larger jobs.
 
 ## Module-by-Module Instructions
@@ -99,12 +99,12 @@ Only the `slurm` plugin has been tested. It is important to understand that thes
 
 **Configure**: Run `0.configure_preprocess_params.ipynb` to set preprocessing parameters.
 
-**Note**: This step determines where ND2 data is loaded from and where results are saved (default: `analysis/brieflow_output`). Users testing only SBS or phenotype can configure only those image types—see notebook for details.
+**Note:** This step determines where ND2 data is loaded from and where results are saved (default: `analysis/brieflow_output`). Users testing only SBS or phenotype can configure only those image types—see notebook for details.
 
 **Run**:
 - **Local**: `sh 1.run_preprocessing.sh` (remove `-n` for actual run)
 - **Slurm**: Set `NUM_PLATES` in `1.run_preprocessing_slurm.sh`, then:
-  ```sh
+  ```bash
   tmux new-session -s preprocessing
   bash 1.run_preprocessing_slurm.sh
   ```
@@ -122,13 +122,13 @@ Only the `slurm` plugin has been tested. It is important to understand that thes
 **Run**:
 - **Local**: `sh 4.run_sbs_phenotype.sh` (remove `-n` for actual run)
 - **Slurm**: Set `NUM_PLATES` in both `4a.run_sbs_slurm.sh` and `4b.run_phenotype_slurm.sh`. These can run simultaneously or separately:
-  ```sh
+  ```bash
   tmux new-session -s sbs_phenotype
   bash 4a.run_sbs_slurm.sh
   bash 4b.run_phenotype_slurm.sh
   ```
 
-**Note**: To run only SBS or phenotype independently:
+**Note:** To run only SBS or phenotype independently:
 1. Leave the respective sample dataframe empty in `0.configure_preprocess_params.ipynb`
 2. Use `--until all_sbs` or `--until all_phenotype` tags in the scripts
 
@@ -139,7 +139,7 @@ Only the `slurm` plugin has been tested. It is important to understand that thes
 **Run**:
 - **Local**: `sh 6.run_merge.sh` (remove `-n` for actual run)
 - **Slurm**: 
-  ```sh
+  ```bash
   tmux new-session -s merge
   bash 6.run_merge_slurm.sh
   ```
@@ -151,7 +151,7 @@ Only the `slurm` plugin has been tested. It is important to understand that thes
 **Run**:
 - **Local**: `sh 8.run_aggregate.sh` (remove `-n` for actual run)
 - **Slurm**: 
-  ```sh
+  ```bash
   tmux new-session -s aggregate
   bash 8.run_aggregate_slurm.sh
   ```
@@ -163,7 +163,7 @@ Only the `slurm` plugin has been tested. It is important to understand that thes
 **Run**:
 - **Local**: `sh 10.run_cluster.sh` (remove `-n` for actual run)
 - **Slurm**: 
-  ```sh
+  ```bash
   tmux new-session -s cluster
   bash 10.run_cluster_slurm.sh
   ```
@@ -176,7 +176,7 @@ Run `11.analyze.ipynb` to evaluate cluster biological relevance using a [LLM wra
 
 Launch the native visualizer for experimental overview, analysis overview, quality control, and cluster analysis:
 
-```sh
+```bash
 sh 12.run_visualization.sh
 ```
 


### PR DESCRIPTION
- Remove an inconsistent number on a module's heading (which shows in the nav)
- Fix the '**Notes:**' markup to be more consistent.
- Standardize markdown syntax highlighting blocks on bash