### PR TITLE
feat(aggregate): port compartment_combo + aggregate fixes onto secondary_object (joint scrubbed)

### DIFF
--- a/tests/small_test_analysis/config/aggregate_combo.tsv
+++ b/tests/small_test_analysis/config/aggregate_combo.tsv
@@ -1,3 +1,5 @@
-cell_class	channel_combo	plate	well
-Interphase	DAPI_COXIV_CENPA_WGA	1	A1
-Interphase	DAPI_COXIV_CENPA_WGA	1	A2
+cell_class	channel_combo	compartment_combo	plate	well
+Interphase	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	1	A1
+Interphase	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	1	A2
+Interphase	DAPI	nucleus	1	A1
+Interphase	DAPI	nucleus	1	A2

--- a/tests/small_test_analysis/config/cluster_combo.tsv
+++ b/tests/small_test_analysis/config/cluster_combo.tsv
@@ -1,2 +1,3 @@
-cell_class	channel_combo	leiden_resolution
-Interphase	DAPI_COXIV_CENPA_WGA	2
+cell_class	channel_combo	compartment_combo	leiden_resolution
+Interphase	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	2
+Interphase	DAPI	nucleus	2

--- a/tests/small_test_analysis/config/config.yml
+++ b/tests/small_test_analysis/config/config.yml
@@ -173,6 +173,10 @@ aggregate:
   bootstrap_combinations:
   - cell_class: Interphase
     channel_combo: DAPI_COXIV_CENPA_WGA
+    compartment_combo: cell-nucleus-cytoplasm
+  - cell_class: Interphase
+    channel_combo: DAPI
+    compartment_combo: nucleus
 cluster:
   cluster_combo_fp: config/cluster_combo.tsv
   uniprot_data_fp: config/benchmark_clusters/uniprot_data.tsv

--- a/tests/test_compartment_filter.py
+++ b/tests/test_compartment_filter.py
@@ -1,0 +1,79 @@
+"""Unit tests for compartment filtering in the aggregate module."""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Make the workflow's `lib` package importable without installing the package
+WORKFLOW_LIB_DIR = Path(__file__).resolve().parents[1] / "workflow"
+sys.path.insert(0, str(WORKFLOW_LIB_DIR))
+
+from lib.aggregate.cell_data_utils import (
+    COMPARTMENT_PREFIXES,
+    SECOND_OBJ_EXTRA_COLS,
+    compartment_combo_subset,
+)
+
+ALL_COMPARTMENTS_4 = ["cell", "nucleus", "cytoplasm", "second_obj"]
+ALL_COMPARTMENTS_3 = ["cell", "nucleus", "cytoplasm"]
+
+
+def _make_features_4c():
+    return pd.DataFrame(
+        {
+            "cell_DAPI_mean": [1.0],
+            "cell_area": [2.0],
+            "nucleus_DAPI_mean": [3.0],
+            "nucleus_area": [4.0],
+            "cytoplasm_DAPI_mean": [5.0],
+            "cytoplasm_area": [6.0],
+            "second_obj_DAPI_mean": [7.0],
+            "second_obj_area": [8.0],
+            "total_second_obj_area": [10.0],
+            "mean_second_obj_diameter": [11.0],
+            "mean_distance_to_nucleus": [12.0],
+        }
+    )
+
+
+def test_all_compartments_kept():
+    df = _make_features_4c()
+    out = compartment_combo_subset(df, ALL_COMPARTMENTS_4, ALL_COMPARTMENTS_4)
+    assert list(out.columns) == list(df.columns)
+
+
+def test_nucleus_only_drops_other_prefixes():
+    df = _make_features_4c()
+    out = compartment_combo_subset(df, ["nucleus"], ALL_COMPARTMENTS_4)
+    assert set(out.columns) == {"nucleus_DAPI_mean", "nucleus_area"}
+
+
+def test_cell_plus_nucleus():
+    df = _make_features_4c()
+    out = compartment_combo_subset(df, ["cell", "nucleus"], ALL_COMPARTMENTS_4)
+    expected = {"cell_DAPI_mean", "cell_area", "nucleus_DAPI_mean", "nucleus_area"}
+    assert set(out.columns) == expected
+
+
+def test_second_obj_exclusion_drops_extra_cols():
+    df = _make_features_4c()
+    out = compartment_combo_subset(df, ALL_COMPARTMENTS_3, ALL_COMPARTMENTS_4)
+    for c in SECOND_OBJ_EXTRA_COLS:
+        assert c not in out.columns
+    assert "second_obj_DAPI_mean" not in out.columns
+    assert "cell_area" in out.columns
+
+
+def test_second_obj_included_keeps_extra_cols():
+    df = _make_features_4c()
+    out = compartment_combo_subset(df, ["second_obj"], ALL_COMPARTMENTS_4)
+    for c in SECOND_OBJ_EXTRA_COLS:
+        assert c in out.columns
+
+
+def test_compartment_prefixes_constant_shape():
+    assert set(COMPARTMENT_PREFIXES) == {"cell", "nucleus", "cytoplasm", "second_obj"}
+    for name, prefix in COMPARTMENT_PREFIXES.items():
+        assert prefix == f"{name}_"

--- a/tests/test_compartment_filter.py
+++ b/tests/test_compartment_filter.py
@@ -77,3 +77,85 @@ def test_compartment_prefixes_constant_shape():
     assert set(COMPARTMENT_PREFIXES) == {"cell", "nucleus", "cytoplasm", "second_obj"}
     for name, prefix in COMPARTMENT_PREFIXES.items():
         assert prefix == f"{name}_"
+
+
+from lib.aggregate.cell_data_utils import resolve_aggregate_combos
+
+
+def test_resolve_defaults_4_when_detection_true():
+    out = resolve_aggregate_combos([{"channels": ["DAPI"]}], second_obj_detection=True)
+    assert out == [
+        {
+            "channels": ["DAPI"],
+            "compartments": ["cell", "nucleus", "cytoplasm", "second_obj"],
+        }
+    ]
+
+
+def test_resolve_defaults_3_when_detection_false():
+    out = resolve_aggregate_combos([{"channels": ["DAPI"]}], second_obj_detection=False)
+    assert out == [
+        {"channels": ["DAPI"], "compartments": ["cell", "nucleus", "cytoplasm"]}
+    ]
+
+
+def test_resolve_rejects_unknown_compartment():
+    with pytest.raises(ValueError, match="unknown compartment"):
+        resolve_aggregate_combos(
+            [{"channels": ["DAPI"], "compartments": ["nucleous"]}],
+            second_obj_detection=True,
+        )
+
+
+def test_resolve_rejects_second_obj_when_detection_false():
+    with pytest.raises(ValueError, match="second_obj_detection"):
+        resolve_aggregate_combos(
+            [{"channels": ["DAPI"], "compartments": ["second_obj"]}],
+            second_obj_detection=False,
+        )
+
+
+def test_resolve_rejects_empty_compartments():
+    with pytest.raises(ValueError, match="at least one compartment"):
+        resolve_aggregate_combos(
+            [{"channels": ["DAPI"], "compartments": []}],
+            second_obj_detection=True,
+        )
+
+
+def test_resolve_rejects_empty_channels():
+    with pytest.raises(ValueError, match="at least one channel"):
+        resolve_aggregate_combos(
+            [{"channels": [], "compartments": ["cell"]}],
+            second_obj_detection=True,
+        )
+
+
+def test_resolve_dedupes_compartments_within_combo():
+    out = resolve_aggregate_combos(
+        [{"channels": ["DAPI"], "compartments": ["cell", "cell", "nucleus"]}],
+        second_obj_detection=True,
+    )
+    assert out[0]["compartments"] == ["cell", "nucleus"]
+
+
+def test_resolve_dedupes_duplicate_combos():
+    out = resolve_aggregate_combos(
+        [
+            {"channels": ["DAPI"], "compartments": ["cell"]},
+            {"channels": ["DAPI"], "compartments": ["cell"]},
+        ],
+        second_obj_detection=True,
+    )
+    assert len(out) == 1
+
+
+def test_resolve_preserves_distinct_combos():
+    out = resolve_aggregate_combos(
+        [
+            {"channels": ["DAPI"], "compartments": ["cell"]},
+            {"channels": ["DAPI"], "compartments": ["nucleus"]},
+        ],
+        second_obj_detection=True,
+    )
+    assert len(out) == 2

--- a/workflow/lib/aggregate/aggregate.py
+++ b/workflow/lib/aggregate/aggregate.py
@@ -16,6 +16,7 @@ def aggregate(
     method="mean",
     ps_probability_threshold=None,
     ps_percentile_threshold=None,
+    carry_cols: list[str] | None = None,
 ) -> tuple[np.ndarray, pd.DataFrame]:
     """Apply mean or median aggregation to replicate embeddings and perturbation scores for each perturbation.
 
@@ -31,6 +32,13 @@ def aggregate(
             Defaults to "mean".
         ps_probability_threshold (float, optional): Threshold for filtering based on perturbation score.
         ps_percentile_threshold (float, optional): Percentile threshold for filtering based on perturbation score.
+        carry_cols (list[str], optional): Metadata columns functionally determined by
+            `pert_col` to preserve (one value per group) in the output. Typical use:
+            when `pert_col` is a construct ID (e.g. `cell_barcode_0`), carry the
+            human-readable gene symbol (`gene_symbol_0`) through so downstream
+            clustering / benchmarking / lookups can match by gene name. Raises
+            ValueError if a carry_col is missing from metadata or has more than one
+            unique value within a group.
 
     Returns:
         tuple:
@@ -47,6 +55,21 @@ def aggregate(
     )
     if aggr_func is None:
         raise ValueError(f"Invalid aggregation method: {method}")
+
+    if carry_cols is None:
+        carry_cols = []
+    else:
+        missing = [c for c in carry_cols if c not in metadata.columns]
+        if missing:
+            raise ValueError(
+                f"carry_cols not found in metadata: {missing}. "
+                f"Available columns: {list(metadata.columns)}"
+            )
+        overlap = [c for c in carry_cols if c == pert_col]
+        if overlap:
+            raise ValueError(
+                f"carry_cols overlap with pert_col: {overlap}. Remove duplicates."
+            )
 
     # filter by ps_probability_threshold; keep NaNs
     if ps_probability_threshold is not None:
@@ -80,6 +103,16 @@ def aggregate(
         # Always include perturbation_auc if present (needed for gene-level filtering in clustering)
         if "perturbation_auc" in metadata.columns:
             agg_meta["perturbation_auc"] = group["perturbation_auc"].iloc[0]
+
+        # Carry through columns that are functionally determined by pert_col.
+        for c in carry_cols:
+            nuniq = group[c].nunique(dropna=False)
+            if nuniq > 1:
+                raise ValueError(
+                    f"carry_col {c!r} has {nuniq} unique values within group "
+                    f"{pert_col}={pert!r}; not functionally determined by {pert_col}."
+                )
+            agg_meta[c] = group[c].iloc[0]
 
         if ps_probability_threshold is not None or ps_percentile_threshold is not None:
             # aggregate perturbation score with same function

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -200,7 +200,9 @@ SECOND_OBJ_EXTRA_COLS = frozenset(
 )
 
 
-def compartment_combo_subset(features, compartment_combo, all_compartments):
+def compartment_combo_subset(
+    features: pd.DataFrame, compartment_combo: str, all_compartments: list[str]
+) -> pd.DataFrame:
     """Filter features to keep only columns belonging to the requested compartments.
 
     Args:
