### PR TITLE
feat(preprocess): Opera Phenix support — numeric wells, wildcard constraints, file-type metadata reader

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,8 +19,11 @@ IMG_FMT = config.get("all", {}).get("image_format", "tiff")
 #     row="[A-Za-z]+",
 #     col="[0-9]+",
 wildcard_constraints:
-    row=r"[A-Za-z]+",
-    col=r"[0-9]+",
+    # Accept both plate-well style (row=letters "A", col=digits "1") AND Opera Phenix
+    # numeric wells (row="r02", col="c02"). Segments are "/"-delimited in paths so
+    # widening these does not introduce cross-wildcard ambiguity.
+    row=r"[A-Za-z]+\d*",
+    col=r"[A-Za-z]*\d+",
     tile=r"[0-9]+",
     plate=r"[0-9]+",
 

--- a/workflow/lib/preprocess/preprocess.py
+++ b/workflow/lib/preprocess/preprocess.py
@@ -287,8 +287,9 @@ def extract_metadata_tiff(
     """Extract metadata for TIFF files using external metadata file.
 
     TIFF files don't contain position metadata in their headers, so this function
-    reads from an external CSV/TSV file containing stage positions and other metadata.
-    The function handles various column naming conventions and unit conversions.
+    reads from an external file containing stage positions and other metadata,
+    dispatching on file type (.csv, .xml Opera Phenix Index, else TSV). The function
+    handles various column naming conventions and unit conversions.
 
     Args:
         file_path: Path to the TIFF file
@@ -297,7 +298,7 @@ def extract_metadata_tiff(
         tile: Tile/FOV number
         cycle: Optional cycle number
         round: Optional round number
-        metadata_file_path: Path to CSV/TSV with position metadata
+        metadata_file_path: Path to a position-metadata file (.csv / .tsv / Phenix .xml)
         verbose: Print debug information
 
     Returns:
@@ -308,9 +309,11 @@ def extract_metadata_tiff(
             print(f"Reading metadata from: {metadata_file_path}")
 
         try:
-            # Read metadata file
+            # Read metadata file, dispatching on its type
             if metadata_file_path.endswith(".csv"):
                 metadata_df = pd.read_csv(metadata_file_path)
+            elif metadata_file_path.endswith(".xml"):
+                metadata_df = read_phenix_index_xml(metadata_file_path)
             else:  # assume TSV
                 metadata_df = pd.read_csv(metadata_file_path, sep="\t")
 
@@ -403,6 +406,17 @@ def extract_metadata_tiff(
                     if name in metadata_df.columns:
                         return name
                 return None
+
+            # Narrow an all-tiles metadata table to this FOV (no-op for per-tile files)
+            _wc = find_column("well")
+            _tc = find_column("tile")
+            _cc = find_column("cycle")
+            if _wc and well is not None:
+                metadata_df = metadata_df[metadata_df[_wc].astype(str) == str(well)]
+            if _tc and tile is not None:
+                metadata_df = metadata_df[metadata_df[_tc].astype(str) == str(tile)]
+            if _cc and cycle is not None:
+                metadata_df = metadata_df[metadata_df[_cc].astype(str) == str(cycle)]
 
             # Convert entire dataframe to standardized format
             metadata_rows = []
@@ -899,6 +913,43 @@ def convert_tiff_to_array(
             )
 
     return result.astype(np.uint16)
+
+
+def read_phenix_index_xml(index_fp):
+    """Read Opera Phenix `Index.xml` stage positions into an external-metadata table.
+
+    Maps each `<Image>` `URL` (filename `rNNcNNfNN...`) to its well (`rNNcNN`) and tile
+    (`fNN`), converting `PositionX/Y` from meters to micrometers. Returns columns
+    `well, tile, x_pos, y_pos`; empty DataFrame if the file holds no readable positions.
+
+    Args:
+        index_fp (str | Path): Path to a single Opera Phenix `Index.xml`.
+
+    Returns:
+        pd.DataFrame: per-FOV stage positions.
+    """
+    with open(index_fp, encoding="utf-8", errors="ignore") as fh:
+        xml = fh.read()
+    rows = []
+    for block in re.finditer(r"<Image[ >].*?</Image>", xml, re.S):
+        b = block.group(0)
+        url = re.search(r"<URL>([^<]*)</URL>", b)
+        pos_x = re.search(r"<PositionX[^>]*>([^<]*)</PositionX>", b)
+        pos_y = re.search(r"<PositionY[^>]*>([^<]*)</PositionY>", b)
+        if not (url and pos_x and pos_y):
+            continue
+        wt = re.match(r"(r\d+c\d+)f(\d+)", url.group(1))
+        if not wt:
+            continue
+        rows.append({
+            "well": wt.group(1),
+            "tile": int(wt.group(2)),
+            "x_pos": float(pos_x.group(1)) * 1e6,
+            "y_pos": float(pos_y.group(1)) * 1e6,
+        })
+    if not rows:
+        return pd.DataFrame(columns=["well", "tile", "x_pos", "y_pos"])
+    return pd.DataFrame(rows).drop_duplicates(subset=["well", "tile"]).reset_index(drop=True)
 
 
 def extract_metadata(

--- a/workflow/lib/shared/file_utils.py
+++ b/workflow/lib/shared/file_utils.py
@@ -438,10 +438,16 @@ def split_well_to_cols(df):
         pd.DataFrame: Copy with ``row`` and ``col`` columns added.
     """
     if len(df) > 0 and "well" in df.columns:
-        splits = df["well"].str.extract(r"^([A-Za-z]+)(\d+)$")
         df = df.copy()
-        df["row"] = splits[0].values
-        df["col"] = splits[1].values
+        w = df["well"].astype(str)
+        # A1 / B12 style: alphabetic row + numeric col.
+        splits = w.str.extract(r"^([A-Za-z]+)(\d+)$")
+        # Opera Phenix rNNcNN style: numeric row AND col. Keep the r/c prefixes so
+        # get_well_from_wildcards' str(row)+str(col) round-trips to the original well
+        # (e.g. "r02c02" -> row="r02", col="c02" -> "r02c02").
+        phenix = w.str.extract(r"^([Rr]\d+)([Cc]\d+)$")
+        df["row"] = splits[0].fillna(phenix[0]).values
+        df["col"] = splits[1].fillna(phenix[1]).values
     return df
 
 


### PR DESCRIPTION
Adds the brieflow-side support to run an Opera Phenix optical pooled screen end-to-end. Three self-contained commits, each surfaced bringing up a real 2-color Phenix screen (zargun):

1. **Numeric-well split** (`split_well_to_cols`) — Phenix wells are `rNNcNN` (e.g. `r02c02`), not plate-well `A1`. Added a `^([Rr]\d+)([Cc]\d+)$` fallback yielding `row=r02, col=c02` that round-trips through `get_well_from_wildcards`.
2. **Wildcard constraints** (`Snakefile`) — widened `row`/`col` to accept both `A1`-style and `rNNcNN`-style wells without cross-wildcard ambiguity (path segments are `/`-delimited).
3. **File-type-dispatched TIFF metadata reader** (`extract_metadata_tiff`) — the function already branched `.csv` vs TSV; added `.xml` → `read_phenix_index_xml` (parses one Opera Phenix `Index.xml`: `<Image>` `URL` → well/tile, `PositionX/Y` m → µm). A generic `(well, tile, cycle)` filter then narrows an all-tiles table to the requested FOV, so one coarse inventory row per `Index.xml` serves every tile. Nothing in the flow is Phenix-specific beyond the xml reader itself — it sits parallel to `pd.read_csv`, and the metadata file's extension is the only switch. Notebooks stay stock; a Phenix screen is configured by pointing the metadata path pattern at `Index.xml`.

Without (3), TIFF position metadata was null and merge's `fast_alignment` had no stage-coordinate seed.

Validated on zargun: `read_phenix_index_xml` returns 2,180 FOV positions from a real `Index.xml`; `extract_metadata_tiff(..., well='r02c02', tile=2, cycle=1, metadata_file_path=Index.xml)` returns exactly the one matching row (x=-1826.412, y=3044.02 µm).