### PR TITLE
Spatial heatmaps from metadata + remove hardcoded plate layouts (#211)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BrieFlow"
-version = "1.4.10"
+version = "1.4.11"
 description = "Package for processing data from optical poooled screens."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BrieFlow"
-version = "1.4.11"
+version = "1.4.12"
 description = "Package for processing data from optical poooled screens."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/small_test_analysis/config/config.yml
+++ b/tests/small_test_analysis/config/config.yml
@@ -24,7 +24,6 @@ preprocess:
   sbs_combo_fp: config/sbs_combo.tsv
   sbs_samples_fp: config/sbs_samples.tsv
 sbs:
-  heatmap_shape: square
   alignment_method: null
   channel_names:
   - DAPI
@@ -75,9 +74,7 @@ sbs:
   cell_flow_threshold: 1
   cell_cellprob_threshold: 0
   cyto_model: cyto3
-  heatmap_plate: 6W
 phenotype:
-  heatmap_shape: square
   align: false
   segment_cells: true
   cell_diameter: 53.075815293046055
@@ -98,7 +95,6 @@ phenotype:
   mode: null
   nuclei_diameter: 41.97813156768016
   reconcile: contained_in_cells
-  heatmap_plate: 6W
 merge:
   approach: fast
   merge_combo_fp: config/merge_combo.tsv

--- a/workflow/lib/aggregate/align.py
+++ b/workflow/lib/aggregate/align.py
@@ -141,6 +141,7 @@ def tvn_on_controls(
     pert_col: str,
     control_key: str,
     batch_col: str | None = None,
+    control_col: str | None = None,
 ) -> np.ndarray:
     """Apply TVN (Typical Variation Normalization) to the data based on the control perturbation units.
 
@@ -153,15 +154,25 @@ def tvn_on_controls(
         control_key (str): The control perturbation label.
         batch_col (str, optional): Column name in the metadata DataFrame representing the batch labels
             to be used for CORAL normalization. Defaults to None.
+        control_col (str, optional): Column name to use for identifying control cells.
+            When None, uses pert_col. Useful when aggregating by barcode but controls
+            are identified by gene name in a different column. Defaults to None.
 
     Returns:
         np.ndarray: The normalized embeddings.
     """
-    embeddings = centerscale_on_controls(embeddings, metadata, pert_col, control_key)
-    ctrl_ind = metadata[pert_col].str.startswith(control_key).to_list()
+    lookup_col = control_col if control_col is not None else pert_col
+    ctrl_ind = metadata[lookup_col].str.startswith(control_key).to_list()
+    n_controls = sum(ctrl_ind)
+    if n_controls == 0:
+        print("Warning: no control cells found, skipping TVN normalization")
+        return embeddings
+    embeddings = centerscale_on_controls(
+        embeddings, metadata, pert_col, control_key, control_col=lookup_col
+    )
     embeddings = PCA().fit(embeddings[ctrl_ind]).transform(embeddings)
     embeddings = centerscale_on_controls(
-        embeddings, metadata, pert_col, control_key, batch_col
+        embeddings, metadata, pert_col, control_key, batch_col, control_col=lookup_col
     )
     target_cov = np.cov(embeddings[ctrl_ind], rowvar=False, ddof=1) + 0.5 * np.eye(
         embeddings.shape[1]
@@ -171,13 +182,27 @@ def tvn_on_controls(
         for batch in batches:
             batch_ind = metadata[batch_col] == batch
             batch_control_ind = (
-                batch_ind & (metadata[pert_col].str.startswith(control_key)).to_list()
+                batch_ind & (metadata[lookup_col].str.startswith(control_key)).to_list()
             )
+            n_controls = np.sum(batch_control_ind)
+            if n_controls < embeddings.shape[1]:
+                print(
+                    f"Warning: batch {batch} has {n_controls} control cells "
+                    f"(< {embeddings.shape[1]} features), skipping CORAL for this batch"
+                )
+                continue
             source_cov = np.cov(
                 embeddings[batch_control_ind], rowvar=False, ddof=1
             ) + 0.5 * np.eye(embeddings.shape[1])
+            source_cov_inv_sqrt = linalg.fractional_matrix_power(source_cov, -0.5)
+            if not np.all(np.isfinite(source_cov_inv_sqrt)):
+                print(
+                    f"Warning: batch {batch} has singular covariance matrix, "
+                    f"skipping CORAL for this batch"
+                )
+                continue
             embeddings[batch_ind] = np.matmul(
-                embeddings[batch_ind], linalg.fractional_matrix_power(source_cov, -0.5)
+                embeddings[batch_ind], source_cov_inv_sqrt
             )
             embeddings[batch_ind] = np.matmul(
                 embeddings[batch_ind], linalg.fractional_matrix_power(target_cov, 0.5)
@@ -235,6 +260,7 @@ def centerscale_on_controls(
     control_key: str,
     batch_col: str | None = None,
     method: str = "standard",
+    control_col: str | None = None,
 ) -> np.ndarray:
     """Center and scale the embeddings on the control perturbation units in the metadata.
 
@@ -249,6 +275,8 @@ def centerscale_on_controls(
             Defaults to None.
         method (str, optional): Scaling method to use. Options are "standard" (mean/std)
             or "mad" (median/MAD). Defaults to "standard".
+        control_col (str, optional): Column to use for identifying controls.
+            When None, uses pert_col. Defaults to None.
 
     Returns:
         numpy.ndarray: The aligned embeddings.
@@ -264,7 +292,8 @@ def centerscale_on_controls(
         return 0.6745 * (X - med) / mad_safe
 
     # boolean mask for "control" rows uses startswith on stringified column, handles NaNs
-    ctrl_mask_all = metadata[pert_col].astype(str).str.startswith(control_key)
+    lookup_col = control_col if control_col is not None else pert_col
+    ctrl_mask_all = metadata[lookup_col].astype(str).str.startswith(control_key)
 
     if batch_col is not None:
         for batch in metadata[batch_col].unique():

--- a/workflow/lib/aggregate/filter.py
+++ b/workflow/lib/aggregate/filter.py
@@ -144,6 +144,11 @@ def missing_values_filter(
                 f"Imputing {len(remaining_cols_with_na)} columns with remaining missing values using batched KNN"
             )
 
+            # Cast integer columns to float64 before imputation (KNNImputer returns float64)
+            for col in remaining_cols_with_na:
+                if pd.api.types.is_integer_dtype(features[col]):
+                    features[col] = features[col].astype("float64")
+
             # Identify rows with any NAs in the remaining columns
             has_na_mask = features[remaining_cols_with_na].isna().any(axis=1)
             na_rows_idx = features.index[has_na_mask]
@@ -208,6 +213,10 @@ def intensity_filter(
 
     if contamination == 0:
         print("Contamination is 0, skipping intensity filtering")
+        return metadata, features
+
+    if len(metadata) == 0:
+        print("No cells to filter, skipping intensity filtering")
         return metadata, features
 
     # Identify feature cols

--- a/workflow/lib/merge/eval_merge.py
+++ b/workflow/lib/merge/eval_merge.py
@@ -15,8 +15,7 @@ def plot_sbs_ph_matching_heatmap(
     df_merge,
     df_info,
     target="sbs",
-    shape="square",
-    plate="6W",
+    metadata=None,
     return_plot=True,
     return_summary=False,
     **kwargs,
@@ -30,6 +29,7 @@ def plot_sbs_ph_matching_heatmap(
         df_info: DataFrame of all cells segmented from either phenotype or SBS images, e.g., concatenated outputs for all tiles
             and wells of extract_phenotype_minimal(data_phenotype=nulcei, nuclei=nuclei), often used as `sbs_cell_info`
             rule in Snakemake.
+        metadata: Optional metadata DataFrame with x_pos/y_pos for spatial plotting.
         target: Which dataset to use as the target, e.g., if target='sbs', plots the fraction of cells in each SBS tile
             that match to a phenotype cell. Should match the information stored in df_info; if df_info is a table of all
             segmented cells from SBS tiles, then target should be set as 'sbs'.
@@ -83,11 +83,11 @@ def plot_sbs_ph_matching_heatmap(
 
     if return_summary and return_plot:
         # Plot heatmap
-        axes = plot_plate_heatmap(df_summary, shape=shape, plate=plate, **kwargs)
+        axes = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return df_summary, axes[0]
     elif return_plot:
         # Plot heatmap
-        axes = plot_plate_heatmap(df_summary, shape=shape, plate=plate, **kwargs)
+        axes = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return axes[0]
     elif return_summary:
         return df_summary

--- a/workflow/lib/merge/eval_merge.py
+++ b/workflow/lib/merge/eval_merge.py
@@ -33,30 +33,21 @@ def plot_sbs_ph_matching_heatmap(
         target: Which dataset to use as the target, e.g., if target='sbs', plots the fraction of cells in each SBS tile
             that match to a phenotype cell. Should match the information stored in df_info; if df_info is a table of all
             segmented cells from SBS tiles, then target should be set as 'sbs'.
-        shape: Shape of subplot for each well used in `plot_plate_heatmap`. Defaults to 'square' and infers shape based on
-            the value of `target`.
-        plate: Plate type for `plot_plate_heatmap`, options are {'6W', '24W', '96W'}.
-        return_plot: If True, returns `df_summary`.
+        return_plot: If True, returns figure.
         return_summary: If True, returns `df_summary`.
         **kwargs: Additional keyword arguments passed to `plot_plate_heatmap()`.
 
     Returns:
         df_summary: DataFrame used for plotting, returned if `return_summary=True`.
-        axes: Numpy array of matplotlib Axes objects.
+        matplotlib.figure.Figure: The figure object.
     """
     # Determine the merge columns and source based on the target
     if target == "sbs":
         merge_cols = ["site", "cell_1"]
         source = "phenotype"
-        # Determine the default shape if not provided
-        if not shape:
-            shape = "6W_sbs"
     elif target == "phenotype":
         merge_cols = ["tile", "cell_0"]
         source = "sbs"
-        # Determine the default shape if not provided
-        if not shape:
-            shape = "6W_ph"
     else:
         raise ValueError("target = {} not implemented".format(target))
 

--- a/workflow/lib/phenotype/eval_features.py
+++ b/workflow/lib/phenotype/eval_features.py
@@ -7,30 +7,27 @@ def plot_feature_heatmap(
     df,
     feature,
     tile="tile",
-    shape="square",
-    plate="6W",
+    metadata=None,
     agg_func="median",
     return_plot=True,
     return_summary=False,
     **kwargs,
 ):
-    """Plot a heatmap of a specified feature in a DataFrame by well and tile in a convenient plate layout.
+    """Plot a heatmap of a specified feature in a DataFrame by well and tile.
 
     Args:
         df (pandas.DataFrame): Input data containing the feature to be plotted.
         feature (str): The column name of the feature to be plotted.
         tile (str, optional): The column name used to group tiles. Defaults to 'tile'.
-        shape (str, optional): Shape of subplot for each well used in the heatmap. Defaults to 'square'.
-        plate (str): Plate type for the heatmap. Options are {'6W', '24W', '96W'}.
-        agg_func (str | callable, optional): The aggregation function to use when grouping by well and tile.
-            Options include 'mean', 'median', 'sum', or any function that can be passed to pandas' `agg()`. Defaults to 'mean'.
+        metadata (pandas.DataFrame, optional): Metadata with x_pos/y_pos for spatial plotting.
+        agg_func (str | callable, optional): Aggregation function. Defaults to 'median'.
         return_plot (bool, optional): If True, returns figure. Defaults to True.
         return_summary (bool, optional): If True, returns `df_summary`. Defaults to False.
         **kwargs: Additional keyword arguments passed to `plot_plate_heatmap()`.
 
     Returns:
-        pandas.DataFrame: Summary DataFrame used for plotting. Returned only if `return_summary=True`.
-        np.ndarray: Array of matplotlib Axes objects.
+        pandas.DataFrame: Summary DataFrame. Returned only if `return_summary=True`.
+        matplotlib.figure.Figure: The figure object.
     """
     # Group data by well and tile and aggregate the specified feature
     df_summary = df.groupby(["well", tile]).agg({feature: agg_func}).reset_index()
@@ -38,13 +35,13 @@ def plot_feature_heatmap(
     if return_summary and return_plot:
         # Plot heatmap
         fig, _ = plot_plate_heatmap(
-            df_summary, metric=feature, shape=shape, plate=plate, **kwargs
+            df_summary, metric=feature, metadata=metadata, **kwargs
         )
         return df_summary, fig
     elif return_plot:
         # Plot heatmap
         fig, _ = plot_plate_heatmap(
-            df_summary, metric=feature, shape=shape, plate=plate, **kwargs
+            df_summary, metric=feature, metadata=metadata, **kwargs
         )
         return fig
     elif return_summary:

--- a/workflow/lib/sbs/eval_mapping.py
+++ b/workflow/lib/sbs/eval_mapping.py
@@ -181,8 +181,7 @@ def plot_mapping_vs_threshold(
 def plot_read_mapping_heatmap(
     df_reads,
     barcodes,
-    shape="square",
-    plate="6W",
+    metadata=None,
     return_plot=True,
     return_summary=False,
     **kwargs,
@@ -191,16 +190,13 @@ def plot_read_mapping_heatmap(
 
     Args:
         df_reads (pandas.DataFrame):
-            DataFrame of all reads output from sbs mapping pipeline, e.g., concatenated outputs for all tiles
-            and wells of call_reads.
+            DataFrame of all reads output from sbs mapping pipeline.
         barcodes (list or set of str):
             Expected barcodes from the pool library design.
-        shape (str, optional):
-            Shape of subplot for each well used in plot_plate_heatmap. Defaults to 'square'.
-        plate (str):
-            Plate type for plot_plate_heatmap. Options are {'6W', '24W', '96W'}.
+        metadata (pandas.DataFrame, optional):
+            Metadata with x_pos/y_pos for spatial plotting. Defaults to None.
         return_plot (bool, optional):
-            If true, returns df_summary. Defaults to True.
+            If true, returns figure. Defaults to True.
         return_summary (bool, optional):
             If true, returns df_summary. Defaults to False.
         **kwargs:
@@ -225,12 +221,10 @@ def plot_read_mapping_heatmap(
     )
 
     if return_summary and return_plot:
-        # Plot heatmap
-        fig, _ = plot_plate_heatmap(df_summary, shape=shape, plate=plate, **kwargs)
+        fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return df_summary, fig
     elif return_plot:
-        # Plot heatmap
-        fig, _ = plot_plate_heatmap(df_summary, shape=shape, plate=plate, **kwargs)
+        fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return fig
     elif return_summary:
         return df_summary
@@ -244,8 +238,7 @@ def plot_cell_mapping_heatmap(
     barcodes,
     mapping_to="one",
     mapping_strategy="barcodes",
-    shape="square",
-    plate="6W",
+    metadata=None,
     return_plot=True,
     return_summary=False,
     **kwargs,
@@ -254,24 +247,17 @@ def plot_cell_mapping_heatmap(
 
     Args:
         df_cells (pandas.DataFrame):
-            DataFrame of all cells output from sbs mapping pipeline, e.g., concatenated outputs for all tiles and wells
-            of call_cells.
+            DataFrame of all cells output from sbs mapping pipeline.
         df_sbs_info (pandas.DataFrame):
-            DataFrame of all cells segmented from sbs images, e.g., concatenated outputs for all tiles and wells of
-            extract_phenotype_minimal(data_phenotype=nuclei, nuclei=nuclei), often used as sbs_cell_info rule in
-            Snakemake.
+            DataFrame of all cells segmented from sbs images.
         barcodes (list or set of str):
             Expected barcodes from the pool library design.
         mapping_to (str):
-            Cells to include as 'mapped'. 'one' only includes cells mapping to a single barcode, 'any' includes cells
-            mapping to at least 1 barcode. Options are {'one', 'any'}.
+            Cells to include as 'mapped'. Options are {'one', 'any'}.
         mapping_strategy (str): Strategy to use for mapping cells. Options are {'barcodes', 'gene symbols'}.
-        shape (str, optional):
-            Shape of subplot for each well used in plot_plate_heatmap. Defaults to 'square'.
-        plate (str):
-            Plate type for plot_plate_heatmap. Options are {'6W', '24W', '96W'}.
+        metadata (pandas.DataFrame, optional): Metadata with x_pos/y_pos for spatial plotting.
         return_plot (bool, optional):
-            If true, returns df_summary. Defaults to True.
+            If true, returns figure. Defaults to True.
         return_summary (bool, optional):
             If true, returns df_summary. Defaults to False.
         **kwargs:
@@ -324,11 +310,10 @@ def plot_cell_mapping_heatmap(
 
     if return_summary and return_plot:
         # Plot heatmap
-        fig, _ = plot_plate_heatmap(df_summary, shape=shape, plate=plate, **kwargs)
+        fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return df_summary, fig
     elif return_plot:
-        # Plot heatmap
-        fig, _ = plot_plate_heatmap(df_summary, shape=shape, plate=plate, **kwargs)
+        fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return fig
     elif return_summary:
         return df_summary

--- a/workflow/lib/shared/eval.py
+++ b/workflow/lib/shared/eval.py
@@ -1,202 +1,117 @@
 """Shared utilties for evaluating steps and visualizing data."""
 
-import string
-
 import numpy as np
 import matplotlib.pyplot as plt
 
 
-def plot_plate_heatmap(
-    df, metric=None, shape="square", plate="6W", snake_sites=True, **kwargs
-):
-    """Plot the heatmap of a summary DataFrame by well and tile in a convenient plate layout.
+def plot_plate_heatmap(df, metric=None, metadata=None, **kwargs):
+    """Plot the heatmap of a summary DataFrame by well and tile in a plate layout.
+
+    Tiles are plotted at their actual spatial positions from metadata using scatter.
+    Wells are auto-detected from the data and arranged in a grid of subplots.
 
     Args:
         df (pandas.DataFrame):
-            Summary DataFrame of values to plot, expects one row for each (well, tile) combination.
+            Summary DataFrame of values to plot, expects one row per (well, tile).
         metric (str, optional):
-            Column of `df` to use for plotting the heatmap. If None, attempts to infer based on column names.
-            Defaults to None.
-        shape (str or list, optional):
-            Shape of subplot for each well. Options are {'square', '6W_ph', '6W_sbs', list}. 'square' infers
-            dimensions of the smallest square that fits the number of sites. '6W_ph' and '6W_sbs' use a common
-            6 well tile map from a Nikon Ti2/Elements set-up with 20X and 10X objectives, respectively. Alternatively,
-            a list can be passed containing the number of sites in each row of a tile layout. This is mapped into a
-            centered shape within a rectangle. Unused corners of this rectangle are plotted as nan. The summation of
-            this list should equal the total number of sites. Defaults to 'square'.
-        plate (str):
-            Plate type for plot_plate_heatmap. Options are {'6W', '24W', '96W'}.
-        snake_sites (bool, optional):
-            If true, plots tiles in a snake order similar to the order of sites acquired by many high throughput
-            microscope systems. Defaults to True.
+            Column of `df` to use for the heatmap. If None, infers from columns.
+        metadata (pandas.DataFrame, optional):
+            Metadata DataFrame with 'well', 'tile', 'x_pos', 'y_pos' columns.
+            When provided, tiles are plotted at their spatial positions.
         **kwargs:
-            Keyword arguments passed to matplotlib.pyplot.imshow().
+            Keyword arguments passed to matplotlib scatter.
 
     Returns:
-        np.array: Array of matplotlib Axes objects for the plot.
-        matplotlib.Colorbar: Colorbar object for the plot.
+        matplotlib.figure.Figure: The figure object.
+        matplotlib.colorbar.Colorbar: Colorbar object for the plot.
     """
-    tiles = df["tile"].astype(int)
-    tiles = max(len(tiles.unique()), tiles.max())
-
-    # Define grid for plotting
-    if shape == "square":
-        r = c = int(np.ceil(np.sqrt(tiles)))
-        grid = np.empty(r * c)
-        grid[:] = np.nan
-        grid[:tiles] = range(tiles)
-        grid = grid.reshape(r, c)
-    else:
-        if shape == "6W_ph":
-            rows = [
-                7,
-                13,
-                17,
-                21,
-                25,
-                27,
-                29,
-                31,
-                33,
-                33,
-                35,
-                35,
-                37,
-                37,
-                39,
-                39,
-                39,
-                41,
-                41,
-                41,
-                41,
-                41,
-                41,
-                41,
-                39,
-                39,
-                39,
-                37,
-                37,
-                35,
-                35,
-                33,
-                33,
-                31,
-                29,
-                27,
-                25,
-                21,
-                17,
-                13,
-                7,
-            ]
-        elif shape == "6W_sbs":
-            rows = [
-                5,
-                9,
-                13,
-                15,
-                17,
-                17,
-                19,
-                19,
-                21,
-                21,
-                21,
-                21,
-                21,
-                19,
-                19,
-                17,
-                17,
-                15,
-                13,
-                9,
-                5,
-            ]
-        elif isinstance(shape, list):
-            rows = shape
-        else:
-            raise ValueError(
-                "{} shape not implemented, can pass custom shape as a"
-                "list specifying number of sites per row".format(shape)
-            )
-
-        r, c = len(rows), max(rows)
-        grid = np.empty((r, c))
-        grid[:] = np.nan
-
-        next_site = 0
-        for row, row_sites in enumerate(rows):
-            start = int((c - row_sites) / 2)
-            grid[row, start : start + row_sites] = range(
-                next_site, next_site + row_sites
-            )
-            next_site += row_sites
-
-    if snake_sites:
-        grid[1::2] = grid[1::2, ::-1]
+    # Merge spatial positions from metadata if provided
+    if metadata is not None and "x_pos" in metadata.columns:
+        pos = metadata.drop_duplicates(subset=["well", "tile"])[
+            ["well", "tile", "x_pos", "y_pos"]
+        ]
+        df = df.merge(pos, on=["well", "tile"], how="left")
 
     # Infer metric to plot if necessary
+    non_metric_cols = ["plate", "well", "tile", "x_pos", "y_pos"]
     if not metric:
-        metric = [col for col in df.columns if col not in ["plate", "well", "tile"]]
+        metric = [col for col in df.columns if col not in non_metric_cols]
         if len(metric) != 1:
             raise ValueError(
-                "Cannot infer metric to plot, can pass metric column name explicitly to metric kwarg"
+                "Cannot infer metric to plot, can pass metric column name "
+                "explicitly to metric kwarg"
             )
         metric = metric[0]
 
-    # Define subplots layout
-    if df["well"].nunique() == 1:
-        wells = df["well"].unique()
+    # Create well layout from data
+    wells = sorted(df["well"].unique())
+    if len(wells) == 1:
         fig, axes = plt.subplots(1, 1, figsize=(10, 10))
         axes = np.array([axes])
-    elif plate == "6W":
-        wells = [f"{r}{c}" for r in string.ascii_uppercase[:2] for c in range(1, 4)]
-        fig, axes = plt.subplots(2, 3, figsize=(15, 10))
-    elif plate == "24W":
-        wells = [f"{r}{c}" for r in string.ascii_uppercase[:4] for c in range(1, 7)]
-        fig, axes = plt.subplots(4, 6, figsize=(15, 10))
-    elif plate == "96W":
-        wells = [f"{r}{c}" for r in string.ascii_uppercase[:8] for c in range(1, 13)]
-        fig, axes = plt.subplots(8, 12, figsize=(15, 10))
     else:
-        wells = sorted(df["well"].unique())
         nr = nc = int(np.ceil(np.sqrt(len(wells))))
         if (nr - 1) * nc >= len(wells):
             nr -= 1
-        fig, axes = plt.subplots(nr, nc, figsize=(15, 15))
+        fig, axes = plt.subplots(nr, nc, figsize=(15, 10))
 
     # Define colorbar min and max
     cmin, cmax = df[metric].min(), df[metric].max()
     if 0 <= cmin and cmax <= 1:
         cmin, cmax = 0, 1
 
+    # Remove imshow-specific kwargs that don't apply to scatter
+    scatter_kwargs = {
+        k: v for k, v in kwargs.items() if k not in ["interpolation", "aspect"]
+    }
+
     # Plot wells
+    use_spatial = "x_pos" in df.columns and "y_pos" in df.columns
+    plot = None
     for ax, well in zip(axes.reshape(-1), wells):
-        values = grid.copy()
         df_well = df.query("well==@well")
-        if df_well.pipe(len) > 0:
-            for tile in range(tiles):
-                try:
-                    values[grid == tile] = df_well.loc[
-                        df_well.tile == tile, metric
-                    ].values[0]
-                except:
-                    values[grid == tile] = np.nan
-            plot = ax.imshow(values, vmin=cmin, vmax=cmax, **kwargs)
-        ax.set_title("Well {}".format(well), fontsize=24)
+        if len(df_well) > 0:
+            if use_spatial:
+                plot = ax.scatter(
+                    df_well["x_pos"],
+                    df_well["y_pos"],
+                    c=df_well[metric],
+                    vmin=cmin,
+                    vmax=cmax,
+                    s=50,
+                    marker="s",
+                    **scatter_kwargs,
+                )
+                ax.set_aspect("equal")
+            else:
+                # Fallback: plot tiles as a square grid by tile ID
+                tiles = max(len(df["tile"].unique()), df["tile"].astype(int).max())
+                r = c = int(np.ceil(np.sqrt(tiles)))
+                grid = np.full(r * c, np.nan)
+                grid[:tiles] = range(tiles)
+                grid = grid.reshape(r, c)
+                values = grid.copy()
+                for tile in range(tiles):
+                    try:
+                        values[grid == tile] = df_well.loc[
+                            df_well.tile == tile, metric
+                        ].values[0]
+                    except Exception:
+                        values[grid == tile] = np.nan
+                plot = ax.imshow(values, vmin=cmin, vmax=cmax, **kwargs)
+        ax.set_title(f"Well {well}", fontsize=24)
         ax.axis("off")
+
+    # Hide unused axes
+    for ax in axes.reshape(-1)[len(wells) :]:
+        ax.set_visible(False)
 
     fig.subplots_adjust(right=0.9)
     cbar_ax = fig.add_axes([0.95, 0.15, 0.025, 0.7])
-    try:
+    if plot is not None:
         cbar = fig.colorbar(plot, cax=cbar_ax)
-    except:
-        # Plot variable empty, no data plotted
+        cbar.set_label(metric, fontsize=18)
+        cbar_ax.yaxis.set_ticks_position("left")
+    else:
         raise ValueError("No data to plot")
-    cbar.set_label(metric, fontsize=18)
-    cbar_ax.yaxis.set_ticks_position("left")
 
     return fig, cbar

--- a/workflow/lib/shared/eval_segmentation.py
+++ b/workflow/lib/shared/eval_segmentation.py
@@ -58,30 +58,19 @@ def segmentation_overview(segmentation_stats_paths):
     return segmentation_overview
 
 
-def plot_cell_density_heatmap(df_cells, shape="square", plate="6W", **kwargs):
+def plot_cell_density_heatmap(df_cells, metadata=None, **kwargs):
     """Plot a heatmap of cell density by well and tile in a plate layout.
-
-    This function calculates and visualizes the number of cells per well-tile combination in a plate layout.
-    It uses `plot_plate_heatmap` to plot cell density across the specified plate type (e.g., '6W', '24W', '96W').
 
     Args:
         df_cells (pandas.DataFrame):
-            DataFrame containing cell data with columns 'well' and 'tile', where each row represents a cell
-            located in a specific well and tile.
-        shape (str, optional):
-            Shape of the subplot for each well within the plate. Options include 'square', '6W_ph', '6W_sbs',
-            or a list defining custom row layouts. Defaults to 'square'.
-        plate (str):
-            Type of plate for plotting layout. Options are {'6W', '24W', '96W'}, which determine the overall
-            layout of wells in the plot.
+            DataFrame containing cell data with columns 'well' and 'tile'.
+        metadata (pandas.DataFrame, optional):
+            Metadata with x_pos/y_pos for spatial plotting. Defaults to None.
         **kwargs:
-            Additional keyword arguments to customize the appearance, passed directly to `plot_plate_heatmap()`.
+            Additional keyword arguments passed to `plot_plate_heatmap()`.
 
     Returns:
-        tuple: A tuple containing:
-            - pandas.DataFrame: A summary DataFrame with cell counts (`cell count`) per well-tile combination.
-            - matplotlib.figure.Figure: The figure object containing the plotted heatmap.
-
+        tuple: (summary DataFrame, figure).
     """
     # Calculate cell counts by well and tile
     df_summary = (
@@ -104,7 +93,7 @@ def plot_cell_density_heatmap(df_cells, shape="square", plate="6W", **kwargs):
 
     # Plot heatmap
     fig, _ = plot_plate_heatmap(
-        df_summary, metric="cell count", shape=shape, plate=plate, **kwargs
+        df_summary, metric="cell count", metadata=metadata, **kwargs
     )
 
     return df_summary, fig

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -191,6 +191,8 @@ rule generate_montage:
         ],
     params:
         channels=config["phenotype"]["channel_names"],
+        montage_cell_size=config["aggregate"].get("montage_cell_size", 40),
+        montage_shape=config["aggregate"].get("montage_shape", [3, 10]),
     script:
         "../scripts/aggregate/generate_montage.py"
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -197,6 +197,8 @@ rule generate_montage:
         ],
     params:
         channels=config["phenotype"]["channel_names"],
+        montage_cell_size=config["aggregate"].get("montage_cell_size", 40),
+        montage_shape=config["aggregate"].get("montage_shape", [3, 10]),
     script:
         "../scripts/aggregate/generate_montage.py"
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -36,7 +36,12 @@ rule filter:
     params:
         metadata_cols_fp=config["aggregate"]["metadata_cols_fp"],
         use_classifier=config.get("classify", {}).get("classifier_path") is not None,
-        filter_queries=config["aggregate"]["filter_queries"],
+        filter_queries=lambda wildcards: (
+            (config["aggregate"]["filter_queries"] or [])
+            + config["aggregate"]
+            .get("filter_queries_by_class", {})
+            .get(wildcards.cell_class, [])
+        ),
         perturbation_name_col=config["aggregate"]["perturbation_name_col"],
         drop_cols_threshold=config["aggregate"]["drop_cols_threshold"],
         drop_rows_threshold=config["aggregate"]["drop_rows_threshold"],
@@ -99,6 +104,7 @@ rule align:
         control_key=config["aggregate"]["control_key"],
         num_align_batches=config["aggregate"]["num_align_batches"],
         skip_perturbation_score=config["aggregate"]["skip_perturbation_score"],
+        control_name_col=config["aggregate"].get("control_name_col"),
     script:
         "../scripts/aggregate/align.py"
 

--- a/workflow/rules/merge.smk
+++ b/workflow/rules/merge.smk
@@ -320,11 +320,18 @@ rule eval_merge:
             metadata_combos=phenotype_wildcard_combos,
             ancient_output=True,
         ),
-    params: 
-        heatmap_plate_sbs=config["sbs"].get("heatmap_plate", "6W"),  
-        heatmap_shape_sbs=config["sbs"].get("heatmap_shape", "6W_sbs"),
-        heatmap_plate_ph=config["phenotype"].get("heatmap_plate", "6W"), 
-        heatmap_shape_ph=config["phenotype"].get("heatmap_shape", "6W_ph"),
+        sbs_metadata_paths=lambda wildcards: output_to_input(
+            ancient(PREPROCESS_OUTPUTS["combine_metadata_sbs"]),
+            wildcards=wildcards,
+            expansion_values=["well"],
+            metadata_combos=sbs_wildcard_combos,
+        ),
+        phenotype_metadata_paths=lambda wildcards: output_to_input(
+            ancient(PREPROCESS_OUTPUTS["combine_metadata_phenotype"]),
+            wildcards=wildcards,
+            expansion_values=["well"],
+            metadata_combos=phenotype_wildcard_combos,
+        ),
     output:
         merge_summary=MERGE_OUTPUTS_MAPPED["eval_merge"][0],
         sbs_to_ph_matching_rates_tsv=MERGE_OUTPUTS_MAPPED["eval_merge"][1],
@@ -334,9 +341,6 @@ rule eval_merge:
         all_cells_by_channel_min=MERGE_OUTPUTS_MAPPED["eval_merge"][5],
         cells_with_channel_min_0=MERGE_OUTPUTS_MAPPED["eval_merge"][6],
         dedup_summaries=MERGE_OUTPUTS_MAPPED["eval_merge"][7],
-    params:
-        sbs_heatmap_shape=config["sbs"].get("heatmap_shape", "6W_sbs"),
-        phenotype_heatmap_shape=config["phenotype"].get("heatmap_shape", "6W_ph"),
     script:
         "../scripts/merge/eval_merge.py"
 

--- a/workflow/rules/phenotype.smk
+++ b/workflow/rules/phenotype.smk
@@ -135,11 +135,15 @@ rule eval_segmentation_phenotype:
             expansion_values=["well"],
             metadata_combos=phenotype_wildcard_combos,
         ),
+        # path to combined metadata for spatial plotting
+        metadata_paths=lambda wildcards: output_to_input(
+            ancient(PREPROCESS_OUTPUTS["combine_metadata_phenotype"]),
+            wildcards=wildcards,
+            expansion_values=["well"],
+            metadata_combos=phenotype_wildcard_combos,
+        ),
     output:
         PHENOTYPE_OUTPUTS_MAPPED["eval_segmentation_phenotype"],
-    params:
-        heatmap_shape=config["phenotype"].get("heatmap_shape", "6W_ph"),
-        heatmap_plate=config["phenotype"].get("heatmap_plate", "6W"),
     script:
         "../scripts/shared/eval_segmentation.py"
 
@@ -153,11 +157,15 @@ rule eval_features:
             expansion_values=["well"],
             metadata_combos=phenotype_wildcard_combos,
         ),
