### PR TITLE
Fix aggregate edge cases (#195, #196, #198)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BrieFlow"
-version = "1.4.10"
+version = "1.4.11"
 description = "Package for processing data from optical poooled screens."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/workflow/lib/aggregate/align.py
+++ b/workflow/lib/aggregate/align.py
@@ -157,8 +157,12 @@ def tvn_on_controls(
     Returns:
         np.ndarray: The normalized embeddings.
     """
-    embeddings = centerscale_on_controls(embeddings, metadata, pert_col, control_key)
     ctrl_ind = metadata[pert_col].str.startswith(control_key).to_list()
+    n_controls = sum(ctrl_ind)
+    if n_controls == 0:
+        print("Warning: no control cells found, skipping TVN normalization")
+        return embeddings
+    embeddings = centerscale_on_controls(embeddings, metadata, pert_col, control_key)
     embeddings = PCA().fit(embeddings[ctrl_ind]).transform(embeddings)
     embeddings = centerscale_on_controls(
         embeddings, metadata, pert_col, control_key, batch_col

--- a/workflow/lib/aggregate/align.py
+++ b/workflow/lib/aggregate/align.py
@@ -141,6 +141,7 @@ def tvn_on_controls(
     pert_col: str,
     control_key: str,
     batch_col: str | None = None,
+    control_col: str | None = None,
 ) -> np.ndarray:
     """Apply TVN (Typical Variation Normalization) to the data based on the control perturbation units.
 
@@ -153,19 +154,25 @@ def tvn_on_controls(
         control_key (str): The control perturbation label.
         batch_col (str, optional): Column name in the metadata DataFrame representing the batch labels
             to be used for CORAL normalization. Defaults to None.
+        control_col (str, optional): Column name to use for identifying control cells.
+            When None, uses pert_col. Useful when aggregating by barcode but controls
+            are identified by gene name in a different column. Defaults to None.
 
     Returns:
         np.ndarray: The normalized embeddings.
     """
-    ctrl_ind = metadata[pert_col].str.startswith(control_key).to_list()
+    lookup_col = control_col if control_col is not None else pert_col
+    ctrl_ind = metadata[lookup_col].str.startswith(control_key).to_list()
     n_controls = sum(ctrl_ind)
     if n_controls == 0:
         print("Warning: no control cells found, skipping TVN normalization")
         return embeddings
-    embeddings = centerscale_on_controls(embeddings, metadata, pert_col, control_key)
+    embeddings = centerscale_on_controls(
+        embeddings, metadata, pert_col, control_key, control_col=lookup_col
+    )
     embeddings = PCA().fit(embeddings[ctrl_ind]).transform(embeddings)
     embeddings = centerscale_on_controls(
-        embeddings, metadata, pert_col, control_key, batch_col
+        embeddings, metadata, pert_col, control_key, batch_col, control_col=lookup_col
     )
     target_cov = np.cov(embeddings[ctrl_ind], rowvar=False, ddof=1) + 0.5 * np.eye(
         embeddings.shape[1]
@@ -175,7 +182,7 @@ def tvn_on_controls(
         for batch in batches:
             batch_ind = metadata[batch_col] == batch
             batch_control_ind = (
-                batch_ind & (metadata[pert_col].str.startswith(control_key)).to_list()
+                batch_ind & (metadata[lookup_col].str.startswith(control_key)).to_list()
             )
             n_controls = np.sum(batch_control_ind)
             if n_controls < embeddings.shape[1]:
@@ -253,6 +260,7 @@ def centerscale_on_controls(
     control_key: str,
     batch_col: str | None = None,
     method: str = "standard",
+    control_col: str | None = None,
 ) -> np.ndarray:
     """Center and scale the embeddings on the control perturbation units in the metadata.
 
@@ -267,6 +275,8 @@ def centerscale_on_controls(
             Defaults to None.
         method (str, optional): Scaling method to use. Options are "standard" (mean/std)
             or "mad" (median/MAD). Defaults to "standard".
+        control_col (str, optional): Column to use for identifying controls.
+            When None, uses pert_col. Defaults to None.
 
     Returns:
         numpy.ndarray: The aligned embeddings.
@@ -282,7 +292,8 @@ def centerscale_on_controls(
         return 0.6745 * (X - med) / mad_safe
 
     # boolean mask for "control" rows uses startswith on stringified column, handles NaNs
-    ctrl_mask_all = metadata[pert_col].astype(str).str.startswith(control_key)
+    lookup_col = control_col if control_col is not None else pert_col
+    ctrl_mask_all = metadata[lookup_col].astype(str).str.startswith(control_key)
 
     if batch_col is not None:
         for batch in metadata[batch_col].unique():

--- a/workflow/lib/aggregate/align.py
+++ b/workflow/lib/aggregate/align.py
@@ -173,11 +173,25 @@ def tvn_on_controls(
             batch_control_ind = (
                 batch_ind & (metadata[pert_col].str.startswith(control_key)).to_list()
             )
+            n_controls = np.sum(batch_control_ind)
+            if n_controls < embeddings.shape[1]:
+                print(
+                    f"Warning: batch {batch} has {n_controls} control cells "
+                    f"(< {embeddings.shape[1]} features), skipping CORAL for this batch"
+                )
+                continue
             source_cov = np.cov(
                 embeddings[batch_control_ind], rowvar=False, ddof=1
             ) + 0.5 * np.eye(embeddings.shape[1])
+            source_cov_inv_sqrt = linalg.fractional_matrix_power(source_cov, -0.5)
+            if not np.all(np.isfinite(source_cov_inv_sqrt)):
+                print(
+                    f"Warning: batch {batch} has singular covariance matrix, "
+                    f"skipping CORAL for this batch"
+                )
+                continue
             embeddings[batch_ind] = np.matmul(
-                embeddings[batch_ind], linalg.fractional_matrix_power(source_cov, -0.5)
+                embeddings[batch_ind], source_cov_inv_sqrt
             )
             embeddings[batch_ind] = np.matmul(
                 embeddings[batch_ind], linalg.fractional_matrix_power(target_cov, 0.5)

--- a/workflow/lib/aggregate/filter.py
+++ b/workflow/lib/aggregate/filter.py
@@ -210,6 +210,10 @@ def intensity_filter(
         print("Contamination is 0, skipping intensity filtering")
         return metadata, features
 
+    if len(metadata) == 0:
+        print("No cells to filter, skipping intensity filtering")
+        return metadata, features
+
     # Identify feature cols
     feature_cols = features.columns.tolist()
 

--- a/workflow/lib/aggregate/filter.py
+++ b/workflow/lib/aggregate/filter.py
@@ -144,6 +144,11 @@ def missing_values_filter(
                 f"Imputing {len(remaining_cols_with_na)} columns with remaining missing values using batched KNN"
             )
 
+            # Cast integer columns to float64 before imputation (KNNImputer returns float64)
+            for col in remaining_cols_with_na:
+                if pd.api.types.is_integer_dtype(features[col]):
+                    features[col] = features[col].astype("float64")
+
             # Identify rows with any NAs in the remaining columns
             has_na_mask = features[remaining_cols_with_na].isna().any(axis=1)
             na_rows_idx = features.index[has_na_mask]

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -36,7 +36,12 @@ rule filter:
     params:
         metadata_cols_fp=config["aggregate"]["metadata_cols_fp"],
         use_classifier=config.get("classify", {}).get("classifier_path") is not None,
-        filter_queries=config["aggregate"]["filter_queries"],
+        filter_queries=lambda wildcards: (
+            config["aggregate"]["filter_queries"]
+            + config["aggregate"]
+            .get("filter_queries_by_class", {})
+            .get(wildcards.cell_class, [])
+        ),
         perturbation_name_col=config["aggregate"]["perturbation_name_col"],
         drop_cols_threshold=config["aggregate"]["drop_cols_threshold"],
         drop_rows_threshold=config["aggregate"]["drop_rows_threshold"],
@@ -99,6 +104,7 @@ rule align:
         control_key=config["aggregate"]["control_key"],
         num_align_batches=config["aggregate"]["num_align_batches"],
         skip_perturbation_score=config["aggregate"]["skip_perturbation_score"],
+        control_name_col=config["aggregate"].get("control_name_col"),
     script:
         "../scripts/aggregate/align.py"
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -37,7 +37,7 @@ rule filter:
         metadata_cols_fp=config["aggregate"]["metadata_cols_fp"],
         use_classifier=config.get("classify", {}).get("classifier_path") is not None,
         filter_queries=lambda wildcards: (
-            config["aggregate"]["filter_queries"]
+            (config["aggregate"]["filter_queries"] or [])
             + config["aggregate"]
             .get("filter_queries_by_class", {})
             .get(wildcards.cell_class, [])

--- a/workflow/scripts/aggregate/aggregate.py
+++ b/workflow/scripts/aggregate/aggregate.py
@@ -7,6 +7,13 @@ from lib.aggregate.aggregate import aggregate
 # Load cell data using PyArrow dataset
 print("Loading cell data")
 cell_data = ds.dataset(snakemake.input[0], format="parquet")
+
+# Handle empty input gracefully
+if cell_data.count_rows() == 0:
+    print("WARNING: No cells in input, writing empty output")
+    pd.DataFrame().to_csv(snakemake.output[0], sep="\t", index=False)
+    exit(0)
+
 cell_data = cell_data.to_table(use_threads=True, memory_pool=None).to_pandas()
 print(f"Shape of input data: {cell_data.shape}")
 

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -132,6 +132,7 @@ for i, indices in enumerate(subset_indices):
         snakemake.params.perturbation_name_col,
         snakemake.params.control_key,
         "batch_values",
+        control_col=snakemake.params.get("control_name_col"),
     )
 
     feature_columns = [f"PC_{j}" for j in range(features.shape[1])]

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -36,6 +36,14 @@ print(f"Number of rows across all parquet files: {cell_dataset.count_rows()}")
 # Count total rows across all Parquet files
 total_rows = cell_dataset.count_rows()
 
+# Handle empty input gracefully
+if total_rows == 0:
+    print("WARNING: No cells in input, writing empty output")
+    import pyarrow.parquet as pq_empty
+
+    pq_empty.write_table(pa.table({}), snakemake.output[0])
+    exit(0)
+
 # Choose random row indices
 n_sample = min(PCA_SUBSET, total_rows)
 random_indices = np.random.choice(total_rows, size=n_sample, replace=False)

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -29,20 +29,22 @@ np.random.seed(0)
 ## Step 1: Create PCA transformation
 PCA_SUBSET = 100000
 
-# Load full dataset as logical PyArrow dataset
-cell_dataset = ds.dataset(snakemake.input.filtered_paths, format="parquet")
-print(f"Number of rows across all parquet files: {cell_dataset.count_rows()}")
+# Filter out empty parquet files to avoid schema conflicts
+non_empty_paths = [
+    p for p in snakemake.input.filtered_paths if pq.read_metadata(p).num_rows > 0
+]
 
-# Count total rows across all Parquet files
-total_rows = cell_dataset.count_rows()
-
-# Handle empty input gracefully
-if total_rows == 0:
+if len(non_empty_paths) == 0:
     print("WARNING: No cells in input, writing empty output")
-    import pyarrow.parquet as pq_empty
-
-    pq_empty.write_table(pa.table({}), snakemake.output[0])
+    pq.write_table(pa.table({}), snakemake.output[0])
     exit(0)
+
+# Load full dataset as logical PyArrow dataset (only non-empty files)
+cell_dataset = ds.dataset(non_empty_paths, format="parquet")
+total_rows = cell_dataset.count_rows()
+print(
+    f"Number of rows across {len(non_empty_paths)} non-empty parquet files: {total_rows}"
+)
 
 # Choose random row indices
 n_sample = min(PCA_SUBSET, total_rows)

--- a/workflow/scripts/aggregate/eval_aggregate.py
+++ b/workflow/scripts/aggregate/eval_aggregate.py
@@ -2,6 +2,7 @@ import random
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pyarrow.parquet as pq
 import pyarrow.dataset as ds
 
 plt.rcParams.update(
@@ -18,12 +19,12 @@ from lib.aggregate.eval_aggregate import (
 
 SUBSET_SIZE = 100000
 
-# Get merge dataset
-merge_data = ds.dataset(snakemake.input.split_datasets_paths, format="parquet")
-total_rows = merge_data.count_rows()
+# Get merge dataset — filter out empty parquets to avoid schema conflicts
+non_empty_split = [
+    p for p in snakemake.input.split_datasets_paths if pq.read_metadata(p).num_rows > 0
+]
 
-# Handle empty input gracefully
-if total_rows == 0:
+if len(non_empty_split) == 0:
     print("WARNING: No cells in input, writing empty eval outputs")
     import pandas as pd
 
@@ -35,6 +36,8 @@ if total_rows == 0:
     plt.close(fig)
     exit(0)
 
+merge_data = ds.dataset(non_empty_split, format="parquet")
+total_rows = merge_data.count_rows()
 # Choose random row indices
 n_sample = min(SUBSET_SIZE, total_rows)
 random_indices = np.random.choice(total_rows, size=n_sample, replace=False)

--- a/workflow/scripts/aggregate/eval_aggregate.py
+++ b/workflow/scripts/aggregate/eval_aggregate.py
@@ -20,8 +20,22 @@ SUBSET_SIZE = 100000
 
 # Get merge dataset
 merge_data = ds.dataset(snakemake.input.split_datasets_paths, format="parquet")
-# Choose random row indices
 total_rows = merge_data.count_rows()
+
+# Handle empty input gracefully
+if total_rows == 0:
+    print("WARNING: No cells in input, writing empty eval outputs")
+    import pandas as pd
+
+    pd.DataFrame().to_csv(snakemake.output[0], sep="\t", index=False)
+    fig, ax = plt.subplots()
+    ax.text(0.5, 0.5, "No data", ha="center", va="center")
+    fig.savefig(snakemake.output[1], dpi=300, bbox_inches="tight")
+    fig.savefig(snakemake.output[2], dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    exit(0)
+
+# Choose random row indices
 n_sample = min(SUBSET_SIZE, total_rows)
 random_indices = np.random.choice(total_rows, size=n_sample, replace=False)
 random_indices.sort()

--- a/workflow/scripts/aggregate/filter.py
+++ b/workflow/scripts/aggregate/filter.py
@@ -8,6 +8,15 @@ from lib.aggregate.filter import (
     intensity_filter,
 )
 
+
+def write_empty_and_exit(metadata, features, output_path, stage):
+    """Write empty parquet and exit if no cells remain after a filtering stage."""
+    if len(metadata) == 0:
+        print(f"WARNING: No cells after {stage}, writing empty output")
+        pd.concat([metadata, features], axis=1).to_parquet(output_path, index=False)
+        exit(0)
+
+
 # Load cell data
 cell_data = pd.read_parquet(snakemake.input[0])
 use_classifier = snakemake.params.get("use_classifier", False)
@@ -16,6 +25,7 @@ metadata_cols = load_metadata_cols(
     include_classification_cols=use_classifier,
 )
 metadata, features = split_cell_data(cell_data, metadata_cols)
+output_path = snakemake.output[0]
 
 # Filter
 metadata, features = query_filter(
@@ -23,11 +33,15 @@ metadata, features = query_filter(
     features,
     snakemake.params.filter_queries,
 )
+write_empty_and_exit(metadata, features, output_path, "query_filter")
+
 metadata, features = perturbation_filter(
     metadata,
     features,
     snakemake.params.perturbation_name_col,
 )
+write_empty_and_exit(metadata, features, output_path, "perturbation_filter")
+
 metadata, features = missing_values_filter(
     metadata,
     features,
@@ -35,6 +49,8 @@ metadata, features = missing_values_filter(
     drop_rows_threshold=snakemake.params.drop_rows_threshold,
     impute=snakemake.params.impute,
 )
+write_empty_and_exit(metadata, features, output_path, "missing_values_filter")
+
 metadata, features = intensity_filter(
     metadata,
     features,
@@ -44,4 +60,4 @@ metadata, features = intensity_filter(
 
 # Save filtered data
 cell_data = pd.concat([metadata, features], axis=1)
-cell_data.to_parquet(snakemake.output[0], index=False)
+cell_data.to_parquet(output_path, index=False)

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -20,15 +20,19 @@ num_batches = snakemake.params.get("num_align_batches", 1)
 
 # Load cell data using PyArrow dataset (lazy - no data loaded yet)
 print("Loading cell data as PyArrow dataset...")
-cell_dataset = ds.dataset(snakemake.input.filtered_paths, format="parquet")
+# Filter out empty parquet files to avoid schema conflicts
+non_empty_paths = [
+    p for p in snakemake.input.filtered_paths if pq.read_metadata(p).num_rows > 0
+]
 
-# Handle empty input gracefully
-if cell_dataset.count_rows() == 0:
+if len(non_empty_paths) == 0:
     print("WARNING: No cells in input, writing empty outputs")
     pd.DataFrame().to_parquet(snakemake.output[0], index=False)
     pd.DataFrame().to_csv(snakemake.output[1], sep="\t", index=False)
     pd.DataFrame().to_csv(snakemake.output[2], sep="\t", index=False)
     exit(0)
+
+cell_dataset = ds.dataset(non_empty_paths, format="parquet")
 
 # Determine columns
 cell_data_cols = cell_dataset.schema.names

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -22,6 +22,14 @@ num_batches = snakemake.params.get("num_align_batches", 1)
 print("Loading cell data as PyArrow dataset...")
 cell_dataset = ds.dataset(snakemake.input.filtered_paths, format="parquet")
 
+# Handle empty input gracefully
+if cell_dataset.count_rows() == 0:
+    print("WARNING: No cells in input, writing empty outputs")
+    pd.DataFrame().to_parquet(snakemake.output[0], index=False)
+    pd.DataFrame().to_csv(snakemake.output[1], sep="\t", index=False)
+    pd.DataFrame().to_csv(snakemake.output[2], sep="\t", index=False)
+    exit(0)
+
 # Determine columns
 cell_data_cols = cell_dataset.schema.names
 use_classifier = snakemake.params.get("use_classifier", False)

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -14,7 +14,7 @@ from lib.aggregate.bootstrap import create_pseudogene_groups
 
 # get snakemake parameters
 pert_col = snakemake.params.perturbation_name_col
-pert_id_col = snakemake.params.perturbation_id_col
+pert_id_col = snakemake.params.perturbation_id_col or pert_col
 control_key = snakemake.params.control_key
 num_batches = snakemake.params.get("num_align_batches", 1)
 

--- a/workflow/scripts/aggregate/prepare_bootstrap_data.py
+++ b/workflow/scripts/aggregate/prepare_bootstrap_data.py
@@ -25,6 +25,17 @@ print("Loading single-cell features data...")
 all_features_cells = pd.read_parquet(snakemake.input.features_singlecell)
 print(f"Features data shape: {all_features_cells.shape}")
 
+# Handle empty input gracefully
+if len(all_features_cells) == 0:
+    print("WARNING: No cells in input, writing empty bootstrap outputs")
+    pd.DataFrame().to_csv(snakemake.output.controls_arr, sep="\t", index=False)
+    pd.DataFrame().to_csv(
+        snakemake.output.construct_features_arr, sep="\t", index=False
+    )
+    pd.DataFrame().to_csv(snakemake.output.sample_sizes, sep="\t", index=False)
+    Path(snakemake.output[0]).mkdir(parents=True, exist_ok=True)
+    exit(0)
+
 print("Loading construct and gene tables...")
 construct_table = pd.read_csv(snakemake.input.construct_table, sep="\t")
 gene_table = pd.read_csv(snakemake.input.gene_table, sep="\t")

--- a/workflow/scripts/aggregate/prepare_bootstrap_data.py
+++ b/workflow/scripts/aggregate/prepare_bootstrap_data.py
@@ -15,7 +15,7 @@ from lib.aggregate.bootstrap import write_construct_data
 
 # Get parameters
 perturbation_col = snakemake.params.perturbation_name_col
-perturbation_id_col = snakemake.params.perturbation_id_col
+perturbation_id_col = snakemake.params.perturbation_id_col or perturbation_col
 control_key = snakemake.params.control_key
 exclusion_string = snakemake.params.exclusion_string
 metadata_cols_fp = snakemake.params.metadata_cols_fp

--- a/workflow/scripts/aggregate/prepare_montage_data.py
+++ b/workflow/scripts/aggregate/prepare_montage_data.py
@@ -12,6 +12,12 @@ from lib.shared.file_utils import get_filename
 output_dir = Path(snakemake.output[0])
 output_dir.mkdir(parents=True, exist_ok=True)
 
+# Handle empty input gracefully
+cell_check = ds.dataset(snakemake.input, format="parquet")
+if cell_check.count_rows() == 0:
+    print("WARNING: No cells in input, skipping montage data preparation")
+    exit(0)
+
 # Load cell data
 montage_columns = [
     "gene_symbol_0",


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

Thank you for your contribution to Brieflow!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Fixes three aggregate module crashes that occur with sparse or edge-case data:

- #195: intensity_filter crashes with LocalOutlierFactor on 0 samples when a cell class is absent from a well. Added early return on empty data and write_empty_and_exit guards after each filter step.
- #196: generate_feature_table.py and prepare_bootstrap_data.py crash with KeyError: None when perturbation_id_col is None. Falls back to perturbation_name_col.
- #198: tvn_on_controls crashes with ValueError: array must not contain infs or NaNs when too few control cells. Skips TVN with 0 controls, skips per-batch CORAL when controls < features or covariance is singular.

Validated on real data from the viso screen (lourido lab) — empty cell classes (Uninfected wells with 0 cells) and wells with 0 controls.

Files changed

- workflow/lib/aggregate/filter.py — early return on empty data
- workflow/lib/aggregate/align.py — 0-control guard + sparse batch CORAL skip
- workflow/scripts/aggregate/filter.py — write_empty_and_exit after each filter step
- workflow/scripts/aggregate/generate_feature_table.py — pert_id_col fallback
- workflow/scripts/aggregate/prepare_bootstrap_data.py — pert_id_col fallback

Please also link to any relevant issues that your code is associated with.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [x] I have updated the `pyproject.toml` to reflect the change as designated by [semantic versioning](https://semver.org/).
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have deleted all non-relevant text in this pull request template.
