### PR TITLE
Fix resolve_path to find config-relative files in deployment

### DIFF
--- a/visualization/pages/3_Screen_Overview.py
+++ b/visualization/pages/3_Screen_Overview.py
@@ -4,7 +4,7 @@ import pandas as pd
 import streamlit as st
 import yaml
 
-from src.config import CONFIG_PATH, SCREEN_PATH, load_config
+from src.config import BRIEFLOW_OUTPUT_PATH, CONFIG_PATH, SCREEN_PATH, load_config
 
 st.set_page_config(page_title="Screen Overview - Brieflow Analysis", layout="wide")
 

--- a/visualization/pages/3_Screen_Overview.py
+++ b/visualization/pages/3_Screen_Overview.py
@@ -4,7 +4,7 @@ import pandas as pd
 import streamlit as st
 import yaml
 
-from src.config import BRIEFLOW_OUTPUT_PATH, SCREEN_PATH, load_config
+from src.config import CONFIG_PATH, SCREEN_PATH, load_config
 
 st.set_page_config(page_title="Screen Overview - Brieflow Analysis", layout="wide")
 
@@ -26,12 +26,17 @@ def read_tabular(path):
 
 
 def resolve_path(path):
-    """Return the path if it exists, trying a fallback relative to data location."""
+    """Return the path if it exists, trying fallbacks relative to config and data locations."""
     if not path:
         return None
     if os.path.isfile(path):
         return path
     if not os.path.isabs(path):
+        # Try relative to the config file directory (deployment layout)
+        alt = os.path.join(os.path.dirname(CONFIG_PATH), path)
+        if os.path.isfile(alt):
+            return alt
+        # Try relative to the original analysis data location
         data_loc = yaml.safe_load(open(SCREEN_PATH)).get("data", {}).get("location", "")
         alt = os.path.join(data_loc, "analysis", path)
         if os.path.isfile(alt):


### PR DESCRIPTION
## Summary

- `resolve_path()` in the Screen Overview page only tried the `data.location` from `screen.yaml` as a fallback for relative paths, which doesn't exist on deployment servers
- Adds `CONFIG_PATH`'s directory as the first fallback, since paths in `config.yaml` like `config/barcode_library.tsv` are meant to resolve relative to the config file itself
- Fixes "Barcode library not found in config" on deployed instances

## Test plan

- [x] Verify barcode library loads on deployment server (where `CONFIG_PATH` points to the directory containing `config/`)
- [x] Verify existing lab/analysis setups still resolve via the `data.location` fallback