+        # path to combined metadata for spatial plotting
+        metadata_paths=lambda wildcards: output_to_input(
+            ancient(PREPROCESS_OUTPUTS["combine_metadata_phenotype"]),
+            wildcards=wildcards,
+            expansion_values=["well"],
+            metadata_combos=phenotype_wildcard_combos,
+        ),
     output:
         PHENOTYPE_OUTPUTS_MAPPED["eval_features"],
-    params:
-        heatmap_shape=config["phenotype"].get("heatmap_shape", "6W_ph"),
-        heatmap_plate=config["phenotype"].get("heatmap_plate", "6W"),
     script:
         "../scripts/phenotype/eval_features.py"
 

--- a/workflow/rules/sbs.smk
+++ b/workflow/rules/sbs.smk
@@ -234,11 +234,15 @@ rule eval_segmentation_sbs:
             expansion_values=["well"],
             metadata_combos=sbs_wildcard_combos,
         ),
+        # path to combined metadata for spatial plotting
+        metadata_paths=lambda wildcards: output_to_input(
+            ancient(PREPROCESS_OUTPUTS["combine_metadata_sbs"]),
+            wildcards=wildcards,
+            expansion_values=["well"],
+            metadata_combos=sbs_wildcard_combos,
+        ),
     output:
         SBS_OUTPUTS_MAPPED["eval_segmentation_sbs"],
