### PR TITLE
fix: bug fixes found during local zarr3 testing

### DIFF
--- a/workflow/lib/classify/shared.py
+++ b/workflow/lib/classify/shared.py
@@ -260,9 +260,7 @@ def load_mask_labels(
             {"plate": plate, "well": wpad, "tile": tile}, label_name, "tiff"
         ),
         images_dir
-        / get_filename(
-            {"plate": plate, "well": wpad, "tile": tile}, label_name, "tif"
-        ),
+        / get_filename({"plate": plate, "well": wpad, "tile": tile}, label_name, "tif"),
     ]
 
     zarr_path = next((p for p in zarr_candidates if p.exists()), None)

--- a/workflow/lib/classify/shared.py
+++ b/workflow/lib/classify/shared.py
@@ -316,8 +316,13 @@ def load_parquet(
     wname = well_for_filename(well)
     m = re.match(r"^([A-Z])(\d{1,2})$", wname)
     wpad = f"{m.group(1)}{int(m.group(2)):02d}" if m else wname
+    row = wname[0]
+    col = wname[1:]
     if mode_ == "vacuole":
         candidates = [
+            # HCS nested layout
+            pq_dir / str(plate) / row / col / "phenotype_vacuoles.parquet",
+            # Flat layout
             pq_dir
             / get_filename(
                 {"plate": plate, "well": wname}, "phenotype_vacuoles", "parquet"
@@ -329,6 +334,10 @@ def load_parquet(
         ]
     else:
         candidates = [
+            # HCS nested layout
+            pq_dir / str(plate) / row / col / "phenotype_cp.parquet",
+            pq_dir / str(plate) / row / col / "phenotype_cp_min.parquet",
+            # Flat layout
             pq_dir
             / get_filename({"plate": plate, "well": wname}, "phenotype_cp", "parquet"),
             pq_dir

--- a/workflow/lib/classify/shared.py
+++ b/workflow/lib/classify/shared.py
@@ -149,19 +149,26 @@ def load_aligned_stack(
     *,
     cache: Optional[Dict[Any, Any]] = None,
 ) -> np.ndarray:
-    """Load aligned TIFF stack as (C,H,W) with channels matching channel_names."""
+    """Load aligned image stack as (C,H,W) from TIFF or OME-Zarr."""
+    from lib.shared.image_io import read_image
+
     phenotype_output_fp = Path(phenotype_output_fp)
     key = (int(plate), str(well), int(tile))
     if cache is not None and key in cache:
         return cache[key]
 
     wname = well_for_filename(well)
-    # Backward-compat: also try zero-padded well variant if files were written that way
     m = re.match(r"^([A-Z])(\d{1,2})$", wname)
     wpad = f"{m.group(1)}{int(m.group(2)):02d}" if m else wname
+    row = wname[0]
+    col = wname[1:]
+
+    # Try OME-Zarr HCS layout first, then TIFF
+    zarr_candidates = [
+        phenotype_output_fp / f"aligned_{plate}.zarr" / row / col / str(tile),
+    ]
     images_dir = phenotype_output_fp / "images"
-    # Prefer using shared filename builder; try both tiff and tif
-    candidates = [
+    tiff_candidates = [
         images_dir
         / get_filename(
             {"plate": plate, "well": wname, "tile": tile}, "aligned", "tiff"
@@ -173,12 +180,18 @@ def load_aligned_stack(
         images_dir
         / get_filename({"plate": plate, "well": wpad, "tile": tile}, "aligned", "tif"),
     ]
-    path = next((p for p in candidates if p.exists()), None)
-    if path is None:
-        raise FileNotFoundError(
-            f"Aligned TIFF not found for P-{plate} W-{wname} T-{tile}"
-        )
-    arr = tifffile.imread(path)
+
+    zarr_path = next((p for p in zarr_candidates if p.exists()), None)
+    if zarr_path is not None:
+        arr = read_image(zarr_path)
+    else:
+        tiff_path = next((p for p in tiff_candidates if p.exists()), None)
+        if tiff_path is None:
+            raise FileNotFoundError(
+                f"Aligned image not found for P-{plate} W-{wname} T-{tile}"
+            )
+        arr = tifffile.imread(tiff_path)
+
     if arr.ndim == 2:
         arr = arr[np.newaxis, ...]
     elif (
@@ -188,7 +201,7 @@ def load_aligned_stack(
     ):
         arr = np.moveaxis(arr, -1, 0)
     if arr.ndim != 3:
-        raise ValueError(f"Aligned TIFF must be 3D; got {arr.shape}")
+        raise ValueError(f"Aligned image must be 3D; got {arr.shape}")
     if arr.shape[0] != len(channel_names):
         raise ValueError("Channel count mismatch.")
     if cache is not None:
@@ -205,7 +218,9 @@ def load_mask_labels(
     *,
     cache: Optional[Dict[Any, Any]] = None,
 ) -> np.ndarray:
-    """Load 2D mask labels image for either 'vacuole' or 'cell' modes."""
+    """Load 2D mask labels image from TIFF or OME-Zarr."""
+    from lib.shared.image_io import read_image
+
     phenotype_output_fp = Path(phenotype_output_fp)
     mode_ = str(mode).lower()
     key = (mode_, int(plate), str(well), int(tile))
@@ -213,62 +228,55 @@ def load_mask_labels(
         return cache[key]
 
     wname = well_for_filename(well)
-    # Backward-compat: also try zero-padded well variant
     m = re.match(r"^([A-Z])(\d{1,2})$", wname)
     wpad = f"{m.group(1)}{int(m.group(2)):02d}" if m else wname
+    row = wname[0]
+    col = wname[1:]
+
+    label_name = "identified_vacuoles" if mode_ == "vacuole" else "cells"
+
+    # Try OME-Zarr HCS layout first (labels nested inside aligned store)
+    zarr_candidates = [
+        phenotype_output_fp
+        / f"aligned_{plate}.zarr"
+        / row
+        / col
+        / str(tile)
+        / "labels"
+        / label_name,
+    ]
     images_dir = phenotype_output_fp / "images"
-    if mode_ == "vacuole":
-        candidates = [
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wname, "tile": tile},
-                "identified_vacuoles",
-                "tiff",
-            ),
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wname, "tile": tile},
-                "identified_vacuoles",
-                "tif",
-            ),
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wpad, "tile": tile},
-                "identified_vacuoles",
-                "tiff",
-            ),
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wpad, "tile": tile},
-                "identified_vacuoles",
-                "tif",
-            ),
-        ]
+    tiff_candidates = [
+        images_dir
+        / get_filename(
+            {"plate": plate, "well": wname, "tile": tile}, label_name, "tiff"
+        ),
+        images_dir
+        / get_filename(
+            {"plate": plate, "well": wname, "tile": tile}, label_name, "tif"
+        ),
+        images_dir
+        / get_filename(
+            {"plate": plate, "well": wpad, "tile": tile}, label_name, "tiff"
+        ),
+        images_dir
+        / get_filename(
+            {"plate": plate, "well": wpad, "tile": tile}, label_name, "tif"
+        ),
+    ]
+
+    zarr_path = next((p for p in zarr_candidates if p.exists()), None)
+    if zarr_path is not None:
+        labels = read_image(zarr_path)
     else:
-        candidates = [
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wname, "tile": tile}, "cells", "tiff"
-            ),
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wname, "tile": tile}, "cells", "tif"
-            ),
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wpad, "tile": tile}, "cells", "tiff"
-            ),
-            images_dir
-            / get_filename(
-                {"plate": plate, "well": wpad, "tile": tile}, "cells", "tif"
-            ),
-        ]
-    path = next((p for p in candidates if p.exists()), None)
-    if path is None:
-        raise FileNotFoundError(
-            f"Mask image not found for mode={mode_}, plate={plate}, well={wname}, tile={tile}."
-        )
-    labels = tifffile.imread(path)
+        tiff_path = next((p for p in tiff_candidates if p.exists()), None)
+        if tiff_path is None:
+            raise FileNotFoundError(
+                f"Mask image not found for mode={mode_}, plate={plate}, "
+                f"well={wname}, tile={tile}."
+            )
+        labels = tifffile.imread(tiff_path)
+
     if labels.ndim != 2:
         raise ValueError(f"Mask must be 2D; got {labels.shape}")
     if cache is not None:

--- a/workflow/lib/external/cp_emulator.py
+++ b/workflow/lib/external/cp_emulator.py
@@ -441,10 +441,9 @@ shape_features = {
     "minor_axis": lambda r: r.minor_axis_length,
     "orientation": lambda r: r.orientation,
     # compactness from centrosome.cpmorphology.ellipse_from_second_moments(): "variance of the radial distribution normalized by the area"
-    "compactness": lambda r: 2
-    * np.pi
-    * (r.moments_central[0, 2] + r.moments_central[2, 0])
-    / (r.area**2),
+    "compactness": lambda r: (
+        2 * np.pi * (r.moments_central[0, 2] + r.moments_central[2, 0]) / (r.area**2)
+    ),
     "radius": lambda r: max_median_mean_radius(r.filled_image),
     "feret_diameter": lambda r: min_max_feret_diameter(
         r.coords

--- a/workflow/lib/sbs/standardize_barcode_design.py
+++ b/workflow/lib/sbs/standardize_barcode_design.py
@@ -384,6 +384,10 @@ def standardize_barcode_design(
             "uniprot_entry",
         ]
 
+    # Only keep required columns that actually exist in the dataframe
+    # (e.g. gene_id is optional and may not be present)
+    required_cols = [col for col in required_cols if col in df.columns]
+
     if keep_extra_cols:
         # Keep additional columns that might be useful
         extra_cols = [col for col in df.columns if col not in required_cols]

--- a/workflow/lib/shared/image_io.py
+++ b/workflow/lib/shared/image_io.py
@@ -234,6 +234,7 @@ def write_image_omezarr(
 
     metadata: Dict[str, Any] = {}
     omero: Dict[str, Any] = {}
+
     if channel_names:
         if is_label:
             omero["channels"] = [

--- a/workflow/scripts/aggregate/format_singlecell_anndata.py
+++ b/workflow/scripts/aggregate/format_singlecell_anndata.py
@@ -203,6 +203,10 @@ adata.uns["pipeline"] = {
     "channels": channel_names,
 }
 
+for col in adata.obs.columns:
+    if adata.obs[col].dtype == object:
+        adata.obs[col] = adata.obs[col].fillna("").astype(str)
+
 print(f"\n{adata}")
 adata.write_h5ad(snakemake.output[0])
 print(f"Saved to {snakemake.output[0]}")

--- a/workflow/scripts/cluster/format_cluster_anndata.py
+++ b/workflow/scripts/cluster/format_cluster_anndata.py
@@ -22,7 +22,11 @@ bootstrap_results = None
 try:
     bootstrap_path = snakemake.input.bootstrap_results
     if bootstrap_path:
-        path = bootstrap_path[0] if isinstance(bootstrap_path, (list, tuple)) else bootstrap_path
+        path = (
+            bootstrap_path[0]
+            if isinstance(bootstrap_path, (list, tuple))
+            else bootstrap_path
+        )
         bootstrap_results = pd.read_csv(path, sep="\t")
         print(f"Bootstrap results: {bootstrap_results.shape}")
 except (AttributeError, Exception):


### PR DESCRIPTION
# Description

Bug fixes discovered while running the zarr3 branch locally on test data. Each fix addresses a runtime error or data-loss issue encountered during end-to-end pipeline execution in zarr mode.

## Changes

- **fix(aggregate):** Coerce NaN values in object-typed `.obs` columns before writing `.h5ad` — prevents `anndata` write failures on mixed-type Series
- **fix(classify):** Add HCS nested parquet path resolution to `load_parquet` so classify finds parquet files under the zarr plate directory structure
- **fix(classify):** Add OME-Zarr support to `load_aligned_stack` and `load_mask_labels` — enables the classifier to read zarr image stores instead of only TIFFs
- **fix(sbs):** Guard against `KeyError` when `gene_id` column is absent in the design table during `standardize_barcode_design`
- **style:** Run `ruff format` on 4 files that drifted during prior merges

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.