@@ -226,7 +228,9 @@ def compartment_combo_subset(features, compartment_combo, all_compartments):
     return features.drop(columns=cols_to_drop)
 
 
-def resolve_aggregate_combos(aggregate_combos, second_obj_detection):
+def resolve_aggregate_combos(
+    aggregate_combos: list[dict], second_obj_detection: bool
+) -> list[dict]:
     """Normalize and validate AGGREGATE_COMBOS entries.
 
     For each entry:

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -224,3 +224,75 @@ def compartment_combo_subset(features, compartment_combo, all_compartments):
         cols_to_drop += [c for c in SECOND_OBJ_EXTRA_COLS if c in features.columns]
 
     return features.drop(columns=cols_to_drop)
+
+
+def resolve_aggregate_combos(aggregate_combos, second_obj_detection):
+    """Normalize and validate AGGREGATE_COMBOS entries.
+
+    For each entry:
+    - Fills in default compartments (all 4 if detection on, 3 otherwise) when missing.
+    - Dedupes compartments within the combo (preserving order).
+    - Validates compartment names, non-empty channels/compartments, and
+      second_obj-vs-detection consistency.
+    After normalization, duplicate (channels, compartments) pairs are deduped.
+
+    Args:
+        aggregate_combos (list[dict]): Each dict has "channels" (list[str]) and
+            optionally "compartments" (list[str]).
+        second_obj_detection (bool): From config["phenotype"]["second_obj_detection"].
+
+    Returns:
+        list[dict]: Normalized, validated, and de-duplicated combos.
+
+    Raises:
+        ValueError: On any validation failure.
+    """
+    valid_compartments = set(COMPARTMENT_PREFIXES)
+    default_compartments = (
+        ["cell", "nucleus", "cytoplasm", "second_obj"]
+        if second_obj_detection
+        else ["cell", "nucleus", "cytoplasm"]
+    )
+
+    resolved = []
+    seen = set()
+    for idx, combo in enumerate(aggregate_combos):
+        channels = list(combo.get("channels") or [])
+        if not channels:
+            raise ValueError(
+                f"AGGREGATE_COMBOS[{idx}] must specify at least one channel"
+            )
+
+        comps = combo.get("compartments")
+        if comps is None:
+            comps = list(default_compartments)
+        else:
+            comps = list(comps)
+        if not comps:
+            raise ValueError(
+                f"AGGREGATE_COMBOS[{idx}] must specify at least one compartment"
+            )
+
+        # Dedupe compartments while preserving order
+        deduped = []
+        for c in comps:
+            if c not in valid_compartments:
+                raise ValueError(
+                    f"AGGREGATE_COMBOS[{idx}] has unknown compartment {c!r}; "
+                    f"must be one of {sorted(valid_compartments)}"
+                )
+            if c == "second_obj" and not second_obj_detection:
+                raise ValueError(
+                    f"AGGREGATE_COMBOS[{idx}] lists 'second_obj' but "
+                    f"config['phenotype']['second_obj_detection'] is False"
+                )
+            if c not in deduped:
+                deduped.append(c)
+
+        key = (tuple(channels), tuple(deduped))
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append({"channels": channels, "compartments": deduped})
+
+    return resolved

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -180,3 +180,47 @@ def get_feature_table_cols(feature_cols):
     selected_columns.extend(overlap_cols)
 
     return selected_columns
+
+
+COMPARTMENT_PREFIXES = {
+    "cell": "cell_",
+    "nucleus": "nucleus_",
+    "cytoplasm": "cytoplasm_",
+    "second_obj": "second_obj_",
+}
+
+# Per-cell summary columns added by aggregate_second_obj_data that don't carry
+# the second_obj_ prefix but are derived from second-object data.
+SECOND_OBJ_EXTRA_COLS = frozenset(
+    {
+        "total_second_obj_area",
+        "mean_second_obj_diameter",
+        "mean_distance_to_nucleus",
+    }
+)
+
+
+def compartment_combo_subset(features, compartment_combo, all_compartments):
+    """Filter features to keep only columns belonging to the requested compartments.
+
+    Args:
+        features (pd.DataFrame): Feature columns (metadata already split out).
+        compartment_combo (list[str]): Compartments to keep, e.g. ["cell", "nucleus"].
+        all_compartments (list[str]): Compartments present in the input. Used to
+            determine which prefixes to exclude.
+
+    Returns:
+        pd.DataFrame: features without columns belonging to excluded compartments.
+    """
+    excluded = [c for c in all_compartments if c not in compartment_combo]
+    excluded_prefixes = [COMPARTMENT_PREFIXES[c] for c in excluded]
+
+    cols_to_drop = [
+        col
+        for col in features.columns
+        if any(col.startswith(p) for p in excluded_prefixes)
+    ]
+    if "second_obj" in excluded:
+        cols_to_drop += [c for c in SECOND_OBJ_EXTRA_COLS if c in features.columns]
+
+    return features.drop(columns=cols_to_drop)

--- a/workflow/lib/aggregate/eval_aggregate.py
+++ b/workflow/lib/aggregate/eval_aggregate.py
@@ -108,6 +108,24 @@ def plot_feature_distributions(
     Returns:
         matplotlib.figure.Figure: Figure containing the violin plots.
     """