-    params:
-        heatmap_plate=config["sbs"].get("heatmap_plate", "6W"),   
-        heatmap_shape=config["sbs"].get("heatmap_shape", "6W_sbs")
     script:
         "../scripts/shared/eval_segmentation.py"
 
@@ -263,12 +267,16 @@ rule eval_mapping:
             expansion_values=["well"],
             metadata_combos=sbs_wildcard_combos,
         ),
+        metadata_paths=lambda wildcards: output_to_input(
+            ancient(PREPROCESS_OUTPUTS["combine_metadata_sbs"]),
+            wildcards=wildcards,
+            expansion_values=["well"],
+            metadata_combos=sbs_wildcard_combos,
+        ),
     output:
         SBS_OUTPUTS_MAPPED["eval_mapping"],
     params:
         df_barcode_library_fp=config["sbs"]["df_barcode_library_fp"],
-        heatmap_plate=config["sbs"].get("heatmap_plate", "6W"),
-        heatmap_shape=config["sbs"].get("heatmap_shape", "6W_sbs"),
         sort_by=config["sbs"]["sort_calls"],
         barcode_type=config["sbs"].get("barcode_type", "simple"),
         sequencing_order=config["sbs"].get("sequencing_order", "map_recomb"),

--- a/workflow/scripts/aggregate/aggregate.py
+++ b/workflow/scripts/aggregate/aggregate.py
@@ -7,6 +7,13 @@ from lib.aggregate.aggregate import aggregate
 # Load cell data using PyArrow dataset
 print("Loading cell data")
 cell_data = ds.dataset(snakemake.input[0], format="parquet")
