### PR TITLE
merge: within-tile 1:1 matching, low-score seed filtering, persist aligned SBS

### DIFF
--- a/workflow/lib/merge/fast_merge.py
+++ b/workflow/lib/merge/fast_merge.py
@@ -123,38 +123,61 @@ def merge_sbs_phenotype(
             wk.setdefault("model", local_refinement)
         Y_pred = refine_local_warp(X, Y, Y_pred, threshold, **wk)
 
-    # Calculate squared Euclidean distances between predicted coordinates and dataset 1 coordinates
-    distances = cdist(Y, Y_pred, metric="sqeuclidean")
-
-    # Find the index of the nearest neighbor in Y_pred for each point in Y
-    ix = distances.argmin(axis=1)
-
-    # Filter matches based on the threshold distance
-    filt = np.sqrt(distances.min(axis=1)) < threshold
+    # Mutual nearest-neighbor match enforces a single phenotype<->SBS pairing per cell in the tile
+    sbs_ix, ph_ix, match_distances = match_cells(Y, Y_pred, threshold)
 
     # Define new column names for merging
     columns_0 = {"tile": "tile", "cell": "cell_0", "i": "i_0", "j": "j_0"}
     columns_1 = {"site": "site", "cell": "cell_1", "i": "i_1", "j": "j_1"}
 
-    # Prepare the target DataFrame with matched coordinates from dataset 0
+    # Prepare the matched rows from each dataset
     target = (
-        cell_locations_0.iloc[ix[filt]].reset_index(drop=True).rename(columns=columns_0)
+        cell_locations_0.iloc[ph_ix].reset_index(drop=True).rename(columns=columns_0)
+    )
+    source = (
+        cell_locations_1.iloc[sbs_ix]
+        .reset_index(drop=True)[list(columns_1.keys())]
+        .rename(columns=columns_1)
     )
 
-    # Merge DataFrames and calculate distances
-    return (
-        cell_locations_1[filt]
-        .reset_index(drop=True)[  # Filtered rows from dataset 1
-            list(columns_1.keys())
-        ]  # Select columns for dataset 1
-        .rename(columns=columns_1)  # Rename columns for dataset 1
-        .pipe(
-            lambda x: pd.concat([target, x], axis=1)
-        )  # Concatenate with target DataFrame
-        .assign(distance=np.sqrt(distances.min(axis=1))[filt])[
-            cols_final
-        ]  # Assign distance column  # Select final columns
-    )
+    # Concatenate matched rows and attach the pair distances
+    return pd.concat([target, source], axis=1).assign(distance=match_distances)[
+        cols_final
+    ]
+
+
+def match_cells(points_a, points_b, threshold):
+    """Mutual nearest-neighbor match between two point sets, enforcing a 1:1 pairing.
+
+    Keeps only pairs where each point is the other's nearest neighbor and within `threshold`,
+    so no cell within a tile is matched more than once. Ambiguous cells are dropped rather than
+    reassigned; cross-tile duplicates are resolved downstream by deduplication.
+
+    Args:
+        points_a (numpy.ndarray): Coordinates of the first set, shape (m, 2).
+        points_b (numpy.ndarray): Coordinates of the second set, shape (n, 2).
+        threshold (float): Maximum Euclidean distance for a valid match.
+
+    Returns:
+        tuple:
+            - numpy.ndarray: Indices into `points_a` of the matched points.
+            - numpy.ndarray: Indices into `points_b` of the matched points.
+            - numpy.ndarray: Euclidean distances of the matched pairs.
+    """
+    if len(points_a) == 0 or len(points_b) == 0:
+        empty = np.array([], dtype=int)
+        return empty, empty, np.array([])
+
+    distances = cdist(points_a, points_b, metric="sqeuclidean")
+    nearest_b = distances.argmin(axis=1)
+    nearest_a = distances.argmin(axis=0)
+    a_index = np.arange(len(points_a))
+
+    # Keep a pair only when a's nearest b has that same a as its own nearest neighbor
+    mutual = nearest_a[nearest_b] == a_index
+    match_distances = np.sqrt(distances[a_index, nearest_b])
+    keep = mutual & (match_distances < threshold)
+    return a_index[keep], nearest_b[keep], match_distances[keep]
 
 
 def build_linear_model(rotation, translation):

--- a/workflow/lib/merge/merge_utils.py
+++ b/workflow/lib/merge/merge_utils.py
@@ -15,12 +15,11 @@ import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import skimage.morphology
-from scipy.spatial.distance import cdist
 import matplotlib.colors as mcolors
 from skimage.measure import regionprops
 
 
-from lib.merge.fast_merge import build_linear_model, refine_local_warp
+from lib.merge.fast_merge import build_linear_model, refine_local_warp, match_cells
 
 
 def plot_combined_tile_grid(
@@ -187,169 +186,121 @@ def plot_merge_example(
             prediction before matching, matching the pipeline (`refine_local_warp`). Defaults None.
         warp_kwargs (dict | None, optional): Keyword args forwarded to `refine_local_warp`. Defaults None.
     """
-    # Create figure with three subplots
+    # Create the figure — three panels sharing one matched/unmatched coloring
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(30, 10))
 
-    # Filter for specific tile and site
+    # Filter for the specific tile and site
     df_ph_filtered = df_ph[df_ph["tile"] == alignment_vec["tile"]]
     df_sbs_filtered = df_sbs[df_sbs["tile"] == alignment_vec["site"]]
 
-    # Get coordinates
     X = df_ph_filtered[["i", "j"]].values
     Y = df_sbs_filtered[["i", "j"]].values
 
-    # Build model and predict
+    # Predict phenotype coordinates into SBS space, optionally warped (mirrors the pipeline)
     model = build_linear_model(alignment_vec["rotation"], alignment_vec["translation"])
     Y_pred = model.predict(X)
-
-    # Optional local warp; mirrors the pipeline so the preview reflects the levers
     if local_refinement:
         wk = dict(warp_kwargs or {})
         if isinstance(local_refinement, str):
             wk.setdefault("model", local_refinement)
         Y_pred = refine_local_warp(X, Y, Y_pred, threshold, **wk)
 
-    # Calculate distances
-    distances = cdist(Y, Y_pred, metric="sqeuclidean")
-    ix = distances.argmin(axis=1)
-    filt = np.sqrt(distances.min(axis=1)) < threshold
+    # Mutual nearest-neighbor match — the same 1:1 rule merge_sbs_phenotype uses
+    sbs_ix, ph_ix, match_distances = match_cells(Y, Y_pred, threshold)
+    n_ph, n_sbs, n_matched = len(X), len(Y), len(ph_ix)
+    matched_ph_mask = np.zeros(n_ph, dtype=bool)
+    matched_ph_mask[ph_ix] = True
+    n_unmatched = int((~matched_ph_mask).sum())
+    frac_ph = n_matched / n_ph if n_ph else 0.0
+    median_residual = float(np.median(match_distances)) if n_matched else float("nan")
+    doubles = n_matched - len(np.unique(ph_ix))
 
-    # Filter out Y_pred based on filt
-    Y_pred = Y_pred[ix[filt]]
+    # Header carries the merge stats so each preview is self-describing
+    fig.suptitle(
+        f"PH tile {alignment_vec['tile']} ↔ SBS site {alignment_vec['site']}   |   "
+        f"{n_matched} matched   |   {frac_ph * 100:.0f}% phenotype   |   "
+        f"{median_residual:.2f} px median residual   |   {doubles} doubles",
+        fontsize=16,
+    )
 
-    # Calculate statistics
-    n_ph = len(X)
-    n_sbs = len(Y)
-    n_matched = len(Y_pred)
-
-    # Plot 1: Original Scale
+    # Panel 1: matched/unmatched phenotype in the real SBS pixel frame, with residual segments
     ax1.scatter(
-        X[:, 0], X[:, 1], c="blue", s=20, alpha=0.5, label=f"Phenotype ({n_ph} points)"
+        Y[:, 0], Y[:, 1], c="lightgray", s=8, alpha=0.3, label=f"SBS field ({n_sbs})"
+    )
+    for k in range(n_matched):
+        p, q = Y_pred[ph_ix[k]], Y[sbs_ix[k]]
+        ax1.plot([p[0], q[0]], [p[1], q[1]], "k-", alpha=0.3, linewidth=0.5)
+    ax1.scatter(
+        Y_pred[matched_ph_mask, 0],
+        Y_pred[matched_ph_mask, 1],
+        c="#2f6fb0",
+        s=14,
+        alpha=0.7,
+        label=f"matched phenotype ({n_matched})",
     )
     ax1.scatter(
-        Y_pred[:, 0],
-        Y_pred[:, 1],
-        c="red",
-        s=20,
-        alpha=0.5,
-        label=f"Aligned SBS ({n_matched}) points)",
+        Y_pred[~matched_ph_mask, 0],
+        Y_pred[~matched_ph_mask, 1],
+        marker="*",
+        c="#e8b93a",
+        s=45,
+        alpha=0.9,
+        label=f"unmatched phenotype ({n_unmatched})",
     )
-    ax1.scatter(
-        Y[:, 0],
-        Y[:, 1],
-        c="green",
-        s=20,
-        alpha=0.5,
-        label=f"Original SBS ({n_sbs} points)",
-    )
+    ax1.set_aspect("equal")
+    ax1.set_title("Aligned overlay (SBS pixel space)")
+    ax1.legend(loc="upper right", fontsize=9)
 
-    # Draw lines between matched points that pass threshold
-    for i in range(len(Y)):
-        if filt[i]:
-            ax1.plot([X[ix[i], 0], Y[i, 0]], [X[ix[i], 1], Y[i, 1]], "k-", alpha=0.1)
-
-    ax1.set_title(
-        f"Original Scale View\nPH:{alignment_vec['tile']}, SBS:{alignment_vec['site']}"
-    )
-    ax1.legend()
-
-    # Plot 2: Scale PH values to SBS axis
+    # Normalize phenotype coordinates into the SBS field for the scaled panels
     X_norm = (X - X.min(axis=0)) / (X.max(axis=0) - X.min(axis=0))
+    X_scaled = (X_norm * (Y_pred.max(axis=0) - Y_pred.min(axis=0))) + Y_pred.min(axis=0)
 
-    # Get the range and minimum of aligned SBS points (Y_pred)
-    Y_pred_range = Y_pred.max(axis=0) - Y_pred.min(axis=0)
-    Y_pred_min = Y_pred.min(axis=0)
-
-    # Scale and translate phenotype points to align with SBS field
-    X_scaled = (X_norm * Y_pred_range) + Y_pred_min
-
+    # Panel 2: normalized overlap of phenotype on the SBS field
     ax2.scatter(
-        Y[:, 0],
-        Y[:, 1],
-        c="lightgray",
-        s=20,
-        alpha=0.1,
-        label=f"SBS Field ({n_sbs} points)",
+        Y[:, 0], Y[:, 1], c="lightgray", s=12, alpha=0.15, label=f"SBS field ({n_sbs})"
     )
     ax2.scatter(
-        Y_pred[:, 0],
-        Y_pred[:, 1],
-        c="red",
-        s=20,
-        alpha=0.25,
-        label=f"Aligned SBS ({n_matched} points)",
+        Y_pred[matched_ph_mask, 0],
+        Y_pred[matched_ph_mask, 1],
+        c="#c0392b",
+        s=14,
+        alpha=0.3,
+        label=f"aligned SBS matches ({n_matched})",
     )
     ax2.scatter(
         X_scaled[:, 0],
         X_scaled[:, 1],
-        c="blue",
-        s=20,
+        c="#2f6fb0",
+        s=14,
         alpha=0.25,
-        label=f"Phenotype ({n_ph} points)",
+        label=f"phenotype ({n_ph})",
     )
+    ax2.set_title("Normalized phenotype relative to SBS")
+    ax2.legend(loc="upper right", fontsize=9)
 
-    ax2.set_title("Normalized Scale For PH Points Relative to SBS")
-    ax2.legend()
-
-    # Plot 3: Scale PH values to SBS axis
-    X_norm = (X - X.min(axis=0)) / (X.max(axis=0) - X.min(axis=0))
-    # Get the range and minimum of aligned SBS points (Y_pred)
-    Y_pred_range = Y_pred.max(axis=0) - Y_pred.min(axis=0)
-    Y_pred_min = Y_pred.min(axis=0)
-    # Scale and translate phenotype points to align with SBS field
-    X_scaled = (X_norm * Y_pred_range) + Y_pred_min
-    # Find unmatched phenotype points
-    matched_ph_ix = np.unique(ix[filt])
-    unmatched_ph_mask = ~np.isin(np.arange(len(X)), matched_ph_ix)
-    # Plot SBS field and aligned points
+    # Panel 3: matched vs unmatched phenotype in the normalized frame (no per-cell labels)
     ax3.scatter(
-        Y[:, 0],
-        Y[:, 1],
-        c="lightgray",
-        s=20,
-        alpha=0.1,
-        label=f"SBS Field ({n_sbs} points)",
+        Y[:, 0], Y[:, 1], c="lightgray", s=12, alpha=0.15, label=f"SBS field ({n_sbs})"
     )
     ax3.scatter(
-        Y_pred[:, 0],
-        Y_pred[:, 1],
-        c="red",
-        s=20,
-        alpha=0.25,
-        label=f"Aligned SBS ({n_matched} points)",
+        X_scaled[matched_ph_mask, 0],
+        X_scaled[matched_ph_mask, 1],
+        c="#2f6fb0",
+        s=14,
+        alpha=0.35,
+        label=f"matched phenotype ({n_matched})",
     )
-    # Plot matched phenotype points in blue
     ax3.scatter(
-        X_scaled[~unmatched_ph_mask][:, 0],
-        X_scaled[~unmatched_ph_mask][:, 1],
-        c="blue",
-        s=20,
-        alpha=0.25,
-        label=f"Matched Phenotype ({n_matched} points)",
-    )
-    # Plot unmatched phenotype points in yellow with star marker
-    ax3.scatter(
-        X_scaled[unmatched_ph_mask][:, 0],
-        X_scaled[unmatched_ph_mask][:, 1],
+        X_scaled[~matched_ph_mask, 0],
+        X_scaled[~matched_ph_mask, 1],
         marker="*",
-        c="yellow",
-        s=100,
-        alpha=1,
-        label=f"Unmatched Phenotype ({sum(unmatched_ph_mask)} points)",
+        c="#e8b93a",
+        s=60,
+        alpha=0.9,
+        label=f"unmatched phenotype ({n_unmatched})",
     )
-    # Optionally add labels for unmatched points
-    for i in np.where(unmatched_ph_mask)[0]:
-        ax3.annotate(
-            f"Cell {i}",
-            (X_scaled[i, 0], X_scaled[i, 1]),
-            xytext=(10, 10),
-            textcoords="offset points",
-            bbox=dict(boxstyle="round", fc="white", alpha=0.7),
-        )
-    ax3.set_title(
-        "Normalized Scale For PH Points Relative to SBS (with unmatched points)"
-    )
-    ax3.legend()
+    ax3.set_title("Matched vs unmatched phenotype")
+    ax3.legend(loc="upper right", fontsize=9)
 
     plt.tight_layout()
     plt.show()
@@ -710,6 +661,43 @@ def find_closest_tiles(sbs_metadata, ph_metadata, sbs_tile_id, verbose=True):
             print(f"  Tile {row['tile']}: Distance = {row['distance']:.2f}")
 
     return result.sort_values("distance")
+
+
+def filter_low_score_seeds(pairs_df, score_col="score", k=3.0, min_keep=5):
+    """Drop initial-site seeds whose score is a low outlier relative to the cohort.
+
+    The alignment score's absolute scale varies by screen, so this uses a robust relative
+    cut (median and MAD) rather than a fixed floor: a seed is dropped only if its score is
+    more than `k` robust standard deviations below the median. At least `min_keep` seeds are
+    always retained (falling back to the top-scoring ones) so filtering can never push a well
+    below the minimum the pipeline requires.
+
+    Args:
+        pairs_df (pandas.DataFrame): Candidate seed pairs with a score column.
+        score_col (str, optional): Name of the score column. Defaults to "score".
+        k (float, optional): Number of robust standard deviations below the median at which a
+            seed is considered a low outlier. Defaults to 3.0.
+        min_keep (int, optional): Minimum number of seeds to retain. Defaults to 5.
+
+    Returns:
+        pandas.DataFrame: The retained seed pairs.
+    """
+    if len(pairs_df) <= min_keep:
+        return pairs_df
+
+    scores = pairs_df[score_col].to_numpy()
+    median = np.median(scores)
+    mad = np.median(np.abs(scores - median))
+    if mad == 0:
+        return pairs_df
+
+    threshold = median - k * 1.4826 * mad
+    kept = pairs_df[pairs_df[score_col] >= threshold]
+
+    # Never filter below the minimum the pipeline needs — keep the best-scoring seeds instead
+    if len(kept) < min_keep:
+        kept = pairs_df.sort_values(score_col, ascending=False).head(min_keep)
+    return kept
 
 
 def fast_merge_example(

--- a/workflow/scripts/merge/fast_alignment.py
+++ b/workflow/scripts/merge/fast_alignment.py
@@ -6,7 +6,11 @@ from lib.merge.hash import (
     extract_rotation,
     initial_alignment,
 )
-from lib.merge.merge_utils import align_metadata, find_closest_tiles
+from lib.merge.merge_utils import (
+    align_metadata,
+    find_closest_tiles,
+    filter_low_score_seeds,
+)
 
 # Load dfs with metadata on well level
 phenotype_metadata = validate_dtypes(pd.read_parquet(snakemake.input[0]))
@@ -168,6 +172,15 @@ if seed_optimize:
     ).drop_duplicates(subset="site", keep="first")
     print(
         f"seed_optimize: kept best-scoring tile per site ({n_before} -> {len(valid_pairs_df)})"
+    )
+
+# Drop seeds whose score is a low outlier relative to the cohort (keeps >= 5)
+n_before = len(valid_pairs_df)
+valid_pairs_df = filter_low_score_seeds(valid_pairs_df)
+if len(valid_pairs_df) < n_before:
+    print(
+        f"filtered {n_before - len(valid_pairs_df)} low-score outlier seed(s) "
+        f"({n_before} -> {len(valid_pairs_df)})"
     )
 
 # Require minimum 5 valid pairs (only if > 5 candidates were provided)

--- a/workflow/targets/sbs.smk
+++ b/workflow/targets/sbs.smk
@@ -180,7 +180,7 @@ SBS_OUTPUTS = {
 }
 
 SBS_OUTPUT_MAPPINGS = {
-    "align_sbs": temp,
+    "align_sbs": None,
     "log_filter": temp,
     "compute_standard_deviation": temp,
     "find_peaks": temp,


### PR DESCRIPTION
## Summary
Three merge/stitch improvements. Backward compatible — no config changes required. Gated by the full `small_test_analysis` pipeline (2173/2173 steps, exit 0).

### Within-tile 1:1 matching (mutual nearest-neighbor)
`merge_sbs_phenotype` and the `plot_merge_example` preview now share a `match_cells()` helper that enforces **mutual nearest-neighbor** matching, so no cell within a tile is matched more than once. Cross-tile duplicates remain resolved downstream by deduplication. The preview figure is also redesigned: a common-frame overlay (no cross-coordinate fan-lines), per-cell labels removed, and a stats header (matched / % phenotype / median residual / doubles).

### Low-score seed filtering
`filter_low_score_seeds()` drops initial-site seeds whose alignment score is a low outlier relative to the cohort (median/MAD, k=3), always keeping >= 5. Wired into `fast_alignment.py` after the best-per-site collapse. Uses a relative cut rather than a fixed floor because the score's absolute scale is screen-dependent.

### Persist aligned SBS (stitch fix)
`align_sbs` output is no longer wrapped in `temp()`, so the stitch merge can read the aligned SBS tiles (previously deleted after use). This matches the phenotype side, which already persisted its aligned/segmented images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)