+    # Defensive: empty feature selection (e.g. a compartment_combo whose
+    # prefixes don't match any *_mean column in the merge data) would pass
+    # nrows=0 to plt.subplots and raise. Return a placeholder figure so
+    # eval_aggregate can still write its other outputs and the DAG proceeds.
+    if not original_feature_cols or not aligned_feature_cols:
+        fig, ax = plt.subplots(figsize=(8, 2))
+        ax.text(
+            0.5,
+            0.5,
+            "No intensity features available for this compartment_combo; "
+            "feature-distribution plot skipped.",
+            ha="center",
+            va="center",
+            wrap=True,
+        )
+        ax.axis("off")
+        return fig
+
     # Melt original features
     df_orig = original_cell_data[["plate", "well"] + original_feature_cols].melt(
         id_vars=["plate", "well"], var_name="Feature", value_name="Value"

--- a/workflow/lib/aggregate/filter.py
+++ b/workflow/lib/aggregate/filter.py
@@ -5,12 +5,114 @@ Available filters:
 - perturbation_filter: Remove cells without perturbation assignments
 - missing_values_filter: Handle missing values through dropping or imputation
 - intensity_filter: Remove outliers based on channel intensities using LocalOutlierFactor
+- harmonize_pool_schema: Compute a consistent feature-column set for a pool of per-well parquets
 """
 
 import pandas as pd
 import numpy as np
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
 from sklearn.impute import KNNImputer
 from sklearn.neighbors import LocalOutlierFactor
+
+
+def harmonize_pool_schema(
+    paths,
+    metadata_cols,
+    drop_cols_threshold=None,
+):
+    """Compute a consistent (metadata, feature) column set for a multi-file pool.
+
+    When per-well filter decisions diverge — e.g. missing_values_filter drops
+    different columns in different wells because class composition varies — naive
+    pool reads via pyarrow's dataset union produce NaN blocks that break
+    downstream operations (PCA, center-scale). This helper produces a single
+    harmonized column set to use across every scan of the pool, matching the
+    drop-column convention from missing_values_filter.
+
+    Steps:
+      1. Schema intersection across `paths`. Columns present in some but not all
+         files are "lost to per-well schema mismatch" (typically driven by
+         class-composition differences across wells) and logged per-file.
+      2. If `drop_cols_threshold` is provided, scan the intersected pool once and
+         drop any feature column whose pool-level NaN proportion is >= threshold.
+         Uses the same comparison as missing_values_filter.
+    Row-level NaN cleanup (drop_rows_threshold, impute) is intentionally
+    deferred to the caller so it can be applied on each working subset.
+
+    Args:
+        paths (list[str]): parquet file paths forming the pool.
+        metadata_cols (list[str]): canonical metadata column names (only those
+            present in every file are returned).
+        drop_cols_threshold (float | None): pool-level NaN proportion threshold
+            above which a feature column is dropped. None disables this step.
+
+    Returns:
+        tuple:
+            kept_metadata_cols (list[str]),
+            kept_feature_cols (list[str]),
+            report (dict) — keys: "schema_mismatch" (dict file -> missing cols),
+                                  "threshold_dropped" (list of col names).
+    """
+    if not paths:
+        return [], [], {"schema_mismatch": {}, "threshold_dropped": []}
+
+    per_file_schemas = {p: set(pq.read_schema(p).names) for p in paths}
+    union_cols = set().union(*per_file_schemas.values())
+    intersection_cols = set.intersection(*per_file_schemas.values())
+    schema_mismatch = {
+        p: sorted(union_cols - cols)
+        for p, cols in per_file_schemas.items()
+        if union_cols - cols
+    }
+
+    if schema_mismatch:
+        total_lost = len(union_cols - intersection_cols)
+        print(
+            f"[pool] dropping {total_lost} column(s) present in some but not all "
+            f"of {len(paths)} input files (per-file missingness — typically driven "
+            f"by class composition differences across wells):"
+        )
+        for p, missing in schema_mismatch.items():
+            preview = ", ".join(missing[:5]) + (
+                f", ...(+{len(missing) - 5} more)" if len(missing) > 5 else ""
+            )
+            print(f"  {p.split('/')[-1]}: missing {len(missing)} col(s): {preview}")
+
+    # Preserve caller-provided order within metadata_cols; feature order is sorted
+    # for determinism since there's no natural ordering after an intersection.
+    kept_metadata_cols = [c for c in metadata_cols if c in intersection_cols]
+    kept_feature_cols = sorted(intersection_cols - set(metadata_cols))
+
+    threshold_dropped = []
+    if drop_cols_threshold is not None and kept_feature_cols:
+        pool = ds.dataset(paths, format="parquet").to_table(columns=kept_feature_cols)
+        # Compute pool-level NaN proportion per column without materializing full pandas.
+        total_rows = pool.num_rows
+        if total_rows > 0:
+            for col_name in list(kept_feature_cols):
+                nulls = pool.column(col_name).null_count
+                if nulls / total_rows >= drop_cols_threshold:
+                    threshold_dropped.append(col_name)
+        if threshold_dropped:
+            print(
+                f"[pool] dropping {len(threshold_dropped)} column(s) with pool-level "
+                f"NaN proportion >= {drop_cols_threshold * 100:.1f}%: "
+                f"{', '.join(threshold_dropped[:10])}"
+                f"{', ...' if len(threshold_dropped) > 10 else ''}"
+            )
+            kept_feature_cols = [
+                c for c in kept_feature_cols if c not in threshold_dropped
+            ]
+
+    return (
+        kept_metadata_cols,
+        kept_feature_cols,
+        {
+            "schema_mismatch": schema_mismatch,
+            "threshold_dropped": threshold_dropped,
+        },
+    )
 
 
 def query_filter(metadata, features, queries):

--- a/workflow/lib/aggregate/filter.py
+++ b/workflow/lib/aggregate/filter.py
@@ -251,42 +251,38 @@ def missing_values_filter(
                 if pd.api.types.is_integer_dtype(features[col]):
                     features[col] = features[col].astype("float64")
 
-            # Identify rows with any NAs in the remaining columns
-            has_na_mask = features[remaining_cols_with_na].isna().any(axis=1)
-            na_rows_idx = features.index[has_na_mask]
-            non_na_rows_idx = features.index[~has_na_mask]
+            # Use positional (iloc) indexing throughout — features.index may have
+            # duplicate labels (e.g. when concat across wells doesn't reset),
+            # which breaks .loc-based reads/writes.
+            has_na_mask = features[remaining_cols_with_na].isna().any(axis=1).to_numpy()
+            na_positions = np.flatnonzero(has_na_mask)
+            non_na_positions = np.flatnonzero(~has_na_mask)
+            col_positions = [
+                features.columns.get_loc(c) for c in remaining_cols_with_na
+            ]
 
             np.random.seed(42)
-            # Process NA rows in batches
-            for i in range(0, len(na_rows_idx), batch_size):
-                batch_na_idx = na_rows_idx[i : i + batch_size]
+            for i in range(0, len(na_positions), batch_size):
+                batch_pos = na_positions[i : i + batch_size]
                 print(
-                    f"Imputing for batch {i // batch_size + 1} with {len(batch_na_idx)} NA rows"
+                    f"Imputing for batch {i // batch_size + 1} with {len(batch_pos)} NA rows"
                 )
 
-                # Sample non-NA rows randomly instead of stratified sampling
-                sampled_non_na_idx = np.random.choice(
-                    non_na_rows_idx,
-                    size=min(sample_size, len(non_na_rows_idx)),
+                sampled_non_na_pos = np.random.choice(
+                    non_na_positions,
+                    size=min(sample_size, len(non_na_positions)),
                     replace=False,
                 )
+                combined_pos = np.concatenate([batch_pos, sampled_non_na_pos])
 
-                # Combine sampled non-NA rows with current batch of NA rows
-                batch_idx = np.concatenate([batch_na_idx, sampled_non_na_idx])
-
-                # Perform KNN imputation on this batch
                 imputer = KNNImputer(n_neighbors=5)
                 imputed_values = imputer.fit_transform(
-                    features.loc[batch_idx, remaining_cols_with_na]
+                    features.iloc[combined_pos, col_positions].to_numpy()
                 )
 
-                # Update only the NA rows with imputed values
-                na_rows_in_batch = np.arange(len(batch_na_idx))
-                features.loc[batch_na_idx, remaining_cols_with_na] = pd.DataFrame(
-                    imputed_values[na_rows_in_batch],
-                    index=batch_na_idx,
-                    columns=remaining_cols_with_na,
-                )
+                features.iloc[batch_pos, col_positions] = imputed_values[
+                    : len(batch_pos)
+                ]
 
     return metadata, features
 

--- a/workflow/lib/aggregate/filter.py
+++ b/workflow/lib/aggregate/filter.py
@@ -17,10 +17,10 @@ from sklearn.neighbors import LocalOutlierFactor
 
 
 def harmonize_pool_schema(
-    paths,
-    metadata_cols,
-    drop_cols_threshold=None,
-):
+    paths: list[str],
+    metadata_cols: list[str],
+    drop_cols_threshold: float | None = None,
+) -> tuple[list[str], list[str], dict]:
     """Compute a consistent (metadata, feature) column set for a multi-file pool.
 
     When per-well filter decisions diverge — e.g. missing_values_filter drops
@@ -86,7 +86,12 @@ def harmonize_pool_schema(
 
     threshold_dropped = []
     if drop_cols_threshold is not None and kept_feature_cols:
-        pool = ds.dataset(paths, format="parquet").to_table(columns=kept_feature_cols)
+        # Pin to one reference schema so pyarrow casts each file to it instead of
+        # auto-unifying (which raises ArrowInvalid when files share a column with a
+        # mismatched dtype). paths are non-empty and share the kept columns.
+        pool = ds.dataset(
+            paths, format="parquet", schema=pq.read_schema(paths[0])
+        ).to_table(columns=kept_feature_cols)
         # Compute pool-level NaN proportion per column without materializing full pandas.
         total_rows = pool.num_rows
         if total_rows > 0:

--- a/workflow/lib/aggregate/perturbation_score.py
+++ b/workflow/lib/aggregate/perturbation_score.py
@@ -24,6 +24,9 @@ def perturbation_score(
     metadata_cols: list[str],
     perturbation_name_col: str,
     control_key: str,
+    perturbation_id_col: str | None = None,
+    control_name_col: str | None = None,
+    batch_cols: list[str] | None = None,
     minimum_cell_count: int = 100,
     n_jobs: int = -1,
 ) -> None:
@@ -36,20 +39,32 @@ def perturbation_score(
     Args:
         cell_data (pd.DataFrame): DataFrame containing cell data that will be modified in-place.
         metadata_cols (list[str]): List of metadata column names that will be updated to include 'perturbation_score'.
-        perturbation_name_col (str): Column name containing perturbation identifiers.
+        perturbation_name_col (str): Column name containing perturbation identifiers (what `gene` is drawn from; e.g. "gene_symbol_0" or "cell_barcode_0").
         control_key (str): Prefix identifying control perturbations (e.g., 'nontargeting').
+        perturbation_id_col (str, optional): Column name for unique perturbation IDs
+            used by prepare_alignment_data. Defaults to perturbation_name_col.
+        control_name_col (str, optional): Column used to identify controls via
+            control_key. Defaults to perturbation_name_col.
+        batch_cols (list[str], optional): Columns defining the batch grouping.
+            Defaults to ["plate", "well"].
         minimum_cell_count (int, optional): Minimum number of cells required to process a perturbation. Defaults to 100.
         n_jobs (int, optional): Number of parallel jobs. -1 uses all available CPUs. Defaults to -1.
     """
+    if perturbation_id_col is None:
+        perturbation_id_col = perturbation_name_col
+    if control_name_col is None:
+        control_name_col = perturbation_name_col
+    if batch_cols is None:
+        batch_cols = ["plate", "well"]
+
     perturbation_col = cell_data[perturbation_name_col]
+    control_col = cell_data[control_name_col]
+    # Non-control perturbations: NaN-safe comparison via astype(str), then drop any NaN-origin "nan" entries.
+    is_control = control_col.astype(str).str.startswith(control_key)
     perturbed_genes = [
-        gene
-        for gene in perturbation_col.unique().tolist()
-        if not gene.startswith(control_key)
+        gene for gene in perturbation_col[~is_control].dropna().unique().tolist()
     ]
-    nt_idx = perturbation_col.index[
-        perturbation_col.str.startswith(control_key)
-    ].to_numpy()
+    nt_idx = perturbation_col.index[is_control].to_numpy()
 
     print(f"Processing {len(perturbed_genes)} genes with {n_jobs} parallel jobs...")
 
@@ -98,6 +113,11 @@ def perturbation_score(
                 gene_subset_df,
                 original_idx,
                 metadata_cols,
+                perturbation_name_col,
+                control_key,
+                perturbation_id_col,
+                control_name_col,
+                batch_cols,
                 minimum_cell_count,
             )
             for gene, gene_idx, gene_subset_df, original_idx in batch_data
@@ -122,7 +142,7 @@ def calculate_perturbation_scores(
     cell_data: pd.DataFrame,
     gene: str,
     feature_cols: list[str],
-    perturbation_col: str = "gene_symbol_0",
+    perturbation_col: str,
     n_differential_features: int = 200,
     minimum_cell_count: int = 100,
 ) -> tuple[pd.Series, float]:
@@ -138,7 +158,7 @@ def calculate_perturbation_scores(
         cell_data (pd.DataFrame): DataFrame containing cell data with features and metadata.
         gene (str): The target gene perturbation to score against.
         feature_cols (list[str]): List of feature column names to use for scoring.
-        perturbation_col (str, optional): Column name containing perturbation labels. Defaults to "gene_symbol_0".
+        perturbation_col (str): Column name containing perturbation labels used to build the binary target.
         n_differential_features (int, optional): Number of top differential features to select. Defaults to 200.
         minimum_cell_count (int, optional): Minimum number of cells required for scoring. Defaults to 200.
 
@@ -149,7 +169,17 @@ def calculate_perturbation_scores(
     if cell_data.shape[0] < minimum_cell_count:
         return pd.Series(np.nan, index=cell_data.index), np.nan
 
-    y = (cell_data[perturbation_col] == gene).astype(int).to_numpy()
+    # NaN-safe binary target. Comparisons on nullable string dtypes can return
+    # pandas.NA for NaN rows; convert to plain bool via fillna(False) so
+    # astype(int) always yields strictly {0, 1}.
+    y = (
+        cell_data[perturbation_col]
+        .eq(gene)
+        .fillna(False)
+        .astype(bool)
+        .astype(int)
+        .to_numpy()
+    )
     X_all = cell_data[feature_cols].to_numpy()
 
     # select top-k differential features (ANOVA F-test)
@@ -178,16 +208,26 @@ def _process_gene_subset(
     gene_subset_df: pd.DataFrame,
     original_idx: pd.Index,
     metadata_cols: list[str],
+    perturbation_name_col: str,
+    control_key: str,
+    perturbation_id_col: str,
+    control_name_col: str,
+    batch_cols: list[str],
     minimum_cell_count: int,
 ) -> tuple[str, np.ndarray, pd.Series, float] | None:
     """Process a pre-sliced gene subset and return perturbation scores.
 
     Args:
-        gene: Gene symbol being processed.
-        gene_idx: Original indices of gene cells in the full dataset.
-        gene_subset_df: Pre-sliced DataFrame with gene + control cells (reset index).
+        gene: Perturbation identifier being scored (drawn from perturbation_name_col).
+        gene_idx: Original indices of perturbation cells in the full dataset.
+        gene_subset_df: Pre-sliced DataFrame with perturbation + control cells (reset index).
         original_idx: Original indices before reset (for mapping scores back).
         metadata_cols: Metadata column names.
+        perturbation_name_col: Column naming each perturbation unit (what `gene` is drawn from).
+        control_key: Prefix identifying control rows in control_name_col.
+        perturbation_id_col: Column used as the unique perturbation ID in prepare_alignment_data.
+        control_name_col: Column used by centerscale to detect controls via control_key.
+        batch_cols: Columns defining the batch grouping.
         minimum_cell_count: Minimum cells required.
 
     Returns:
@@ -203,19 +243,20 @@ def _process_gene_subset(
     metadata, features = prepare_alignment_data(
         metadata,
         features,
-        ["plate", "well"],
-        "gene_symbol_0",
-        "nontargeting",
-        "cell_barcode_0",
+        batch_cols,
+        perturbation_name_col,
+        control_key,
+        perturbation_id_col,
     )
 
     features = features.astype(np.float32)
     features = centerscale_on_controls(
         features,
         metadata,
-        "gene_symbol_0",
-        "nontargeting",
+        perturbation_name_col,
+        control_key,
         "batch_values",
+        control_col=control_name_col,
     )
     features = pd.DataFrame(features, columns=feature_cols)
     gene_subset_df = pd.concat([metadata, features], axis=1)
@@ -225,7 +266,7 @@ def _process_gene_subset(
         gene_subset_df,
         gene,
         feature_cols,
-        perturbation_col="gene_symbol_0",
+        perturbation_col=perturbation_name_col,
     )
 
     print(

--- a/workflow/lib/aggregate/perturbation_score.py
+++ b/workflow/lib/aggregate/perturbation_score.py
@@ -98,8 +98,12 @@ def perturbation_score(
             )
             keep_idx = np.union1d(gene_idx, nt_keep)
 
-            # Extract subset
-            gene_subset_df = cell_data.iloc[keep_idx].copy()
+            # Extract subset. keep_idx holds pandas index labels (built from
+            # perturbation_col.index[...] and nt_idx above); use .loc so this
+            # works whether cell_data has a RangeIndex or a preserved label
+            # index (the latter happens when the caller passes a groupby slice
+            # without reset_index).
+            gene_subset_df = cell_data.loc[keep_idx].copy()
             original_idx = gene_subset_df.index.copy()
             gene_subset_df = gene_subset_df.reset_index(drop=True)
 

--- a/workflow/lib/cluster/cluster_eval.py
+++ b/workflow/lib/cluster/cluster_eval.py
@@ -19,6 +19,7 @@ from lib.shared.file_utils import parse_filename, get_filename
 def find_optimal_resolution(
     root_fp,
     channel_combo,
+    compartment_combo,
     cell_class,
     use_filtered=False,
     metric="balanced",
@@ -34,6 +35,7 @@ def find_optimal_resolution(
     Args:
         root_fp (Path): Root output directory (config["all"]["root_fp"]).
         channel_combo (str): Channel combination name.
+        compartment_combo (str): Compartment combination name.
         cell_class (str): Cell class name.
         use_filtered (bool): Whether to look in filtered/ subdirectory.
         metric (str): Metric to optimize. Options:
@@ -65,9 +67,16 @@ def find_optimal_resolution(
 
     # Build base cluster path
     if use_filtered:
-        base_path = root_fp / "cluster" / channel_combo / cell_class / "filtered"
+        base_path = (
+            root_fp
+            / "cluster"
+            / channel_combo
+            / compartment_combo
+            / cell_class
+            / "filtered"
+        )
     else:
-        base_path = root_fp / "cluster" / channel_combo / cell_class
+        base_path = root_fp / "cluster" / channel_combo / compartment_combo / cell_class
 
     # Auto-discover resolutions if not provided
     if resolutions is None:
@@ -430,6 +439,7 @@ def analyze_all_resolutions(
     root_fp,
     cell_classes,
     channel_combos,
+    compartment_combos,
     use_filtered=False,
     metric="balanced",
     ideal_size_range=(15, 25),
@@ -438,7 +448,7 @@ def analyze_all_resolutions(
     top_n_table=10,
     verbose=True,
 ):
-    """Analyze optimal resolutions for all cell class/channel combinations.
+    """Analyze optimal resolutions for all cell class/channel/compartment combinations.
 
     Convenience wrapper that finds optimal resolutions, displays results,
     and returns a summary for all combinations.
@@ -447,6 +457,7 @@ def analyze_all_resolutions(
         root_fp (Path): Root output directory (config["all"]["root_fp"]).
         cell_classes (list): List of cell class names (e.g., ["Interphase", "Mitotic"]).
         channel_combos (list): List of channel combinations.
+        compartment_combos (list): List of compartment combinations.
         use_filtered (bool): Whether to look in filtered/ subdirectory.
         metric (str): Metric to optimize ("balanced", "combined", etc.).
         ideal_size_range (tuple): (min, max) target cluster size.
@@ -467,56 +478,58 @@ def analyze_all_resolutions(
 
     for cell_class in cell_classes:
         for channel_combo in channel_combos:
-            try:
-                result = find_optimal_resolution(
-                    root_fp=root_fp,
-                    channel_combo=channel_combo,
-                    cell_class=cell_class,
-                    use_filtered=use_filtered,
-                    metric=metric,
-                    ideal_size_range=ideal_size_range,
-                    size_metric=size_metric,
-                )
-                key = f"{cell_class}_{channel_combo}"
-                optimal_resolutions[key] = result
+            for compartment_combo in compartment_combos:
+                try:
+                    result = find_optimal_resolution(
+                        root_fp=root_fp,
+                        channel_combo=channel_combo,
+                        compartment_combo=compartment_combo,
+                        cell_class=cell_class,
+                        use_filtered=use_filtered,
+                        metric=metric,
+                        ideal_size_range=ideal_size_range,
+                        size_metric=size_metric,
+                    )
+                    key = f"{cell_class}_{channel_combo}_{compartment_combo}"
+                    optimal_resolutions[key] = result
 
-                if verbose:
-                    print(f"\n{'=' * 80}")
-                    print(f"{cell_class} / {channel_combo}")
-                    print(f"{'=' * 80}")
-                    print(f"  Optimal resolution: {result['optimal_resolution']}")
-                    print(f"  Optimization metric: {result['metric_used']}")
-                    print(f"  Size metric used: {result['size_metric_used']}")
-                    print(f"  Target size range: {result['ideal_size_range']}")
+                    if verbose:
+                        print(f"\n{'=' * 80}")
+                        print(f"{cell_class} / {channel_combo} / {compartment_combo}")
+                        print(f"{'=' * 80}")
+                        print(f"  Optimal resolution: {result['optimal_resolution']}")
+                        print(f"  Optimization metric: {result['metric_used']}")
+                        print(f"  Size metric used: {result['size_metric_used']}")
+                        print(f"  Target size range: {result['ideal_size_range']}")
 
-                    # Show formatted decision table
-                    print(
-                        f"\nTop {top_n_table} resolutions (sorted by {metric} score):"
-                    )
-                    table = format_resolution_table(
-                        result["all_results"], top_n=top_n_table
-                    )
-                    display(table)
+                        # Show formatted decision table
+                        print(
+                            f"\nTop {top_n_table} resolutions (sorted by {metric} score):"
+                        )
+                        table = format_resolution_table(
+                            result["all_results"], top_n=top_n_table
+                        )
+                        display(table)
 
-                if show_plots:
-                    # Show metrics comparison plot
-                    fig = plot_resolution_comparison(
-                        result["all_results"], metric=metric
-                    )
-                    plt.suptitle(
-                        f"{cell_class} / {channel_combo}",
-                        fontsize=14,
-                        fontweight="bold",
-                    )
-                    plt.tight_layout()
-                    plt.show()
+                    if show_plots:
+                        # Show metrics comparison plot
+                        fig = plot_resolution_comparison(
+                            result["all_results"], metric=metric
+                        )
+                        plt.suptitle(
+                            f"{cell_class} / {channel_combo} / {compartment_combo}",
+                            fontsize=14,
+                            fontweight="bold",
+                        )
+                        plt.tight_layout()
+                        plt.show()
 
-            except Exception as e:
-                if verbose:
-                    print(
-                        f"\n{cell_class} / {channel_combo}: No benchmark results found"
-                    )
-                    print(f"  Error: {e}")
+                except Exception as e:
+                    if verbose:
+                        print(
+                            f"\n{cell_class} / {channel_combo} / {compartment_combo}: No benchmark results found"
+                        )
+                        print(f"  Error: {e}")
 
     # Generate summary table
     if verbose:

--- a/workflow/lib/shared/file_utils.py
+++ b/workflow/lib/shared/file_utils.py
@@ -16,6 +16,7 @@ FILENAME_METADATA_MAPPING = {
     "round": ["R-", str],
     "cell_class": ["CeCl-", str],
     "channel_combo": ["ChCo-", str],
+    "compartment_combo": ["CmCo-", str],
     "gene": ["G-", str],
     "sgrna": ["SG-", str],
     "channel": ["CH-", str],

--- a/workflow/lib/shared/metrics.py
+++ b/workflow/lib/shared/metrics.py
@@ -298,7 +298,7 @@ def get_aggregate_stats(config, n_rows=10000, include_batch_effects=False):
         include_batch_effects: Whether to calculate batch effect metrics (slow)
 
     Returns:
-        dict: Dictionary with statistics for each cell_class/channel_combo combination
+        dict: Dictionary with statistics for each cell_class/channel_combo/compartment_combo combination
     """
     root_fp = Path(config["all"]["root_fp"])
     aggregate_dir = root_fp / "aggregate"
@@ -307,8 +307,10 @@ def get_aggregate_stats(config, n_rows=10000, include_batch_effects=False):
     aggregate_combo_fp = Path(config["aggregate"]["aggregate_combo_fp"])
     aggregate_combos = pd.read_csv(aggregate_combo_fp, sep="\t")
 
-    # Get unique cell_class and channel_combo combinations
-    unique_combos = aggregate_combos[["cell_class", "channel_combo"]].drop_duplicates()
+    # Get unique cell_class, channel_combo, and compartment_combo combinations
+    unique_combos = aggregate_combos[
+        ["cell_class", "channel_combo", "compartment_combo"]
+    ].drop_duplicates()
 
     # Get perturbation column name from config
     perturbation_col = config["aggregate"].get("perturbation_name_col", "gene_symbol_0")
@@ -319,12 +321,14 @@ def get_aggregate_stats(config, n_rows=10000, include_batch_effects=False):
     for _, combo in unique_combos.iterrows():
         cell_class = combo["cell_class"]
         channel_combo = combo["channel_combo"]
+        compartment_combo = combo["compartment_combo"]
 
         try:
             result = _get_single_aggregate_stats(
                 config,
                 cell_class,
                 channel_combo,
+                compartment_combo,
                 n_rows,
                 root_fp,
                 aggregate_dir,
@@ -332,10 +336,14 @@ def get_aggregate_stats(config, n_rows=10000, include_batch_effects=False):
                 control_key,
                 include_batch_effects,
             )
-            all_results[f"{cell_class}_{channel_combo}"] = result
+            all_results[f"{cell_class}_{channel_combo}_{compartment_combo}"] = result
         except Exception as e:
-            print(f"Error processing {cell_class}/{channel_combo}: {str(e)}")
-            all_results[f"{cell_class}_{channel_combo}"] = {"error": str(e)}
+            print(
+                f"Error processing {cell_class}/{channel_combo}/{compartment_combo}: {str(e)}"
+            )
+            all_results[f"{cell_class}_{channel_combo}_{compartment_combo}"] = {
+                "error": str(e)
+            }
 
     return all_results
 
@@ -344,6 +352,7 @@ def _get_single_aggregate_stats(
     config,
     cell_class,
     channel_combo,
+    compartment_combo,
     n_rows,
     root_fp,
     aggregate_dir,
@@ -351,14 +360,14 @@ def _get_single_aggregate_stats(
     control_key,
     include_batch_effects,
 ):
-    """Helper function to get stats for a single cell_class/channel_combo combination."""
+    """Helper function to get stats for a single cell_class/channel_combo/compartment_combo combination."""
     from lib.shared.file_utils import load_parquet_subset
 
     # Load the aggregated TSV file
     aggregated_path = (
         aggregate_dir
         / "tsvs"
-        / f"CeCl-{cell_class}_ChCo-{channel_combo}__aggregated.tsv"
+        / f"CeCl-{cell_class}_ChCo-{channel_combo}_CmCo-{compartment_combo}__aggregated.tsv"
     )
     aggregated = pd.read_csv(aggregated_path, sep="\t")
 
@@ -378,7 +387,7 @@ def _get_single_aggregate_stats(
     merge_data_dir = aggregate_dir / "parquets"
     merge_data_paths = list(
         merge_data_dir.glob(
-            f"*_CeCl-{cell_class}_ChCo-{channel_combo}__merge_data.parquet"
+            f"*_CeCl-{cell_class}_ChCo-{channel_combo}_CmCo-{compartment_combo}__merge_data.parquet"
         )
     )
 
@@ -390,7 +399,9 @@ def _get_single_aggregate_stats(
     # Count filtered cells from parquet metadata (fast)
     filtered_dir = aggregate_dir / "parquets"
     filtered_paths = list(
-        filtered_dir.glob(f"*_CeCl-{cell_class}_ChCo-{channel_combo}__filtered.parquet")
+        filtered_dir.glob(
+            f"*_CeCl-{cell_class}_ChCo-{channel_combo}_CmCo-{compartment_combo}__filtered.parquet"
+        )
     )
 
     total_filtered_cells = 0
@@ -414,6 +425,7 @@ def _get_single_aggregate_stats(
             config,
             cell_class,
             channel_combo,
+            compartment_combo,
             n_rows,
             aggregate_dir,
             perturbation_col,
@@ -428,6 +440,7 @@ def _calculate_batch_effects(
     config,
     cell_class,
     channel_combo,
+    compartment_combo,
     n_rows,
     aggregate_dir,
     perturbation_col,
@@ -441,7 +454,9 @@ def _calculate_batch_effects(
     filtered_dir = aggregate_dir / "parquets"
     # Use direct path instead of recursive glob for speed
     filtered_paths = list(
-        filtered_dir.glob(f"*_CeCl-{cell_class}_ChCo-{channel_combo}__filtered.parquet")
+        filtered_dir.glob(
+            f"*_CeCl-{cell_class}_ChCo-{channel_combo}_CmCo-{compartment_combo}__filtered.parquet"
+        )
     )
 
     # Load filtered data - sample from a subset of files to avoid
@@ -504,7 +519,7 @@ def _calculate_batch_effects(
     aligned_path = (
         aggregate_dir
         / "parquets"
-        / f"CeCl-{cell_class}_ChCo-{channel_combo}__aligned.parquet"
+        / f"CeCl-{cell_class}_ChCo-{channel_combo}_CmCo-{compartment_combo}__aligned.parquet"
     )
 
     # Use same sample size as pre-alignment for consistency
@@ -565,10 +580,15 @@ def get_cluster_stats(config):
     for _, row in cluster_combos.iterrows():
         cell_class = row["cell_class"]
         channel_combo = row["channel_combo"]
+        compartment_combo = row["compartment_combo"]
         leiden_resolution = row["leiden_resolution"]
 
         cluster_specific_dir = (
-            cluster_dir / channel_combo / cell_class / str(leiden_resolution)
+            cluster_dir
+            / channel_combo
+            / compartment_combo
+            / cell_class
+            / str(leiden_resolution)
         )
 
         # Path to metrics files
@@ -598,6 +618,7 @@ def get_cluster_stats(config):
             result = {
                 "cell_class": cell_class,
                 "channel_combo": channel_combo,
+                "compartment_combo": compartment_combo,
                 "leiden_resolution": leiden_resolution,
                 "unique_clusters": unique_clusters,
                 # CORUM metrics
@@ -641,7 +662,7 @@ def get_cluster_stats(config):
 
         except Exception as e:
             print(
-                f"Error reading metrics for {cell_class}/{channel_combo}/{leiden_resolution}: {e}"
+                f"Error reading metrics for {cell_class}/{channel_combo}/{compartment_combo}/{leiden_resolution}: {e}"
             )
 
     results_df = pd.DataFrame(results)
@@ -813,7 +834,7 @@ def get_all_stats(
     if not stats["cluster"]["detailed_results"].empty:
         for _, row in stats["cluster"]["detailed_results"].iterrows():
             print(
-                f"\n   {row['cell_class']} - {row['channel_combo']} (resolution={row['leiden_resolution']}):"
+                f"\n   {row['cell_class']} - {row['channel_combo']} - {row['compartment_combo']} (resolution={row['leiden_resolution']}):"
             )
             print(f"      - Clusters: {row['unique_clusters']}")
             print(

--- a/workflow/lib/shared/rule_utils.py
+++ b/workflow/lib/shared/rule_utils.py
@@ -313,6 +313,7 @@ def get_bootstrap_inputs(
     gene_pvals_pattern: Union[str, Path],
     cell_class: str,
     channel_combo: str,
+    compartment_combo: str,
 ) -> List[str]:
     """Get all bootstrap inputs for completion flag.
 
@@ -324,13 +325,16 @@ def get_bootstrap_inputs(
         gene_pvals_pattern (Union[str, Path]): Template string for gene p-value files.
         cell_class (str): Cell class for bootstrap analysis.
         channel_combo (str): Channel combination for bootstrap analysis.
+        compartment_combo (str): Compartment combination for bootstrap analysis.
 
     Returns:
         List[str]: List of all bootstrap output file paths for both constructs and genes.
     """
     # Get all construct data files from checkpoint
     bootstrap_data_dir = checkpoint.get(
-        cell_class=cell_class, channel_combo=channel_combo
+        cell_class=cell_class,
+        channel_combo=channel_combo,
+        compartment_combo=compartment_combo,
     ).output[0]
 
     construct_files = glob.glob(f"{bootstrap_data_dir}/*__construct_data.tsv")
@@ -362,12 +366,14 @@ def get_bootstrap_inputs(
                 str(construct_nulls_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),
                 str(construct_pvals_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),
@@ -380,10 +386,16 @@ def get_bootstrap_inputs(
             outputs.extend(
                 [
                     str(gene_nulls_pattern).format(
-                        cell_class=cell_class, channel_combo=channel_combo, gene=gene
+                        cell_class=cell_class,
+                        channel_combo=channel_combo,
+                        compartment_combo=compartment_combo,
+                        gene=gene,
                     ),
                     str(gene_pvals_pattern).format(
-                        cell_class=cell_class, channel_combo=channel_combo, gene=gene
+                        cell_class=cell_class,
+                        channel_combo=channel_combo,
+                        compartment_combo=compartment_combo,
+                        gene=gene,
                     ),
                 ]
             )
@@ -397,6 +409,7 @@ def get_bootstrap_construct_outputs(
     construct_pvals_pattern: Union[str, Path],
     cell_class: str,
     channel_combo: str,
+    compartment_combo: str,
 ) -> List[str]:
     """Get all construct bootstrap outputs for completion flag.
 
@@ -410,6 +423,8 @@ def get_bootstrap_construct_outputs(
         cell_class (str): Cell class identifier for bootstrap analysis (e.g., 'live', 'dead').
         channel_combo (str): Channel combination identifier for bootstrap analysis
             (e.g., 'dapi_tubulin', 'all_channels').
+        compartment_combo (str): Compartment combination identifier for bootstrap analysis
+            (e.g., 'cell-nucleus-cytoplasm', 'nucleus').
 
     Returns:
         List[str]: List of all construct bootstrap output file paths, including both
@@ -418,7 +433,9 @@ def get_bootstrap_construct_outputs(
     """
     # Get all construct data files from checkpoint
     bootstrap_data_dir = checkpoint.get(
-        cell_class=cell_class, channel_combo=channel_combo
+        cell_class=cell_class,
+        channel_combo=channel_combo,
+        compartment_combo=compartment_combo,
     ).output[0]
 
     construct_files = glob.glob(f"{bootstrap_data_dir}/*__construct_data.tsv")
@@ -449,12 +466,14 @@ def get_bootstrap_construct_outputs(
                 str(construct_nulls_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),
                 str(construct_pvals_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),

--- a/workflow/lib/shared/target_utils.py
+++ b/workflow/lib/shared/target_utils.py
@@ -221,7 +221,7 @@ def get_merge_targets_by_approach(config):
 def map_wildcard_outputs(wildcard_combos_df, output_template, wildcards_to_map):
     """Map specified wildcards in a template string using values from a DataFrame.
 
-    Given a template path and a list of wildcards to map (e.g. ["cell_class", "channel_combo"]),
+    Given a template path and a list of wildcards to map (e.g. ["cell_class", "channel_combo", "compartment_combo"]),
     replaces only those placeholders with values from the DataFrame, leaving others untouched.
     Useful for creating lists of output paths where we need to fill in some wildcards but not others.
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -96,6 +96,7 @@ rule generate_feature_table:
         num_align_batches=config["aggregate"]["num_align_batches"],
         feature_normalization=config["aggregate"].get("feature_normalization", "standard"),
         pseudogene_patterns=config.get("aggregate", {}).get("pseudogene_patterns", None),
+        drop_cols_threshold=config["aggregate"].get("drop_cols_threshold"),
     script:
         "../scripts/aggregate/generate_feature_table.py"
 
@@ -126,6 +127,7 @@ rule align:
         num_align_batches=config["aggregate"]["num_align_batches"],
         skip_perturbation_score=config["aggregate"]["skip_perturbation_score"],
         control_name_col=config["aggregate"].get("control_name_col"),
+        drop_cols_threshold=config["aggregate"].get("drop_cols_threshold"),
     script:
         "../scripts/aggregate/align.py"
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -32,7 +32,7 @@ rule split_datasets:
         map_wildcard_outputs(
             aggregate_wildcard_combos,
             AGGREGATE_OUTPUTS["split_datasets"][0],
-            ["cell_class", "channel_combo"],
+            ["cell_class", "channel_combo", "compartment_combo"],
         ),
     params:
         all_channels=config["phenotype"]["channel_names"],
@@ -41,8 +41,7 @@ rule split_datasets:
         confidence_thresholds=config.get("classify", {}).get("confidence_thresholds"),
         class_title=config.get("classify", {}).get("class_title"),
         class_mapping=config.get("classify", {}).get("class_mapping"),
-        cell_classes=aggregate_wildcard_combos["cell_class"].unique(),
-        channel_combos=aggregate_wildcard_combos["channel_combo"].unique(),
+        aggregate_wildcard_combos=aggregate_wildcard_combos,
     script:
         "../scripts/aggregate/split_datasets.py"
 
@@ -79,6 +78,7 @@ rule generate_feature_table:
             wildcards={
                 "cell_class": wildcards.cell_class,
                 "channel_combo": wildcards.channel_combo,
+                "compartment_combo": wildcards.compartment_combo,
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -107,6 +107,7 @@ rule align:
             wildcards={
                 "cell_class": wildcards.cell_class,
                 "channel_combo": wildcards.channel_combo,
+                "compartment_combo": wildcards.compartment_combo,
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -156,6 +157,7 @@ rule eval_aggregate:
             wildcards={
                 "cell_class": wildcards.cell_class,
                 "channel_combo": wildcards.channel_combo,
+                "compartment_combo": wildcards.compartment_combo,
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -181,9 +183,8 @@ checkpoint prepare_montage_data:
             AGGREGATE_OUTPUTS["filter"],
             wildcards={
                 "cell_class": wildcards.cell_class,
-                "channel_combo": aggregate_wildcard_combos["channel_combo"].unique()[
-                    0
-                ],
+                "channel_combo": aggregate_wildcard_combos["channel_combo"].iloc[0],
+                "compartment_combo": aggregate_wildcard_combos["compartment_combo"].iloc[0],
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -251,13 +252,19 @@ rule initiate_montage:
 checkpoint prepare_bootstrap_data:
     input:
         features_singlecell=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][0]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+            cell_class=wildcards.cell_class,
+            channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
         ),
         construct_table=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][1]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+            cell_class=wildcards.cell_class,
+            channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
         ),
         gene_table=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][2]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+            cell_class=wildcards.cell_class,
+            channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
         ),
     output:
         directory(BOOTSTRAP_OUTPUTS["bootstrap_data_dir"]),
@@ -281,13 +288,19 @@ rule bootstrap_construct:
     input:
         construct_data=BOOTSTRAP_OUTPUTS["construct_data"],
         controls_arr=lambda wildcards: str(BOOTSTRAP_OUTPUTS["controls_arr"]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+            cell_class=wildcards.cell_class,
+            channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
         ),
         construct_features_arr=lambda wildcards: str(BOOTSTRAP_OUTPUTS["construct_features_arr"]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+            cell_class=wildcards.cell_class,
+            channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
         ),
         sample_sizes=lambda wildcards: str(BOOTSTRAP_OUTPUTS["sample_sizes"]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+            cell_class=wildcards.cell_class,
+            channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
         ),
     output:
         BOOTSTRAP_OUTPUTS["bootstrap_construct_nulls"],
@@ -307,17 +320,20 @@ rule construct_bootstrap_complete:
             BOOTSTRAP_OUTPUTS["bootstrap_construct_pvals"],
             wildcards.cell_class,
             wildcards.channel_combo,
+            wildcards.compartment_combo,
         ),
     output:
-        touch(AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__construct_bootstrap_complete.flag"),
+        touch(AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__construct_bootstrap_complete.flag"),
 
 
 # Aggregate construct results to gene level
 rule bootstrap_gene:
     input:
-        construct_flag=AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__construct_bootstrap_complete.flag",
+        construct_flag=AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__construct_bootstrap_complete.flag",
         gene_table=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][2]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+            cell_class=wildcards.cell_class,
+            channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
         ),
     output:
         BOOTSTRAP_OUTPUTS["bootstrap_gene_nulls"],
@@ -327,6 +343,7 @@ rule bootstrap_gene:
         construct_nulls_pattern=lambda wildcards: str(BOOTSTRAP_OUTPUTS["bootstrap_construct_nulls"]).format(
             cell_class=wildcards.cell_class,
             channel_combo=wildcards.channel_combo,
+            compartment_combo=wildcards.compartment_combo,
             gene=wildcards.gene,
             construct="{construct}"
         ),
@@ -346,6 +363,7 @@ rule initiate_bootstrap:
             BOOTSTRAP_OUTPUTS["bootstrap_gene_pvals"],
             wildcards.cell_class,
             wildcards.channel_combo,
+            wildcards.compartment_combo,
         ),
     output:
         touch(BOOTSTRAP_OUTPUTS["bootstrap_flag"]),
@@ -359,8 +377,14 @@ rule combine_bootstrap:
         BOOTSTRAP_OUTPUTS["combined_construct_results"],
         BOOTSTRAP_OUTPUTS["combined_gene_results"],
     params:
-        constructs_dir=lambda wildcards: str(AGGREGATE_FP / "bootstrap" / f"{wildcards.cell_class}__{wildcards.channel_combo}__constructs"),
-        genes_dir=lambda wildcards: str(AGGREGATE_FP / "bootstrap" / f"{wildcards.cell_class}__{wildcards.channel_combo}__genes"),
+        constructs_dir=lambda wildcards: str(
+            AGGREGATE_FP / "bootstrap"
+            / f"{wildcards.cell_class}__{wildcards.channel_combo}__{wildcards.compartment_combo}__constructs"
+        ),
+        genes_dir=lambda wildcards: str(
+            AGGREGATE_FP / "bootstrap"
+            / f"{wildcards.cell_class}__{wildcards.channel_combo}__{wildcards.compartment_combo}__genes"
+        ),
     script:
         "../scripts/aggregate/combine_bootstrap.py"
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -145,6 +145,7 @@ rule aggregate:
         agg_method=config["aggregate"]["agg_method"],
         ps_probability_threshold=config["aggregate"]["ps_probability_threshold"],
         ps_percentile_threshold=config["aggregate"]["ps_percentile_threshold"],
+        control_name_col=config["aggregate"].get("control_name_col"),
     script:
         "../scripts/aggregate/aggregate.py"
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -92,6 +92,7 @@ rule generate_feature_table:
         perturbation_name_col=config["aggregate"]["perturbation_name_col"],
         perturbation_id_col=config["aggregate"]["perturbation_id_col"],
         control_key=config["aggregate"]["control_key"],
+        control_name_col=config["aggregate"].get("control_name_col"),
         batch_cols=config["aggregate"]["batch_cols"],
         num_align_batches=config["aggregate"]["num_align_batches"],
         feature_normalization=config["aggregate"].get("feature_normalization", "standard"),

--- a/workflow/scripts/aggregate/aggregate.py
+++ b/workflow/scripts/aggregate/aggregate.py
@@ -26,14 +26,29 @@ metadata, tvn_normalized = split_cell_data(cell_data, metadata_cols)
 tvn_normalized = tvn_normalized.to_numpy()
 del cell_data
 
+# When aggregating by a construct-level ID (e.g. cell_barcode_0) while controls
+# are identified via a different column (e.g. gene_symbol_0), carry the
+# control/gene column through so downstream clustering / benchmarking /
+# annotation merges can match on the human-readable name.
+pert_col = snakemake.params.perturbation_name_col
+control_name_col = snakemake.params.get("control_name_col")
+carry_cols = None
+if (
+    control_name_col
+    and control_name_col != pert_col
+    and control_name_col in metadata.columns
+):
+    carry_cols = [control_name_col]
+
 # Aggregate
 aggregated_embeddings, aggregated_metadata = aggregate(
     tvn_normalized,
     metadata,
-    snakemake.params.perturbation_name_col,
+    pert_col,
     method=snakemake.params.agg_method,
     ps_probability_threshold=snakemake.params.ps_probability_threshold,
     ps_percentile_threshold=snakemake.params.ps_percentile_threshold,
+    carry_cols=carry_cols,
 )
 
 # Save aggregated data

--- a/workflow/scripts/aggregate/aggregate_cells_second_objs.py
+++ b/workflow/scripts/aggregate/aggregate_cells_second_objs.py
@@ -17,10 +17,10 @@ print(f"  Cells: {len(cells_df)} rows")
 print(f"  Secondary objects: {len(second_objs_df)} rows")
 
 # Filter secondary objects to matching plate/well
-plate = str(snakemake.wildcards.plate)
-well = str(snakemake.wildcards.well)
-second_objs_df["plate"] = second_objs_df["plate"].astype(str)
-second_objs_df["well"] = second_objs_df["well"].astype(str)
+plate = int(
+    snakemake.wildcards.plate
+)  # plate is int64 in both merge_final and phenotype parquets
+well = str(snakemake.wildcards.well)  # well is always string ("A1", etc.)
 second_objs_filtered = second_objs_df[
     (second_objs_df["plate"] == plate) & (second_objs_df["well"] == well)
 ]

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -16,6 +16,7 @@ from lib.aggregate.align import (
     centerscale_by_batch,
     tvn_on_controls,
 )
+from lib.aggregate.filter import harmonize_pool_schema
 from lib.aggregate.perturbation_score import perturbation_score
 
 warnings.filterwarnings(
@@ -51,13 +52,38 @@ n_sample = min(PCA_SUBSET, total_rows)
 random_indices = np.random.choice(total_rows, size=n_sample, replace=False)
 random_indices.sort()
 
-# load sample df
-sample_df = cell_dataset.scanner().take(random_indices)
-sample_df = sample_df.to_pandas(use_threads=True, memory_pool=None)
-
 # load sample df as pandas dataframe
 use_classifier = snakemake.params.get("use_classifier", False)
 metadata_cols = load_metadata_cols(snakemake.params.metadata_cols_fp, use_classifier)
+
+# Harmonize the pool's column set once: drop cols present in only some per-well
+# files (typically driven by per-well filter decisions diverging when class
+# composition differs across wells) and apply drop_cols_threshold at the pool
+# level — matching the convention used by missing_values_filter.
+kept_metadata_cols, kept_feature_cols, _pool_report = harmonize_pool_schema(
+    non_empty_paths,
+    metadata_cols,
+    drop_cols_threshold=snakemake.params.get("drop_cols_threshold"),
+)
+scan_cols = kept_metadata_cols + kept_feature_cols
+
+# load sample df
+sample_df = (
+    cell_dataset.scanner(columns=scan_cols)
+    .take(random_indices)
+    .to_pandas(use_threads=True, memory_pool=None)
+)
+
+# Residual NaN handling: after pool-level col drops, any remaining NaN is
+# sparse and row-localized. Drop those rows from the PCA training sample so
+# PCA/StandardScaler see a clean matrix. Matches the drop_rows_threshold intent
+# at a per-row granularity appropriate for a training sample.
+_sample_pre = len(sample_df)
+sample_df = sample_df.dropna(subset=kept_feature_cols).reset_index(drop=True)
+if len(sample_df) < _sample_pre:
+    print(
+        f"[pool] dropped {_sample_pre - len(sample_df)} PCA-sample rows with residual NaN"
+    )
 metadata, features = split_cell_data(sample_df, metadata_cols)
 metadata, features = prepare_alignment_data(
     metadata,
@@ -87,11 +113,19 @@ for i, indices in enumerate(subset_indices):
     print(f"Processing subset {i + 1}/{num_align_batches} with {len(indices)} cells")
 
     subset_df = (
-        cell_dataset.scanner()
+        cell_dataset.scanner(columns=scan_cols)
         .take(pa.array(indices))
         .to_pandas(use_threads=True, memory_pool=None)
-        .dropna(axis=1)
     )
+    # Drop any residual per-row NaN (pool-level col drops above have already
+    # eliminated systematically-missing columns).
+    _pre = len(subset_df)
+    subset_df = subset_df.dropna(subset=kept_feature_cols).reset_index(drop=True)
+    if len(subset_df) < _pre:
+        print(
+            f"[pool] dropped {_pre - len(subset_df)} rows with residual NaN "
+            f"from batch {i + 1}"
+        )
 
     # CALCULATE PERTURBATION SCORE
     subset_df["perturbation_score"] = np.nan

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -137,6 +137,9 @@ for i, indices in enumerate(subset_indices):
             metadata_cols,
             snakemake.params.perturbation_name_col,
             snakemake.params.control_key,
+            perturbation_id_col=snakemake.params.perturbation_id_col,
+            control_name_col=snakemake.params.get("control_name_col"),
+            batch_cols=snakemake.params.batch_cols,
         )
 
     for col in subset_df.columns:

--- a/workflow/scripts/aggregate/bootstrap_gene.py
+++ b/workflow/scripts/aggregate/bootstrap_gene.py
@@ -12,6 +12,7 @@ from lib.aggregate.cell_data_utils import get_feature_table_cols
 gene_id = snakemake.wildcards.gene
 cell_class = snakemake.wildcards.cell_class
 channel_combo = snakemake.wildcards.channel_combo
+compartment_combo = snakemake.wildcards.compartment_combo
 num_sims = snakemake.params.num_sims
 bootstrap_features_fp = snakemake.params.get("bootstrap_features_fp", None)
 

--- a/workflow/scripts/aggregate/eval_aggregate.py
+++ b/workflow/scripts/aggregate/eval_aggregate.py
@@ -64,16 +64,29 @@ aligned_data = aligned_data.to_pandas(use_threads=True, memory_pool=None)
 
 # determine original and aligned columns
 random.seed(42)
-# Prefer cell-level features, fall back to nuclear if none found
-merge_feature_cols = [
-    col for col in merge_data.columns if ("cell_" in col and col.endswith("_mean"))
+# Try compartment prefixes in priority order and use the first that yields
+# *_<channel>_mean feature columns. Driven by the wildcard's compartment_combo
+# first (whichever compartments this output is actually about), then a fallback
+# chain so e.g. second_obj or cytoplasm combos still find intensity means.
+compartment_combo = snakemake.wildcards.compartment_combo.split("-")
+prefix_priority = compartment_combo + [
+    c
+    for c in ("cell", "nucleus", "cytoplasm", "second_obj")
+    if c not in compartment_combo
 ]
-if len(merge_feature_cols) == 0:
+merge_feature_cols = []
+for prefix in prefix_priority:
     merge_feature_cols = [
         col
         for col in merge_data.columns
-        if ("nucleus_" in col and col.endswith("_mean"))
+        if col.startswith(f"{prefix}_") and col.endswith("_mean")
     ]
+    if merge_feature_cols:
+        print(
+            f"[eval] using {len(merge_feature_cols)} '{prefix}_*_mean' feature columns"
+        )
+        break
+
 pc_cols = [col for col in aligned_data.columns if col.startswith("PC_")]
 aligned_feature_cols = random.sample(
     pc_cols, k=min(len(merge_feature_cols), len(pc_cols))

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -11,6 +11,7 @@ from pandas.api.types import is_numeric_dtype
 from lib.aggregate.align import prepare_alignment_data, centerscale_on_controls
 from lib.aggregate.cell_data_utils import load_metadata_cols, split_cell_data
 from lib.aggregate.bootstrap import create_pseudogene_groups
+from lib.aggregate.filter import harmonize_pool_schema
 
 # get snakemake parameters
 pert_col = snakemake.params.perturbation_name_col
@@ -34,14 +35,18 @@ if len(non_empty_paths) == 0:
 
 cell_dataset = ds.dataset(non_empty_paths, format="parquet")
 
-# Determine columns
-cell_data_cols = cell_dataset.schema.names
 use_classifier = snakemake.params.get("use_classifier", False)
 metadata_cols = load_metadata_cols(snakemake.params.metadata_cols_fp, use_classifier)
-feature_cols = [col for col in cell_dataset.schema.names if col not in metadata_cols]
 
-# Filter metadata_cols to only include columns that exist in the parquet
-existing_metadata_cols = [col for col in metadata_cols if col in cell_data_cols]
+# Harmonize the pool's column set once: drop cols present in only some per-well
+# files (typically driven by per-well filter decisions diverging when class
+# composition differs across wells) and apply drop_cols_threshold at the pool
+# level — matching the convention used by missing_values_filter.
+existing_metadata_cols, feature_cols, _pool_report = harmonize_pool_schema(
+    non_empty_paths,
+    metadata_cols,
+    drop_cols_threshold=snakemake.params.get("drop_cols_threshold"),
+)
 
 print(
     f"Number of metadata columns: {len(existing_metadata_cols)} | Number of feature columns: {len(feature_cols)}"

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -191,7 +191,12 @@ gc.collect()
 construct_table = pd.DataFrame(construct_rows)
 
 # Reorder columns: sgRNA, gene, cell_count, features
-construct_columns = [pert_id_col, pert_col, "cell_count"] + feature_cols
+# Dedupe while preserving order: when perturbation_id_col == perturbation_name_col
+# (a valid config when aggregation is already at the per-construct level),
+# listing both would create a duplicate column and break downstream Series ops.
+construct_columns = list(
+    dict.fromkeys([pert_id_col, pert_col, "cell_count"] + feature_cols)
+)
 construct_table = construct_table[construct_columns]
 
 print(f"Construct table shape: {construct_table.shape}")

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -17,6 +17,11 @@ from lib.aggregate.filter import harmonize_pool_schema
 pert_col = snakemake.params.perturbation_name_col
 pert_id_col = snakemake.params.perturbation_id_col or pert_col
 control_key = snakemake.params.control_key
+# Column used to identify controls via control_key. When aggregating by a
+# construct ID (pert_col = cell_barcode_0) controls are still named in a
+# separate column (e.g. gene_symbol_0); fall back to pert_col when unset so
+# gene-level runs (control_name_col == pert_col) are unchanged.
+control_name_col = snakemake.params.get("control_name_col") or pert_col
 num_batches = snakemake.params.get("num_align_batches", 1)
 
 # Load cell data using PyArrow dataset (lazy - no data loaded yet)
@@ -74,6 +79,7 @@ writer = None
 # We'll collect per-construct data across batches
 construct_cell_counts = {}  # {construct_id: count}
 construct_gene_map = {}  # {construct_id: gene_name}
+construct_control_map = {}  # {construct_id: control_name_col value (for control id)}
 construct_feature_sums = {}  # {construct_id: [sum of features]}
 construct_feature_counts = {}  # {construct_id: count for averaging}
 # For median, we need all values - store them
@@ -123,6 +129,7 @@ for batch_idx, indices in enumerate(subset_indices):
         control_key,
         "batch_values",
         method=snakemake.params.feature_normalization,
+        control_col=control_name_col,
     ).astype(np.float32)
 
     # OUTPUT 1: Write center-scaled single-cell data incrementally
@@ -147,10 +154,12 @@ for batch_idx, indices in enumerate(subset_indices):
         mask = metadata[pert_id_col].values == construct_id
         construct_features = features[mask]
         gene_name = metadata.loc[mask, pert_col].iloc[0]
+        control_name = metadata.loc[mask, control_name_col].iloc[0]
 
         if construct_id not in construct_cell_counts:
             construct_cell_counts[construct_id] = 0
             construct_gene_map[construct_id] = gene_name
+            construct_control_map[construct_id] = control_name
             construct_feature_values[construct_id] = []
 
         construct_cell_counts[construct_id] += mask.sum()
@@ -178,6 +187,7 @@ for construct_id in construct_cell_counts.keys():
     row = {
         pert_id_col: construct_id,
         pert_col: construct_gene_map[construct_id],
+        control_name_col: construct_control_map[construct_id],
         "cell_count": construct_cell_counts[construct_id],
     }
     for i, col in enumerate(feature_cols):
@@ -195,7 +205,9 @@ construct_table = pd.DataFrame(construct_rows)
 # (a valid config when aggregation is already at the per-construct level),
 # listing both would create a duplicate column and break downstream Series ops.
 construct_columns = list(
-    dict.fromkeys([pert_id_col, pert_col, "cell_count"] + feature_cols)
+    dict.fromkeys(
+        [pert_id_col, pert_col, control_name_col, "cell_count"] + feature_cols
+    )
 )
 construct_table = construct_table[construct_columns]
 
@@ -206,7 +218,7 @@ print("\n=== Creating gene-level table ===")
 
 # Filter out controls for gene-level aggregation
 non_control_constructs = construct_table[
-    ~construct_table[pert_col].str.contains(control_key, na=False)
+    ~construct_table[control_name_col].str.contains(control_key, na=False)
 ]
 
 # Calculate gene-level sample sizes (sum of construct cell counts)
@@ -228,7 +240,7 @@ gene_table = pd.merge(gene_features, gene_sample_sizes, on=pert_col, how="left")
 
 # Add controls to gene table (controls are their own "genes")
 control_constructs = construct_table[
-    construct_table[pert_col].str.contains(control_key, na=False)
+    construct_table[control_name_col].str.contains(control_key, na=False)
 ]
 control_gene_table = control_constructs[[pert_col, "cell_count"] + feature_cols].copy()
 

--- a/workflow/scripts/aggregate/split_datasets.py
+++ b/workflow/scripts/aggregate/split_datasets.py
@@ -6,6 +6,7 @@ from lib.aggregate.cell_data_utils import (
     load_metadata_cols,
     split_cell_data,
     channel_combo_subset,
+    compartment_combo_subset,
 )
 
 
@@ -148,8 +149,22 @@ else:
 # Load all channels
 all_channels = snakemake.params.all_channels
 
-# split cells by cell class
-for cell_class in snakemake.params.cell_classes:
+# Each row pairs a channel_combo with its compartment_combo; compartments are zipped not crossed.
+aggregate_wildcard_combos = snakemake.params.aggregate_wildcard_combos
+unique_specs = aggregate_wildcard_combos[
+    ["cell_class", "channel_combo", "compartment_combo"]
+].drop_duplicates()
+
+# Full set of compartments this run has data for (derived from the TSV, not hard-coded)
+all_compartments_run = sorted(
+    {comp for combo in unique_specs["compartment_combo"] for comp in combo.split("-")}
+)
+
+for _, row in unique_specs.iterrows():
+    cell_class = row["cell_class"]
+    channel_combo = row["channel_combo"]
+    compartment_combo = row["compartment_combo"]
+
     if cell_class == "all":
         cell_class_metadata = metadata
         cell_class_features = features
@@ -158,22 +173,23 @@ for cell_class in snakemake.params.cell_classes:
         cell_class_metadata = metadata[cell_class_mask]
         cell_class_features = features[cell_class_mask]
 
-    # split features into channel combos
-    for channel_combo in snakemake.params.channel_combos:
-        channel_combo_list = channel_combo.split("_")
-        channel_combo_features = channel_combo_subset(
-            cell_class_features, channel_combo_list, all_channels
-        )
+    channel_combo_list = channel_combo.split("_")
+    compartment_combo_list = compartment_combo.split("-")
 
-        # concatenate metadata and features
-        cell_class_data = pd.concat(
-            [cell_class_metadata, channel_combo_features], axis=1
-        ).reset_index(drop=True)
+    filtered = channel_combo_subset(
+        cell_class_features, channel_combo_list, all_channels
+    )
+    filtered = compartment_combo_subset(
+        filtered, compartment_combo_list, all_compartments_run
+    )
 
-        # Save data
-        dataset_fp = [
-            f
-            for f in snakemake.output
-            if f"CeCl-{cell_class}_ChCo-{channel_combo}__" in f
-        ][0]
-        cell_class_data.to_parquet(dataset_fp, index=False)
+    cell_class_data = pd.concat([cell_class_metadata, filtered], axis=1).reset_index(
+        drop=True
+    )
+
+    dataset_fp = [
+        f
+        for f in snakemake.output
+        if f"CeCl-{cell_class}_ChCo-{channel_combo}_CmCo-{compartment_combo}__" in f
+    ][0]
+    cell_class_data.to_parquet(dataset_fp, index=False)

--- a/workflow/scripts/aggregate/split_datasets.py
+++ b/workflow/scripts/aggregate/split_datasets.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from lib.aggregate.cell_classification import CellClassifier
 from lib.aggregate.cell_data_utils import (
+    COMPARTMENT_PREFIXES,
     load_metadata_cols,
     split_cell_data,
     channel_combo_subset,
@@ -155,10 +156,10 @@ unique_specs = aggregate_wildcard_combos[
     ["cell_class", "channel_combo", "compartment_combo"]
 ].drop_duplicates()
 
-# Full set of compartments this run has data for (derived from the TSV, not hard-coded)
-all_compartments_run = sorted(
-    {comp for combo in unique_specs["compartment_combo"] for comp in combo.split("-")}
-)
+# Universe of compartment prefixes that may exist in the input data. Must come from
+# the known prefix set, not from the TSV — compartments never requested in any combo
+# would otherwise pass through undropped.
+all_compartments_run = sorted(COMPARTMENT_PREFIXES.keys())
 
 for _, row in unique_specs.iterrows():
     cell_class = row["cell_class"]

--- a/workflow/targets/aggregate.smk
+++ b/workflow/targets/aggregate.smk
@@ -24,6 +24,7 @@ AGGREGATE_OUTPUTS = {
                 "well": "{well}",
                 "cell_class": "{cell_class}",
                 "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
             },
             "merge_data",
             "parquet",
@@ -38,6 +39,7 @@ AGGREGATE_OUTPUTS = {
                 "well": "{well}",
                 "cell_class": "{cell_class}",
                 "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
             },
             "filtered",
             "parquet",
@@ -47,21 +49,33 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "parquets"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "features_singlecell",
             "parquet",
         ),
         AGGREGATE_FP
         / "tsvs"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "features_constructs",
             "tsv",
         ),
         AGGREGATE_FP
         / "tsvs"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "features_genes",
             "tsv",
         ),
@@ -70,7 +84,11 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "parquets"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "aligned",
             "parquet",
         ),
@@ -79,7 +97,11 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "tsvs"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "aggregated",
             "tsv",
         ),
@@ -88,21 +110,33 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "eval"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "na_stats",
             "tsv",
         ),
         AGGREGATE_FP
         / "eval"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "na_stats",
             "png",
         ),
         AGGREGATE_FP
         / "eval"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                "compartment_combo": "{compartment_combo}",
+            },
             "feature_distributions",
             "png",
         ),
@@ -198,41 +232,61 @@ MONTAGE_TARGETS_ALL = [
 # These are special because we dynamically derive outputs
 BOOTSTRAP_OUTPUTS = {
     # Data preparation outputs
-    "bootstrap_data_dir": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__bootstrap_data",
-    "construct_data": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__bootstrap_data" / "{gene}__{construct}__construct_data.tsv",
-    
+    "bootstrap_data_dir": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__bootstrap_data",
+    "construct_data": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__bootstrap_data" / "{gene}__{construct}__construct_data.tsv",
+
     # Input arrays
     "controls_arr": AGGREGATE_FP / "bootstrap" / "inputs" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            "compartment_combo": "{compartment_combo}",
+        },
         "controls_arr", "tsv"
     ),
     "construct_features_arr": AGGREGATE_FP / "bootstrap" / "inputs" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            "compartment_combo": "{compartment_combo}",
+        },
         "construct_features_arr", "tsv"
     ),
     "sample_sizes": AGGREGATE_FP / "bootstrap" / "inputs" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            "compartment_combo": "{compartment_combo}",
+        },
         "sample_sizes", "tsv"
     ),
 
     # Construct-level outputs
-    "bootstrap_construct_nulls": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__constructs" / "{gene}__{construct}__nulls.npy",
-    "bootstrap_construct_pvals": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__constructs" / "{gene}__{construct}__pvals.tsv",
-    
+    "bootstrap_construct_nulls": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__constructs" / "{gene}__{construct}__nulls.npy",
+    "bootstrap_construct_pvals": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__constructs" / "{gene}__{construct}__pvals.tsv",
+
     # Gene-level outputs
-    "bootstrap_gene_nulls": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__genes" / "{gene}__nulls.npy",
-    "bootstrap_gene_pvals": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__genes" / "{gene}__pvals.tsv",
-    
+    "bootstrap_gene_nulls": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__genes" / "{gene}__nulls.npy",
+    "bootstrap_gene_pvals": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__genes" / "{gene}__pvals.tsv",
+
     # Completion flags
-    "bootstrap_flag": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__bootstrap_complete.flag",
+    "bootstrap_flag": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__{compartment_combo}__bootstrap_complete.flag",
 
     # Combined results
     "combined_construct_results": AGGREGATE_FP / "bootstrap" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            "compartment_combo": "{compartment_combo}",
+        },
         "all_construct_bootstrap_results", "tsv"
     ),
     "combined_gene_results": AGGREGATE_FP / "bootstrap" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            "compartment_combo": "{compartment_combo}",