+
+# Handle empty input gracefully
+if cell_data.count_rows() == 0:
+    print("WARNING: No cells in input, writing empty output")
+    pd.DataFrame().to_csv(snakemake.output[0], sep="\t", index=False)
+    exit(0)
+
 cell_data = cell_data.to_table(use_threads=True, memory_pool=None).to_pandas()
 print(f"Shape of input data: {cell_data.shape}")
 

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -29,12 +29,22 @@ np.random.seed(0)
 ## Step 1: Create PCA transformation
 PCA_SUBSET = 100000
 
-# Load full dataset as logical PyArrow dataset
-cell_dataset = ds.dataset(snakemake.input.filtered_paths, format="parquet")
-print(f"Number of rows across all parquet files: {cell_dataset.count_rows()}")
+# Filter out empty parquet files to avoid schema conflicts
+non_empty_paths = [
+    p for p in snakemake.input.filtered_paths if pq.read_metadata(p).num_rows > 0
+]
 
-# Count total rows across all Parquet files
+if len(non_empty_paths) == 0:
+    print("WARNING: No cells in input, writing empty output")
+    pq.write_table(pa.table({}), snakemake.output[0])
+    exit(0)
+
+# Load full dataset as logical PyArrow dataset (only non-empty files)
+cell_dataset = ds.dataset(non_empty_paths, format="parquet")
 total_rows = cell_dataset.count_rows()
