### PR TITLE
fix(aggregate): construct-ID handling, collapse_cols guard, configurable bootstrap features

### DIFF
--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -123,11 +123,14 @@ def channel_combo_subset(features, channel_combo, all_channels):
     return features[columns_to_keep]
 
 
-def get_feature_table_cols(feature_cols):
+def get_feature_table_cols(feature_cols, extra_tags=None):
     """Filter feature columns based on specific tags and compartments.
 
     Args:
         feature_cols (list): List of feature column names.
+        extra_tags (list, optional): Additional substring tags to include on top of
+            the default nucleus/cell subset. Any column whose name contains one of
+            these tags (e.g. "radial_cv", "frac_at_d") is added. Defaults to None.
 
     Returns:
         list: Filtered list of feature column names.
@@ -144,6 +147,7 @@ def get_feature_table_cols(feature_cols):
     ]
     shape_tags = ["area", "solidity", "form_factor", "eccentricity"]
     overlap_tags = ["manders"]
+    extra_tags = [tag.lower() for tag in extra_tags] if extra_tags else []
 
     # Define the specific compartments to look for
     compartments = ["nucleus", "cell"]
@@ -152,6 +156,7 @@ def get_feature_table_cols(feature_cols):
     intensity_cols = []
     shape_cols = []
     overlap_cols = []
+    extra_cols = []
 
     # Filter columns based on compartments and tags
     for col in feature_cols:
@@ -169,6 +174,10 @@ def get_feature_table_cols(feature_cols):
             elif any(tag in col.lower() for tag in overlap_tags):
                 overlap_cols.append(col)
 
+            # Extra user-requested features - substring match anywhere in string
+            elif any(tag in col.lower() for tag in extra_tags):
+                extra_cols.append(col)
+
     # Create a new DataFrame with selected columns, preserving the label column if it exists
     selected_columns = []
     if "label" in feature_cols:
@@ -178,5 +187,6 @@ def get_feature_table_cols(feature_cols):
     selected_columns.extend(intensity_cols)
     selected_columns.extend(shape_cols)
     selected_columns.extend(overlap_cols)
+    selected_columns.extend(extra_cols)
 
     return selected_columns

--- a/workflow/lib/aggregate/eval_aggregate.py
+++ b/workflow/lib/aggregate/eval_aggregate.py
@@ -78,7 +78,7 @@ def summarize_cell_data(
         class_subset = cell_data[cell_data["class"] == class_name]
         counts.append((f"{class_name} cells", len(class_subset)))
 
-        for col in collapse_cols:
+        for col in collapse_cols or []:
             counts.append((f"{class_name} {col}", class_subset[col].nunique()))
 
     summary_df = pd.DataFrame(counts, columns=["Stage", "Count"])

--- a/workflow/lib/external/CP_EMULATOR_FEATURES.md
+++ b/workflow/lib/external/CP_EMULATOR_FEATURES.md
@@ -248,6 +248,35 @@ These parameters control granularity spectrum computation (computationally expen
 
 ---
 
+## Bootstrap Feature Selection
+
+Not every feature documented above is tested by the aggregate bootstrap. By default, `get_feature_table_cols` (`workflow/lib/aggregate/cell_data_utils.py`) selects a curated subset and everything else is silently dropped.
+
+**Compartment gate:** only columns belonging to the `nucleus` or `cell` compartments are considered. Other compartments (e.g. `cytoplasm`) are excluded regardless of feature type.
+
+**Included by default:**
+
+| Category | Match rule | Features |
+|----------|------------|----------|
+| Intensity | name **ends with** | `mean`, `int`, `mass_displacement`, `mean_edge`, `std_edge`, `mean_frac_0`, `mean_frac_3` |
+| Shape | name **ends with** | `area`, `solidity`, `form_factor`, `eccentricity` |
+| Overlap | substring **anywhere** | `manders` |
+
+**Excluded by default:** texture (PFTAS and Haralick), granularity, most intensity-distribution features, Zernike and Hu moments, radius and Feret diameter, neighbor features, foci features, and every non-`nucleus`/`cell` compartment.
+
+Note the intensity-distribution set is included only partially: `mean_frac_0` and `mean_frac_3` are kept, while `mean_frac_1`, `mean_frac_2`, all `frac_at_d_*`, and all `radial_cv_*` are not.
+
+**Extending the default set** — `aggregate.bootstrap_extra_features` in `config.yml` (`BOOTSTRAP_EXTRA_FEATURES` in notebook 8) additively includes any feature whose name contains one of the given substrings:
+
+```yaml
+aggregate:
+  bootstrap_extra_features: ["radial_cv", "frac_at_d"]
+```
+
+**Replacing the default set** — `aggregate.bootstrap_features_fp` points to a file listing exact feature names, one per line. This bypasses the curated subset and the compartment gate entirely.
+
+---
+
 ## References
 
 - Haralick RM, Shanmugam K, Dinstein I. (1973) "Textural Features for Image Classification" IEEE Trans. SMC 3(6):610-621

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -252,6 +252,7 @@ checkpoint prepare_bootstrap_data:
         control_key=config["aggregate"]["control_key"],
         exclusion_string=config.get("aggregate", {}).get("exclusion_string", None),
         bootstrap_features_fp=config.get("aggregate", {}).get("bootstrap_features_fp", None),
+        bootstrap_extra_features=config.get("aggregate", {}).get("bootstrap_extra_features", None),
     script:
         "../scripts/aggregate/prepare_bootstrap_data.py"
 
@@ -311,6 +312,7 @@ rule bootstrap_gene:
             construct="{construct}"
         ),
         bootstrap_features_fp=config.get("aggregate", {}).get("bootstrap_features_fp", None),
+        bootstrap_extra_features=config.get("aggregate", {}).get("bootstrap_extra_features", None),
     script:
         "../scripts/aggregate/bootstrap_gene.py"
 

--- a/workflow/scripts/aggregate/bootstrap_gene.py
+++ b/workflow/scripts/aggregate/bootstrap_gene.py
@@ -14,6 +14,7 @@ cell_class = snakemake.wildcards.cell_class
 channel_combo = snakemake.wildcards.channel_combo
 num_sims = snakemake.params.num_sims
 bootstrap_features_fp = snakemake.params.get("bootstrap_features_fp", None)
+bootstrap_extra_features = snakemake.params.get("bootstrap_extra_features", None)
 
 print(f"Running gene-level bootstrap aggregation for: {gene_id}")
 
@@ -64,7 +65,9 @@ if bootstrap_features_fp is not None:
     available_features = [f for f in requested_features if f in all_features]
 else:
     # Use get_feature_table_cols to filter to nucleus/cell intensity, shape, and overlap features
-    available_features = get_feature_table_cols(all_features)
+    available_features = get_feature_table_cols(
+        all_features, extra_tags=bootstrap_extra_features
+    )
 
 print(f"Using {len(available_features)} features for bootstrap analysis")
 

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -195,9 +195,7 @@ gc.collect()
 construct_table = pd.DataFrame(construct_rows)
 
 # Reorder columns: sgRNA, gene, cell_count, features
-# When perturbation_id_col is unset, pert_id_col falls back to pert_col; list it
-# once to avoid a duplicate column (which turns construct_table[pert_col] into a
-# DataFrame and breaks the .str accessor below).
+# List the label column once when the id and name columns coincide
 label_cols = [pert_id_col, pert_col] if pert_id_col != pert_col else [pert_col]
 construct_columns = label_cols + ["cell_count"] + feature_cols
 construct_table = construct_table[construct_columns]

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -186,7 +186,11 @@ gc.collect()
 construct_table = pd.DataFrame(construct_rows)
 
 # Reorder columns: sgRNA, gene, cell_count, features
-construct_columns = [pert_id_col, pert_col, "cell_count"] + feature_cols
+# When perturbation_id_col is unset, pert_id_col falls back to pert_col; list it
+# once to avoid a duplicate column (which turns construct_table[pert_col] into a
+# DataFrame and breaks the .str accessor below).
+label_cols = [pert_id_col, pert_col] if pert_id_col != pert_col else [pert_col]
+construct_columns = label_cols + ["cell_count"] + feature_cols
 construct_table = construct_table[construct_columns]
 
 print(f"Construct table shape: {construct_table.shape}")

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -16,6 +16,15 @@ from lib.aggregate.bootstrap import create_pseudogene_groups
 pert_col = snakemake.params.perturbation_name_col
 pert_id_col = snakemake.params.perturbation_id_col or pert_col
 control_key = snakemake.params.control_key
+
+if pert_id_col == pert_col:
+    print(
+        f"WARNING: perturbation_id_col is not set, so '{pert_col}' is being used as "
+        "the construct ID. Constructs collapse to gene level, which leaves a single "
+        "control construct and a bootstrap null that lacks construct-level variance "
+        "(p-values will be under-dispersed). Set perturbation_id_col to your "
+        "construct column (e.g. cell_barcode_0 or sgRNA_0)."
+    )
 num_batches = snakemake.params.get("num_align_batches", 1)
 
 # Load cell data using PyArrow dataset (lazy - no data loaded yet)

--- a/workflow/scripts/aggregate/prepare_bootstrap_data.py
+++ b/workflow/scripts/aggregate/prepare_bootstrap_data.py
@@ -20,6 +20,7 @@ control_key = snakemake.params.control_key
 exclusion_string = snakemake.params.exclusion_string
 metadata_cols_fp = snakemake.params.metadata_cols_fp
 bootstrap_features_fp = snakemake.params.get("bootstrap_features_fp", None)
+bootstrap_extra_features = snakemake.params.get("bootstrap_extra_features", None)
 
 print("Loading single-cell features data...")
 all_features_cells = pd.read_parquet(snakemake.input.features_singlecell)
@@ -80,7 +81,11 @@ if bootstrap_features_fp is not None:
 else:
     # Use get_feature_table_cols to filter to nucleus/cell intensity, shape, and overlap features
     print("Using default feature filtering (nucleus/cell: intensity, shape, overlap)")
-    available_features = get_feature_table_cols(all_features)
+    if bootstrap_extra_features:
+        print(f"Adding extra feature tags: {bootstrap_extra_features}")
+    available_features = get_feature_table_cols(
+        all_features, extra_tags=bootstrap_extra_features
+    )
 
 print(
     f"Using {len(available_features)} features for bootstrap analysis (from {len(all_features)} total)"


### PR DESCRIPTION
Three small, backward-compatible aggregate-module changes.

## 1. `perturbation_id_col` unset → duplicate column crash

When `perturbation_id_col` is `null`, `pert_id_col` falls back to `perturbation_name_col`, so the label column got listed twice:
```python
construct_columns = [pert_id_col, pert_col, "cell_count"] + feature_cols
#                  = ["gene_symbol_0", "gene_symbol_0", ...]   ← duplicate
construct_table = construct_table[construct_columns]
... construct_table[pert_col].str.contains(control_key)  # DataFrame, not Series
# AttributeError: 'DataFrame' object has no attribute 'str'
```
Fixed by listing the label column once when the id and name columns coincide. When a distinct `perturbation_id_col` is set, the column list is unchanged.

**Scope:** this only fires on `perturbation_id_col: null`. All 16 configured screens set it (`cell_barcode_0` or `sgRNA_0`), so no existing screen hits this — it is a latent crash on a documented-but-unused setting, not a fleet-wide breakage.

**Importantly, the fix alone is not sufficient.** Making that path merely *run* is worse than crashing: constructs collapse to gene level, all controls become a **single construct**, and the bootstrap null loses construct-to-construct variance — yielding under-dispersed p-values with no signal that anything is wrong. So this PR also emits a loud warning when the fallback triggers, naming the column to set. (The accompanying notebook PR rewrites the misleading docstring and changes the default to `cell_barcode_0`.)

## 2. `summarize_cell_data` crashes when `collapse_cols=None`

`COLLAPSE_COLS` defaults to `None` in the config notebook, but `summarize_cell_data` iterated it unconditionally → `TypeError: 'NoneType' object is not iterable`. Guarded with `for col in collapse_cols or []`.

## 3. Configurable extra bootstrap features

The bootstrap feature set was a hardcoded curated subset (`get_feature_table_cols`), with only an all-or-nothing exact override (`bootstrap_features_fp`) that required enumerating every default feature by hand. Added `get_feature_table_cols(extra_tags=...)` to *additively* include features whose name contains any user tag, plus an optional `aggregate.bootstrap_extra_features` config key threaded through `prepare_bootstrap_data` and `bootstrap_gene`.

Motivating case: including radial metrics (`radial_cv`, `frac_at_d`) alongside the defaults — see #230.

## Compatibility

`extra_tags=None` reproduces the previous feature set exactly; the two guards only activate on the `None` values that previously crashed; the warning is print-only. Verified the default feature list is unchanged and that a distinct `perturbation_id_col` produces a byte-identical column list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
