### PR TITLE
fix(preprocess): expand coarse (per-cycle) metadata to per-tile extraction jobs

### DIFF
--- a/workflow/lib/preprocess/file_utils.py
+++ b/workflow/lib/preprocess/file_utils.py
@@ -211,7 +211,23 @@ def get_metadata_wildcard_combos(
         metadata_columns = [
             col for col in metadata_samples_df.columns if col != "sample_fp"
         ]
-        return metadata_samples_df[metadata_columns].drop_duplicates().astype(str)
+        combos = metadata_samples_df[metadata_columns].drop_duplicates().astype(str)
+        # The metadata rule runs per-tile (plate/well/tile/cycle). When the metadata
+        # source is coarser than that — e.g. one Opera Phenix Index.xml per cycle covers
+        # every well/tile — expand to per-tile jobs by joining the image samples' finer
+        # keys onto the shared coarse keys; extract_metadata_tiff then narrows the shared
+        # file to each FOV. No-op when the metadata is already per-tile.
+        if not samples_df.empty and not {"well", "tile"}.issubset(metadata_columns):
+            tile_keys = [
+                k
+                for k in ("plate", "well", "tile", "cycle", "round")
+                if k in samples_df.columns
+            ]
+            shared = [c for c in metadata_columns if c in tile_keys]
+            if shared and {"well", "tile"} & set(tile_keys):
+                tiles = samples_df[tile_keys].drop_duplicates().astype(str)
+                combos = tiles.merge(combos, on=shared, how="inner")
+        return combos.reset_index(drop=True)
     elif not samples_df.empty:
         # Use image file structure for metadata extraction
         return samples_df.drop(columns=["sample_fp"]).drop_duplicates().astype(str)


### PR DESCRIPTION
Follow-up to #246 (Opera Phenix support). The Index.xml metadata reader landed, but a full preprocess run crashed at DAG construction:

\`\`\`
InputFunctionException in rule extract_metadata_sbs:
  AttributeError: 'Wildcards' object has no attribute 'row'
  Wildcards: plate=1, cycle=1     # no well
  in get_well_from_wildcards (lib/shared/file_utils.py)
\`\`\`

**Cause.** `extract_metadata_{sbs,phenotype}` run per-tile (`plate/well/tile/cycle`) and read `params.well = get_well_from_wildcards(wildcards)`. A Phenix screen's external metadata is one `Index.xml` **per cycle** (covers every well/tile), so the metadata inventory has only `(plate, cycle)` columns. `get_metadata_wildcard_combos` used those columns directly as job granularity → per-`(plate,cycle)` jobs with no `well` wildcard → the rule's `get_well_from_wildcards` hit `wildcards.row` and crashed.

**Fix.** When the metadata inventory is coarser than per-tile (missing `well`/`tile`), expand its wildcard combos to per-tile by joining the image samples' finer keys onto the shared coarse keys. `extract_metadata_tiff` already narrows the shared file to each FOV, so one coarse `Index.xml` row still serves every tile. No-op when the metadata is already per-tile (normal per-tile-CSV screens unaffected).

**Validated** on a real 2-color Phenix screen (zargun): the SBS metadata inventory (7 rows, one Index.xml per cycle) now expands to 10,466 per-tile combos, each carrying `well` — the crash is resolved.