+print(
+    f"Number of rows across {len(non_empty_paths)} non-empty parquet files: {total_rows}"
+)
 
 # Choose random row indices
 n_sample = min(PCA_SUBSET, total_rows)
@@ -122,6 +132,7 @@ for i, indices in enumerate(subset_indices):
         snakemake.params.perturbation_name_col,
         snakemake.params.control_key,
         "batch_values",
+        control_col=snakemake.params.get("control_name_col"),
     )
 
     feature_columns = [f"PC_{j}" for j in range(features.shape[1])]

--- a/workflow/scripts/aggregate/eval_aggregate.py
+++ b/workflow/scripts/aggregate/eval_aggregate.py
@@ -2,6 +2,7 @@ import random
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pyarrow.parquet as pq
 import pyarrow.dataset as ds
 
 plt.rcParams.update(
@@ -18,10 +19,26 @@ from lib.aggregate.eval_aggregate import (
 
 SUBSET_SIZE = 100000
 
-# Get merge dataset
-merge_data = ds.dataset(snakemake.input.split_datasets_paths, format="parquet")
-# Choose random row indices
+# Get merge dataset — filter out empty parquets to avoid schema conflicts
+non_empty_split = [
+    p for p in snakemake.input.split_datasets_paths if pq.read_metadata(p).num_rows > 0
+]
+
+if len(non_empty_split) == 0:
+    print("WARNING: No cells in input, writing empty eval outputs")
+    import pandas as pd
+
+    pd.DataFrame().to_csv(snakemake.output[0], sep="\t", index=False)
+    fig, ax = plt.subplots()
+    ax.text(0.5, 0.5, "No data", ha="center", va="center")
+    fig.savefig(snakemake.output[1], dpi=300, bbox_inches="tight")
+    fig.savefig(snakemake.output[2], dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    exit(0)
+
+merge_data = ds.dataset(non_empty_split, format="parquet")
 total_rows = merge_data.count_rows()
+# Choose random row indices
 n_sample = min(SUBSET_SIZE, total_rows)
 random_indices = np.random.choice(total_rows, size=n_sample, replace=False)
 random_indices.sort()

--- a/workflow/scripts/aggregate/filter.py
+++ b/workflow/scripts/aggregate/filter.py
@@ -8,6 +8,15 @@ from lib.aggregate.filter import (
     intensity_filter,
 )
 
+
+def write_empty_and_exit(metadata, features, output_path, stage):
+    """Write empty parquet and exit if no cells remain after a filtering stage."""
+    if len(metadata) == 0:
+        print(f"WARNING: No cells after {stage}, writing empty output")
+        pd.concat([metadata, features], axis=1).to_parquet(output_path, index=False)
+        exit(0)
+
+
 # Load cell data
 cell_data = pd.read_parquet(snakemake.input[0])
 use_classifier = snakemake.params.get("use_classifier", False)
@@ -16,6 +25,7 @@ metadata_cols = load_metadata_cols(
     include_classification_cols=use_classifier,
 )
 metadata, features = split_cell_data(cell_data, metadata_cols)
+output_path = snakemake.output[0]
 
 # Filter
 metadata, features = query_filter(
@@ -23,11 +33,15 @@ metadata, features = query_filter(
     features,
     snakemake.params.filter_queries,
 )
+write_empty_and_exit(metadata, features, output_path, "query_filter")
+
 metadata, features = perturbation_filter(
     metadata,
     features,
     snakemake.params.perturbation_name_col,
 )
+write_empty_and_exit(metadata, features, output_path, "perturbation_filter")
+
 metadata, features = missing_values_filter(
     metadata,
     features,
@@ -35,6 +49,8 @@ metadata, features = missing_values_filter(
     drop_rows_threshold=snakemake.params.drop_rows_threshold,
     impute=snakemake.params.impute,
 )
+write_empty_and_exit(metadata, features, output_path, "missing_values_filter")
+
 metadata, features = intensity_filter(
     metadata,
     features,
@@ -44,4 +60,4 @@ metadata, features = intensity_filter(
 
 # Save filtered data
 cell_data = pd.concat([metadata, features], axis=1)
-cell_data.to_parquet(snakemake.output[0], index=False)
+cell_data.to_parquet(output_path, index=False)

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -14,13 +14,25 @@ from lib.aggregate.bootstrap import create_pseudogene_groups
 
 # get snakemake parameters
 pert_col = snakemake.params.perturbation_name_col
-pert_id_col = snakemake.params.perturbation_id_col
+pert_id_col = snakemake.params.perturbation_id_col or pert_col
 control_key = snakemake.params.control_key
 num_batches = snakemake.params.get("num_align_batches", 1)
 
 # Load cell data using PyArrow dataset (lazy - no data loaded yet)
 print("Loading cell data as PyArrow dataset...")
-cell_dataset = ds.dataset(snakemake.input.filtered_paths, format="parquet")
+# Filter out empty parquet files to avoid schema conflicts
+non_empty_paths = [
+    p for p in snakemake.input.filtered_paths if pq.read_metadata(p).num_rows > 0
+]
+
+if len(non_empty_paths) == 0:
+    print("WARNING: No cells in input, writing empty outputs")
+    pd.DataFrame().to_parquet(snakemake.output[0], index=False)
+    pd.DataFrame().to_csv(snakemake.output[1], sep="\t", index=False)
+    pd.DataFrame().to_csv(snakemake.output[2], sep="\t", index=False)
+    exit(0)
+
+cell_dataset = ds.dataset(non_empty_paths, format="parquet")
 
 # Determine columns
 cell_data_cols = cell_dataset.schema.names

--- a/workflow/scripts/aggregate/generate_montage.py
+++ b/workflow/scripts/aggregate/generate_montage.py
@@ -10,7 +10,12 @@ from lib.aggregate.montage_utils import create_cell_montage
 montage_data = pd.read_csv(snakemake.input[0], sep="\t")
 
 # create cell montage
-montage = create_cell_montage(montage_data, snakemake.params.channels)
+montage = create_cell_montage(
+    montage_data,
+    snakemake.params.channels,
+    cell_size=snakemake.params.get("montage_cell_size", 40),
+    shape=tuple(snakemake.params.get("montage_shape", (3, 10))),
+)
 
 # save montages
 overlay = []

--- a/workflow/scripts/aggregate/prepare_bootstrap_data.py
+++ b/workflow/scripts/aggregate/prepare_bootstrap_data.py
@@ -15,7 +15,7 @@ from lib.aggregate.bootstrap import write_construct_data
 
 # Get parameters
 perturbation_col = snakemake.params.perturbation_name_col
-perturbation_id_col = snakemake.params.perturbation_id_col
+perturbation_id_col = snakemake.params.perturbation_id_col or perturbation_col
 control_key = snakemake.params.control_key
 exclusion_string = snakemake.params.exclusion_string
 metadata_cols_fp = snakemake.params.metadata_cols_fp
@@ -24,6 +24,17 @@ bootstrap_features_fp = snakemake.params.get("bootstrap_features_fp", None)
 print("Loading single-cell features data...")
 all_features_cells = pd.read_parquet(snakemake.input.features_singlecell)
 print(f"Features data shape: {all_features_cells.shape}")
+
+# Handle empty input gracefully
+if len(all_features_cells) == 0:
+    print("WARNING: No cells in input, writing empty bootstrap outputs")
+    pd.DataFrame().to_csv(snakemake.output.controls_arr, sep="\t", index=False)
+    pd.DataFrame().to_csv(
+        snakemake.output.construct_features_arr, sep="\t", index=False
+    )
+    pd.DataFrame().to_csv(snakemake.output.sample_sizes, sep="\t", index=False)
+    Path(snakemake.output[0]).mkdir(parents=True, exist_ok=True)
+    exit(0)
 
 print("Loading construct and gene tables...")
 construct_table = pd.read_csv(snakemake.input.construct_table, sep="\t")

--- a/workflow/scripts/aggregate/prepare_montage_data.py
+++ b/workflow/scripts/aggregate/prepare_montage_data.py
@@ -12,6 +12,12 @@ from lib.shared.file_utils import get_filename
 output_dir = Path(snakemake.output[0])
 output_dir.mkdir(parents=True, exist_ok=True)
 
+# Handle empty input gracefully
+cell_check = ds.dataset(snakemake.input, format="parquet")
+if cell_check.count_rows() == 0:
+    print("WARNING: No cells in input, skipping montage data preparation")
+    exit(0)
+
 # Load cell data
 montage_columns = [
     "gene_symbol_0",

--- a/workflow/scripts/merge/eval_merge.py
+++ b/workflow/scripts/merge/eval_merge.py
@@ -74,6 +74,15 @@ phenotype_info = validate_dtypes(
     )
 )
 
+# Load metadata for spatial heatmap plotting
+sbs_metadata = pd.concat(
+    [pd.read_parquet(p) for p in snakemake.input.sbs_metadata_paths], ignore_index=True
+).drop_duplicates(subset=["well", "tile"])
+phenotype_metadata = pd.concat(
+    [pd.read_parquet(p) for p in snakemake.input.phenotype_metadata_paths],
+    ignore_index=True,
+).drop_duplicates(subset=["well", "tile"])
+
 # Load dedup stats by well
 dedup_stats = {}
 for p in snakemake.input.dedup_stats_paths:
@@ -165,8 +174,7 @@ sbs_summary, fig = plot_sbs_ph_matching_heatmap(
     merge_minimal,
     sbs_info.rename(columns={"cell": "cell_1"}),  # sbs_info uses "cell" not "cell_1"
     target="sbs",
-    shape=snakemake.params.heatmap_shape_sbs,
-    plate=snakemake.params.heatmap_plate_sbs,
+    metadata=sbs_metadata,
     return_summary=True,
 )
 sbs_summary.to_csv(snakemake.output.sbs_to_ph_matching_rates_tsv, sep="\t", index=False)
@@ -184,8 +192,7 @@ ph_summary, fig = plot_sbs_ph_matching_heatmap(
         columns={"cell": "cell_0"}
     ),  # phenotype_info uses "cell" not "cell_0"
     target="phenotype",
-    shape=snakemake.params.heatmap_shape_ph,
-    plate=snakemake.params.heatmap_plate_ph,
+    metadata=phenotype_metadata,
     return_summary=True,
 )
 ph_summary.to_csv(snakemake.output.ph_to_sbs_matching_rates_tsv, sep="\t", index=False)

--- a/workflow/scripts/phenotype/eval_features.py
+++ b/workflow/scripts/phenotype/eval_features.py
@@ -11,10 +11,15 @@ plt.rcParams.update(
 from lib.phenotype.eval_features import plot_feature_heatmap
 
 
-# Load SBS processing files
+# Load phenotype processing files
 phenotype_cp_min = pd.concat(
-    [pd.read_parquet(p) for p in snakemake.input], ignore_index=True
+    [pd.read_parquet(p) for p in snakemake.input.cells_paths], ignore_index=True
 )
+
+# Load metadata for spatial heatmap plotting
+metadata = pd.concat(
+    [pd.read_parquet(p) for p in snakemake.input.metadata_paths], ignore_index=True
+).drop_duplicates(subset=["well", "tile"])
 
 # Generate and save feature heatmaps
 min_feature_names = [col for col in phenotype_cp_min.columns if col.endswith("_min")]
@@ -23,8 +28,7 @@ for feature_name in min_feature_names:
     df_summary_one, fig = plot_feature_heatmap(
         phenotype_cp_min,
         feature=feature_name,
-        shape=snakemake.params.heatmap_shape,
-        plate=snakemake.params.heatmap_plate,
+        metadata=metadata,
         return_summary=True,
     )
 

--- a/workflow/scripts/sbs/eval_mapping.py
+++ b/workflow/scripts/sbs/eval_mapping.py
@@ -39,6 +39,11 @@ sbs_info = pd.concat(
     [pd.read_parquet(p) for p in snakemake.input.sbs_info_paths], ignore_index=True
 )
 
+# Load metadata for spatial heatmap plotting
+metadata = pd.concat(
+    [pd.read_parquet(p) for p in snakemake.input.metadata_paths], ignore_index=True
+).drop_duplicates(subset=["well", "tile"])
+
 _, fig = plot_mapping_vs_threshold(reads, barcodes, "peak", num_thresholds=10)
 fig.savefig(snakemake.output[0], dpi=300, bbox_inches="tight", transparent=True)
 
@@ -48,8 +53,7 @@ fig.savefig(snakemake.output[1], dpi=300, bbox_inches="tight", transparent=True)
 fig = plot_read_mapping_heatmap(
     reads,
     barcodes,
-    plate=snakemake.params.heatmap_plate,
-    shape=snakemake.params.heatmap_shape,
+    metadata=metadata,
 )
 fig.savefig(snakemake.output[2], dpi=300, bbox_inches="tight", transparent=True)
 
@@ -59,8 +63,7 @@ df_summary_one, fig = plot_cell_mapping_heatmap(
     barcodes,
     mapping_to="one",
     mapping_strategy="gene symbols",
-    shape=snakemake.params.heatmap_shape,
-    plate=snakemake.params.heatmap_plate,
+    metadata=metadata,
     return_summary=True,
 )
 df_summary_one.to_csv(snakemake.output[3], index=False, sep="\t")
@@ -72,8 +75,7 @@ df_summary_any, fig = plot_cell_mapping_heatmap(
     barcodes,
     mapping_to="any",
     mapping_strategy="gene symbols",
-    shape=snakemake.params.heatmap_shape,
-    plate=snakemake.params.heatmap_plate,
+    metadata=metadata,
     return_summary=True,
 )
 df_summary_any.to_csv(snakemake.output[5], index=False, sep="\t")

--- a/workflow/scripts/shared/eval_segmentation.py
+++ b/workflow/scripts/shared/eval_segmentation.py
@@ -27,10 +27,15 @@ cells = pd.concat(
     [pd.read_parquet(p) for p in snakemake.input.cells_paths], ignore_index=True
 )
 
+# Load metadata for spatial heatmap plotting
+metadata = pd.concat(
+    [pd.read_parquet(p) for p in snakemake.input.metadata_paths], ignore_index=True
+).drop_duplicates(subset=["well", "tile"])
 
 # plot cell density heatmap
 cell_density_summary, fig = plot_cell_density_heatmap(
-    cells, shape=snakemake.params.heatmap_shape, plate=snakemake.params.heatmap_plate
+    cells,
+    metadata=metadata,
 )
 cell_density_summary.to_csv(snakemake.output[1], index=False, sep="\t")
 fig.savefig(snakemake.output[2], dpi=300, bbox_inches="tight", transparent=True)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

Thank you for your contribution to Brieflow!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Please also link to any relevant issues that your code is associated with.

Replaces hardcoded plate/tile layouts in eval heatmaps with spatial plotting from metadata. Fixes #211.

Core change: plot_plate_heatmap now accepts an optional metadata param. When provided, tiles are scatter-plotted at their real x_pos/y_pos positions. Wells are auto-detected from the data. Falls back to a square grid by tile ID when metadata is not available.

Removed: shape, plate, snake_sites parameters and all hardcoded tile layouts (6W_ph, 6W_sbs, 6W, 24W, 96W). The heatmap_plate and heatmap_shape config params are no longer needed.

Montage improvement (#210): generate_montage now reads montage_cell_size and montage_shape from config instead of using hardcoded defaults. Also adds documentation to #204 

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [x] I have updated the `pyproject.toml` to reflect the change as designated by [semantic versioning](https://semver.org/).
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have deleted all non-relevant text in this pull request template.
