### PR TITLE
enhance(io): OME-Zarr metadata spec compliance for OMERO windows and axis names

### DIFF
--- a/workflow/lib/shared/image_io.py
+++ b/workflow/lib/shared/image_io.py
@@ -235,7 +235,11 @@ def write_image_omezarr(
     metadata: Dict[str, Any] = {}
     omero: Dict[str, Any] = {}
 
-    dtype_max = float(np.iinfo(image_data.dtype).max) if np.issubdtype(image_data.dtype, np.integer) else 1.0
+    dtype_max = (
+        float(np.iinfo(image_data.dtype).max)
+        if np.issubdtype(image_data.dtype, np.integer)
+        else 1.0
+    )
     default_window = {"start": 0.0, "end": dtype_max, "min": 0.0, "max": dtype_max}
 
     if channel_names:

--- a/workflow/lib/shared/image_io.py
+++ b/workflow/lib/shared/image_io.py
@@ -310,13 +310,13 @@ _AXIS_TYPES: Dict[str, str] = {
 
 
 def _axes_str_to_dicts(axes: str) -> List[Dict[str, str]]:
-    """Convert an uppercase axes string to a list of axis dicts for ome_zarr.
+    """Convert an axes string to a list of axis dicts for ome_zarr.
 
-    ome_zarr.writer only recognises lowercase axis names for type inference.
-    Passing a list of dicts with explicit ``type`` values lets us store
-    uppercase names while still satisfying the validator.
+    OME-NGFF v0.5 requires lowercase axis names. The internal ``axes``
+    parameter may be uppercase for readability; this function lowercases
+    the stored ``name`` so that ngio and other spec-compliant readers
+    can parse the metadata without an AxesSetup override.
     """
-    # Units for axes that have a physical dimension.
     _AXIS_UNITS: Dict[str, str] = {
         "T": "second",
         "Z": "micrometer",
@@ -325,7 +325,7 @@ def _axes_str_to_dicts(axes: str) -> List[Dict[str, str]]:
     }
     result = []
     for ch in axes.upper():
-        d: Dict[str, str] = {"name": ch}
+        d: Dict[str, str] = {"name": ch.lower()}
         if ch in _AXIS_TYPES:
             d["type"] = _AXIS_TYPES[ch]
         if ch in _AXIS_UNITS:

--- a/workflow/lib/shared/image_io.py
+++ b/workflow/lib/shared/image_io.py
@@ -234,6 +234,10 @@ def write_image_omezarr(
 
     metadata: Dict[str, Any] = {}
     omero: Dict[str, Any] = {}
+
+    dtype_max = float(np.iinfo(image_data.dtype).max) if np.issubdtype(image_data.dtype, np.integer) else 1.0
+    default_window = {"start": 0.0, "end": dtype_max, "min": 0.0, "max": dtype_max}
+
     if channel_names:
         if is_label:
             omero["channels"] = [
@@ -245,6 +249,7 @@ def write_image_omezarr(
                     "label": name,
                     "active": True,
                     "color": DEFAULT_CHANNEL_COLORS[i % len(DEFAULT_CHANNEL_COLORS)],
+                    "window": dict(default_window),
                 }
                 for i, name in enumerate(channel_names)
             ]


### PR DESCRIPTION
# Description

Two enhancements to OME-Zarr metadata generation in `image_io.py` to improve spec compliance and viewer compatibility (napari, OMERO, neuroglancer).

**OMERO window fields** — Channel metadata now includes `window` objects (`start`, `end`, `min`, `max`) derived from the image dtype. Without these, viewers that rely on OMERO rendering metadata (e.g., napari-ome-zarr) fall back to auto-contrast or fail to render channels correctly.

**Lowercase axis names** — OME-NGFF spec defines axis names as lowercase (`t`, `c`, `z`, `y`, `x`). The `multiscales` metadata block now writes lowercase axis names regardless of the internal uppercase convention used elsewhere in the pipeline. This fixes validation warnings from spec-checking tools like `ome-zarr validate`.

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.