### PR TITLE
feat(cluster): species-parameterize CORUM + MSigDB benchmark generation (#238)

### DIFF
--- a/workflow/lib/cluster/scrape_benchmarks.py
+++ b/workflow/lib/cluster/scrape_benchmarks.py
@@ -8,7 +8,7 @@ gene benchmarks for use in enrichment and precision-recall analyses.
 Key functions:
     - generate_string_pair_benchmark: Create gene pair benchmarks from STRING interactions.
     - generate_corum_group_benchmark: Extract gene complexes from CORUM.
-    - generate_msigdb_group_benchmark: Convert MSigDB KEGG pathways to gene group format.
+    - generate_msigdb_group_benchmark: Convert MSigDB canonical pathways to gene group format.
     - get_uniprot_data: Retrieve UniProt gene and annotation data.
     - get_corum_data / get_string_data: Download raw benchmark inputs.
     - select_gene_variants: Harmonize variant gene names with clustering outputs.
@@ -26,6 +26,15 @@ from pathlib import Path
 
 _REQUEST_HEADERS = {
     "User-Agent": "brieflow/1.5 (+https://github.com/cheeseman-lab/brieflow)"
+}
+
+# CORUM organism labels keyed by NCBI taxonomy ID, used to filter the complete export.
+_CORUM_ORGANISM_BY_SPECIES = {"9606": "Human", "10090": "Mouse", "10116": "Rat"}
+
+# Per-species MSigDB canonical-pathway collection (mouse has no native KEGG, so Reactome is used).
+_MSIGDB_CP_COLLECTION_BY_SPECIES = {
+    "9606": "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2024.1.Hs/c2.cp.kegg_medicus.v2024.1.Hs.json",
+    "10090": "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2024.1.Mm/m2.cp.reactome.v2024.1.Mm.json",
 }
 
 import pandas as pd
@@ -99,16 +108,19 @@ def generate_string_pair_benchmark(
     return string_pair_benchmark
 
 
-def generate_corum_group_benchmark():
+def generate_corum_group_benchmark(species_id="9606"):
     """Generate a CORUM group benchmark DataFrame.
 
     This function processes CORUM data to create a benchmark DataFrame with gene names
     and their associated protein complexes.
 
+    Args:
+        species_id (str, optional): NCBI taxonomy ID for the organism. Defaults to "9606" (human).
+
     Returns:
         pd.DataFrame: A DataFrame containing the CORUM group benchmark.
     """
-    corum_data = get_corum_data()
+    corum_data = get_corum_data(species_id)
 
     # Create the new dataframe with columns for gene_name and complex
     benchmark_rows = []
@@ -130,20 +142,29 @@ def generate_corum_group_benchmark():
     return corum_cluster_benchmark
 
 
-def generate_msigdb_group_benchmark(
-    url="https://data.broadinstitute.org/gsea-msigdb/msigdb/release/2024.1.Hs/c2.cp.kegg_medicus.v2024.1.Hs.json",
-):
+def generate_msigdb_group_benchmark(species_id="9606", url=None):
     """Generate a group benchmark from MSigDB data.
 
     This function fetches pathway data from the Molecular Signatures Database (MSigDB)
     and creates a benchmark DataFrame with gene names and their associated pathways.
+    Human uses the KEGG MEDICUS collection; mouse has no native KEGG collection, so the
+    native mouse Reactome collection is used instead.
 
     Args:
-        url (str, optional): The URL to fetch MSigDB data. Defaults to the KEGG Medicus pathway.
+        species_id (str, optional): NCBI taxonomy ID for the organism. Defaults to "9606" (human).
+        url (str, optional): Explicit MSigDB JSON URL. Overrides the per-species default when set.
 
     Returns:
         pd.DataFrame: A DataFrame containing the MSigDB group benchmark.
     """
+    if url is None:
+        if species_id not in _MSIGDB_CP_COLLECTION_BY_SPECIES:
+            raise ValueError(
+                f"No MSigDB canonical-pathway collection configured for species_id {species_id}; "
+                "pass an explicit url."
+            )
+        url = _MSIGDB_CP_COLLECTION_BY_SPECIES[species_id]
+
     response = requests.get(url, headers=_REQUEST_HEADERS)
     msigdb_data = json.loads(response.text)
 
@@ -274,26 +295,41 @@ def get_uniprot_data(species_id: str = "9606", cache_path: str = None):
     return df
 
 
-def get_corum_data():
-    """Fetch CORUM complex data for human proteins.
+def get_corum_data(species_id="9606"):
+    """Fetch CORUM complex data for a specified species.
 
-    This function retrieves CORUM data for human protein complexes and processes it
-    into a DataFrame.
+    This function retrieves CORUM protein complex data and processes it into a DataFrame.
+    Human uses the native human export; other species are filtered out of the complete
+    export by organism (CORUM has no per-organism download for them).
+
+    Args:
+        species_id (str): NCBI taxonomy ID for the organism. Defaults to "9606" (human).
+                         Common species IDs:
+                         - "9606": Homo sapiens (human)
+                         - "10090": Mus musculus (mouse)
+                         - "10116": Rattus norvegicus (rat)
 
     Returns:
         pd.DataFrame: A DataFrame containing CORUM complex data.
     """
+    organism = _CORUM_ORGANISM_BY_SPECIES.get(species_id)
+    if organism is None:
+        raise ValueError(f"No CORUM organism configured for species_id {species_id}")
+
     print("Fetching CORUM data...")
     url = "https://mips.helmholtz-muenchen.de/fastapi-corum/public/file/download_current_file"
 
-    # Parameters for human complexes in text format
-    params = {"file_id": "human", "file_format": "txt"}
+    # Human has a native export; other species are filtered out of the complete export.
+    file_id = "human" if species_id == "9606" else "complete"
+    params = {"file_id": file_id, "file_format": "txt"}
 
     response = requests.get(url, params=params, verify=False, headers=_REQUEST_HEADERS)
     response.raise_for_status()
 
     # Read data into DataFrame
     df = pd.read_csv(io.StringIO(response.text), sep="\t")
+    if species_id != "9606":
+        df = df[df["organism"] == organism].reset_index(drop=True)
     print(f"Completed. Total complexes: {len(df)}")
     return df
 


### PR DESCRIPTION
## Summary

Cluster benchmark generation (`workflow/lib/cluster/scrape_benchmarks.py`) hardwired human sources, so mouse (and other non-human) screens could not build the CORUM/KEGG group validators. Closes #238.

- **CORUM** (`get_corum_data` / `generate_corum_group_benchmark`): now accept `species_id`. Human keeps its native `file_id=human` export **unchanged** (zero regression); other species are pulled from the CORUM `complete` export and filtered by the `organism` column (CORUM has no per-organism download for them).
- **MSigDB** (`generate_msigdb_group_benchmark`): now accepts `species_id` and resolves the collection per species. Human = KEGG MEDICUS (unchanged). Mouse has **no native KEGG collection in MSigDB**, so the native mouse **Reactome** collection is used. An explicit `url` still overrides.
- **STRING** and **UniProt** generators were already `species_id`-aware — no change; the companion analysis PR just starts passing them the species.

## Note on the mouse "KEGG" slot

For mouse, the second group validator is native Reactome data occupying the slot named `kegg_group_benchmark`. This was a deliberate choice (native mouse pathways, no orthology inference) over orthology-converting human KEGG. Functionally it is a valid pathway group benchmark; the name is retained to avoid churn in config keys and downstream labels.

## Verification

Live smoke test (not covered by `small_test_analysis`, which reads static committed TSVs and never invokes these generators):
- CORUM human path byte-identical request → 5,628 complexes (unchanged).
- CORUM mouse → 1,333 complexes → 3,893 rows / 1,322 groups (matches an independent native-mouse rebuild).
- MSigDB mouse → native Reactome groups.
- `ruff check` + `ruff format --check` clean.