+        },
         "all_gene_bootstrap_results", "tsv"
     ),
 }
@@ -240,7 +294,11 @@ BOOTSTRAP_OUTPUTS = {
 # Bootstrap target combinations
 bootstrap_combos = config.get("aggregate", {}).get("bootstrap_combinations", [])
 BOOTSTRAP_TARGETS_ALL = [
-    str(output_path).format(cell_class=combo["cell_class"], channel_combo=combo["channel_combo"])
+    str(output_path).format(
+        cell_class=combo["cell_class"],
+        channel_combo=combo["channel_combo"],
+        compartment_combo=combo["compartment_combo"],
+    )
     for combo in bootstrap_combos
     for output_path in [
         BOOTSTRAP_OUTPUTS["combined_construct_results"],

--- a/workflow/targets/aggregate.smk
+++ b/workflow/targets/aggregate.smk
@@ -222,10 +222,15 @@ MONTAGE_OUTPUTS = {
     "montage_flag": AGGREGATE_FP / "montages" / "{cell_class}__montages_complete.flag",
 }
 cell_classes = aggregate_wildcard_combos["cell_class"].unique()
-MONTAGE_TARGETS_ALL = [
-    str(MONTAGE_OUTPUTS["montage_flag"]).format(cell_class=cell_class)
-    for cell_class in cell_classes
-]
+generate_montages = config.get("aggregate", {}).get("generate_montages", True)
+MONTAGE_TARGETS_ALL = (
+    [
+        str(MONTAGE_OUTPUTS["montage_flag"]).format(cell_class=cell_class)
+        for cell_class in cell_classes
+    ]
+    if generate_montages
+    else []
+)
 
 
 # Define bootstrap outputs

--- a/workflow/targets/cluster.smk
+++ b/workflow/targets/cluster.smk
@@ -11,12 +11,14 @@ CLUSTER_OUTPUTS = {
     "clean_aggregate": [
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / get_filename({}, "aggregate_cleaned", "tsv"),
     ],
     "phate_leiden_clustering": [
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename(
@@ -26,11 +28,13 @@ CLUSTER_OUTPUTS = {
         ),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({}, "cluster_sizes", "png"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({}, "clusters", "png"),
@@ -38,41 +42,49 @@ CLUSTER_OUTPUTS = {
     "benchmark_clusters": [
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "integrated_results", "json"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Shuffled"}, "integrated_results", "json"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "combined_table", "tsv"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Shuffled"}, "combined_table", "tsv"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "global_metrics", "json"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Shuffled"}, "global_metrics", "json"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "pie_chart", "png"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename(
@@ -80,11 +92,13 @@ CLUSTER_OUTPUTS = {
         ),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "enrichment_bar_chart", "png"),
         CLUSTER_FP
         / "{channel_combo}"
+        / "{compartment_combo}"
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename(


### PR DESCRIPTION
## Summary

Ports the aggregate-module work developed on `recomb_hamming_thresh` down onto `secondary_object` — **without** the joint-alignment feature, which is deliberately and fully scrubbed. 21 commits, +939 / −210 across the aggregate module (plus the cross-cutting `compartment_combo` propagation through cluster/shared).

## What's included

- **`compartment_combo` wildcard** — per-compartment aggregate/cluster outputs (`cell` / `nucleus` / `cytoplasm` / `second_obj`): `CmCo-` filename prefix, `resolve_aggregate_combos` validation, `compartment_combo_subset`, wired through paths/rules/targets/metrics.
- **Pool schema harmonization** (`harmonize_pool_schema`) — intersects per-well parquet schemas before pooling so divergent per-well `missing_values_filter` drops no longer inject NaN blocks that crash PCA in `align` / `generate_feature_table`.
- **Perturbation-scoring correctness** — de-hardcodes `gene_symbol_0` / `nontargeting` / `cell_barcode_0` (plumbs the configured pert/control/batch columns through), NaN-safe binary target, `.loc` (not `.iloc`) for label-indexed slices, dedupe construct columns when `pert_id_col == pert_col`.
- **Aggregate correctness** — preserve int64 plate dtype in second-obj aggregation, compartment-aware NaN-safe `eval_aggregate`, `carry_cols` (carry a functionally-determined column such as `gene_symbol_0` through construct-level aggregation), positional indexing in `missing_values_filter` imputation.
- **misc** — `generate_montages` opt-out.

## Explicitly excluded (out of scope for this port)

- **Joint alignment** — scrubbed entirely. `grep -rni joint workflow/` returns nothing; no `stratified_subsample` / `JOINT_PCA` / `is_joint` / `tvn_on_controls_joint`. The harmonize/perturbation/carry_cols surgery was adapted to the non-joint single-`pert_col` grouping.
- Cluster benchmark gating and the recomb-hamming SBS change.

## Validation

- `tests/test_compartment_filter.py` — **15/15 pass**.
- All changed Python files compile (`py_compile`).
- `snakemake -n --until all_aggregate` builds a clean DAG against a real analysis config.
- **End-to-end aggregate run** on plate 1/2 × well B3, construct-level (`perturbation_name_col=cell_barcode_0`, `control_name_col=gene_symbol_0`, perturbation scoring **on**) — exercises `harmonize_pool_schema`, `carry_cols`, the de-hardcoded perturbation scoring, second-object aggregation, and compartment-aware `eval_aggregate` on real data. **Completed: 23/23 jobs, snakemake exit 0, no errors/OOM in the run log**; produced `aggregated.tsv` / `aligned.parquet` / `eval` / `features_genes.tsv` for all three classes. (Run via the production slurm resource profile.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
