### PR TITLE
fix(preprocess): coarse (per-cycle) external metadata must extract all FOVs

### DIFF
--- a/workflow/lib/preprocess/preprocess.py
+++ b/workflow/lib/preprocess/preprocess.py
@@ -407,17 +407,6 @@ def extract_metadata_tiff(
                         return name
                 return None
 
-            # Narrow an all-tiles metadata table to this FOV (no-op for per-tile files)
-            _wc = find_column("well")
-            _tc = find_column("tile")
-            _cc = find_column("cycle")
-            if _wc and well is not None:
-                metadata_df = metadata_df[metadata_df[_wc].astype(str) == str(well)]
-            if _tc and tile is not None:
-                metadata_df = metadata_df[metadata_df[_tc].astype(str) == str(tile)]
-            if _cc and cycle is not None:
-                metadata_df = metadata_df[metadata_df[_cc].astype(str) == str(cycle)]
-
             # Convert entire dataframe to standardized format
             metadata_rows = []
 

--- a/workflow/lib/shared/file_utils.py
+++ b/workflow/lib/shared/file_utils.py
@@ -454,17 +454,20 @@ def split_well_to_cols(df):
 def get_well_from_wildcards(wildcards):
     """Get well identifier from wildcards.
 
-    Handles both ``{well}`` (TIFF) and ``{row}/{col}`` (zarr) modes.
+    Handles ``{well}`` (TIFF) and ``{row}/{col}`` (zarr) modes, and returns None
+    when neither is present (a coarse metadata job scoped by plate/cycle, not well).
 
     Args:
         wildcards: Snakemake wildcards object.
 
     Returns:
-        str: Well string (e.g. ``"A1"``).
+        str | None: Well string (e.g. ``"A1"``), or None when the job carries no well.
     """
     if hasattr(wildcards, "well"):
         return str(wildcards.well)
-    return str(wildcards.row) + str(wildcards.col)
+    if hasattr(wildcards, "row") and hasattr(wildcards, "col"):
+        return str(wildcards.row) + str(wildcards.col)
+    return None
 
 
 def validate_data_type(data_type):


### PR DESCRIPTION
Follow-up to #246. Running a tiff screen whose external metadata is **one file per cycle** (a `coordinates.csv`, or an Opera Phenix `Index.xml`) covering every well/tile — the normal coarse metadata shape, same as existing cloud screens (e.g. whitney) — hit two bugs:

**1. `get_well_from_wildcards` crashed at DAG build.** The coarse metadata job is scoped `(plate, cycle)` with no `well`. The function's zarr `row/col` fallback did `wildcards.row` unguarded → `AttributeError: 'Wildcards' object has no attribute 'row'` in `rule extract_metadata_sbs`. Fixed to return `None` when neither `well` nor `row`/`col` is present — matching how the rule's `tile`/`cycle` params already degrade via `getattr(..., None)`.

**2. `extract_metadata_tiff` filtered by `(well, tile, cycle)`** (added in #246). The dispatcher passes `tile=0` for a coarse job (`current_tile = tile if tile is not None else i`), so the filter dropped **every** row (there is no tile 0) → empty metadata. Removed it: a coarse extract must return **all** FOVs; per-FOV narrowing happens downstream (the same way a `coordinates.csv` screen has always worked). The `well`/`tile`/`x_pos`/`y_pos` in the output come from the file **content**, not the wildcards.

Net: the Index.xml path now behaves identically to the coordinates.csv path. Validated on zargun — extract returns all 2180 FOVs (20 wells) per cycle; no notebook change, the metadata TSV stays coarse.