### PR TITLE
fix(preprocess,shared): Phenix rNNcNN well split + SBS z-plane convert collapse

### DIFF
--- a/tests/test_phenix_wells.py
+++ b/tests/test_phenix_wells.py
@@ -1,0 +1,116 @@
+"""Regression tests for Opera Phenix rNNcNN well nomenclature + SBS z-plane convert.
+
+Covers the two bug classes fixed for the first Phenix screens (PoTC, zargun):
+
+1. Well->(row,col) derivation must handle both the alphanumeric convention (A1) and
+   Opera Phenix (r02c05), via the single canonical `split_well`/`split_well_to_cols`
+   in lib.shared.file_utils. The naive `well[0], well[1:]` split turned r02c05 into
+   ("r","02c05") and 404'd every HCS-nested path; `discover_plate_structure`'s
+   alpha-only guard also silently dropped Phenix wells from tile enumeration.
+2. `get_sample_fps` must not collapse z-planes for SBS (no round_order): keying a
+   dict by channel dropped the n_z_planes rows/channel, yielding single-channel zarrs.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Import the way the pipeline does at runtime (workflow/ on path -> top-level `lib`),
+# so hcs.py's own `from lib.shared.file_utils import ...` resolves too.
+_WORKFLOW = Path(__file__).resolve().parents[1] / "workflow"
+if str(_WORKFLOW) not in sys.path:
+    sys.path.insert(0, str(_WORKFLOW))
+
+from lib.shared.file_utils import split_well, split_well_to_cols  # noqa: E402
+from lib.preprocess.file_utils import get_sample_fps  # noqa: E402
+from lib.shared.hcs import discover_plate_structure  # noqa: E402
+
+
+# --- Bug class 1: canonical well split ------------------------------------------
+
+@pytest.mark.parametrize(
+    "well,expected",
+    [
+        ("A1", ("A", "1")),
+        ("B12", ("B", "12")),
+        ("A01", ("A", "01")),  # zeros preserved so read paths match write paths
+        ("r02c05", ("r02", "c05")),
+        ("r06c10", ("r06", "c10")),
+        ("R2C5", ("R2", "C5")),
+    ],
+)
+def test_split_well(well, expected):
+    assert split_well(well) == expected
+
+
+def test_split_well_roundtrips():
+    for well in ("A1", "B12", "r02c05", "r06c10"):
+        row, col = split_well(well)
+        assert f"{row}{col}" == well  # str(row)+str(col) reconstructs the well
+
+
+def test_split_well_raises_on_unknown():
+    with pytest.raises(ValueError):
+        split_well("weird-99")
+
+
+def test_split_well_to_cols_matches_scalar():
+    df = pd.DataFrame({"well": ["A1", "B12", "r02c05", "r06c10"]})
+    out = split_well_to_cols(df)
+    for _, r in out.iterrows():
+        assert (r["row"], r["col"]) == split_well(r["well"])
+
+
+def test_discover_plate_structure_includes_phenix(tmp_path):
+    """Phenix wells must not be silently dropped from tile enumeration."""
+    plate = tmp_path / "image_1.zarr"
+    # one alpha well and one Phenix well, each a tile marker <row>/<col>/<tile>/zarr.json
+    for row, col in [("A", "1"), ("r02", "c03")]:
+        d = plate / row / col / "1"
+        d.mkdir(parents=True)
+        (d / "zarr.json").write_text("{}")
+    found = set(discover_plate_structure(plate))
+    assert ("A", "1", "1") in found
+    assert ("r02", "c03", "1") in found  # would be dropped by the old alpha-only guard
+
+
+# --- Bug class 2: SBS z-plane convert -------------------------------------------
+
+def _tile_df(channels, z_planes, well="r05c04"):
+    rows = []
+    for ch in channels:
+        for zp in z_planes:
+            rows.append(
+                {
+                    "plate": "1", "well": well, "tile": "24", "cycle": "1",
+                    "channel": ch, "z": zp, "sample_fp": f"{ch}_z{zp}.tiff",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_get_sample_fps_multiz_keeps_all_channels_and_planes():
+    """3 channels x 3 z must return 9 files, channel-major, z ascending within channel."""
+    df = _tile_df(["C", "T", "DAPI"], [1, 2, 3])
+    res = get_sample_fps(df, plate="1", channel_order=["C", "T", "DAPI"])
+    assert res == [
+        "C_z1.tiff", "C_z2.tiff", "C_z3.tiff",
+        "T_z1.tiff", "T_z2.tiff", "T_z3.tiff",
+        "DAPI_z1.tiff", "DAPI_z2.tiff", "DAPI_z3.tiff",
+    ]
+
+
+def test_get_sample_fps_singlez_unaffected():
+    """1 z per channel (e.g. PoTC): dict-collapse never bit this — still N files."""
+    df = _tile_df(["DAPI", "A568", "A488", "A647"], [1])
+    res = get_sample_fps(df, plate="1", channel_order=["DAPI", "A568", "A488", "A647"])
+    assert res == ["DAPI_z1.tiff", "A568_z1.tiff", "A488_z1.tiff", "A647_z1.tiff"]
+
+
+def test_get_sample_fps_bare_z_guard_raises_on_multichannel():
+    """Multi-channel z-stack with NO channel_order must raise, not interleave."""
+    df = _tile_df(["C", "T"], [1, 2, 3])
+    with pytest.raises(ValueError):
+        get_sample_fps(df, plate="1")  # no channel_order -> ambiguous ordering

--- a/workflow/lib/aggregate/montage_utils.py
+++ b/workflow/lib/aggregate/montage_utils.py
@@ -19,7 +19,7 @@ from itertools import product
 
 import numpy as np
 
-from lib.shared.file_utils import get_filename, get_hcs_nested_path
+from lib.shared.file_utils import get_filename, get_hcs_nested_path, split_well
 from lib.shared.image_io import read_image
 from lib.external.cp_emulator import subimage
 
@@ -43,10 +43,11 @@ def add_filenames(merge_data, root_fp, img_fmt="tiff"):
     def _build_path(row):
         if img_fmt == "zarr":
             well = str(row["well"])
+            _row, _col = split_well(well)
             loc = {
                 "plate": row["plate"],
-                "row": well[0],
-                "col": well[1:],
+                "row": _row,
+                "col": _col,
                 "tile": row["tile"],
             }
             return str(root_fp / "phenotype" / get_hcs_nested_path(loc, "aligned"))

--- a/workflow/lib/classify/shared.py
+++ b/workflow/lib/classify/shared.py
@@ -20,7 +20,7 @@ import tifffile
 from PIL import Image as PILImage
 from skimage import measure, segmentation
 
-from lib.shared.file_utils import get_filename
+from lib.shared.file_utils import get_filename, split_well
 from lib.shared.parquet_io import read_parquet
 
 
@@ -160,8 +160,8 @@ def load_aligned_stack(
     wname = well_for_filename(well)
     m = re.match(r"^([A-Z])(\d{1,2})$", wname)
     wpad = f"{m.group(1)}{int(m.group(2)):02d}" if m else wname
-    row = wname[0]
-    col = wname[1:]
+    # Split the raw well canonically (wname/wpad above are for the TIFF-fallback filename).
+    row, col = split_well(str(well))
 
     # Try OME-Zarr HCS layout first, then TIFF
     zarr_candidates = [
@@ -230,8 +230,8 @@ def load_mask_labels(
     wname = well_for_filename(well)
     m = re.match(r"^([A-Z])(\d{1,2})$", wname)
     wpad = f"{m.group(1)}{int(m.group(2)):02d}" if m else wname
-    row = wname[0]
-    col = wname[1:]
+    # Split the raw well canonically (wname/wpad above are for the TIFF-fallback filename).
+    row, col = split_well(str(well))
 
     label_name = "identified_vacuoles" if mode_ == "vacuole" else "cells"
 
@@ -314,8 +314,8 @@ def load_parquet(
     wname = well_for_filename(well)
     m = re.match(r"^([A-Z])(\d{1,2})$", wname)
     wpad = f"{m.group(1)}{int(m.group(2)):02d}" if m else wname
-    row = wname[0]
-    col = wname[1:]
+    # Split the raw well canonically (wname/wpad above are for the TIFF-fallback filename).
+    row, col = split_well(str(well))
     if mode_ == "vacuole":
         candidates = [
             # HCS nested layout

--- a/workflow/lib/preprocess/file_utils.py
+++ b/workflow/lib/preprocess/file_utils.py
@@ -115,29 +115,11 @@ def get_sample_fps(
 
             # If channel order is specified, get files in that order for this round
             if "channel" in round_df.columns and channel_order is not None:
-                # Group by channel, handling potential z-planes
-                channel_groups = {
-                    chan: group for chan, group in round_df.groupby("channel")
-                }
-
-                # Add files for each requested channel if available in this round
+                # Shared channel-major / z-within-channel ordering (see collect_channel_z_ordered).
+                all_files.extend(collect_channel_z_ordered(round_df, channel_order, z))
+                present_channels = set(round_df["channel"].unique())
                 for channel in channel_order:
-                    if channel in channel_groups:
-                        channel_df = channel_groups[channel]
-
-                        # Handle z-planes: if z column exists and z is None, add all z-planes sorted
-                        if "z" in channel_df.columns and z is None:
-                            z_sorted = channel_df.sort_values("z")
-                            z_files = z_sorted["sample_fp"].tolist()
-                            all_files.extend(z_files)
-                            if verbose:
-                                print(
-                                    f"Round {round_num}, Channel {channel}: Added {len(z_files)} z-planes"
-                                )
-                        else:
-                            # Single file per channel
-                            all_files.append(channel_df["sample_fp"].iloc[0])
-
+                    if channel in present_channels:
                         final_channel_order.append(f"Round {round_num}: {channel}")
             else:
                 # If no channel order, handle z-planes if present
@@ -168,14 +150,10 @@ def get_sample_fps(
             return all_files[0]
         return all_files
 
-    # If no rounds specified but we have channels and channel order
+    # If no rounds specified but we have channels and channel order (the SBS path)
     if "channel" in filtered_df.columns and channel_order is not None:
-        channel_to_file = dict(zip(filtered_df["channel"], filtered_df["sample_fp"]))
-        result = [
-            channel_to_file[channel]
-            for channel in channel_order
-            if channel in channel_to_file
-        ]
+        # Shared ordering; a {channel: fp} dict here collapsed z-planes -> single-channel zarrs.
+        result = collect_channel_z_ordered(filtered_df, channel_order, z)
         # Return single string if input was single value and result is single file
         if channel_was_single and len(result) == 1:
             return result[0]
@@ -183,6 +161,13 @@ def get_sample_fps(
 
     # Handle z-planes: if z column exists and z parameter is None, return all z-planes sorted
     if "z" in filtered_df.columns and z is None:
+        # Without channel_order a bare z-sort would interleave multiple channels; refuse.
+        if "channel" in filtered_df.columns and filtered_df["channel"].nunique() > 1:
+            raise ValueError(
+                "get_sample_fps: a multi-channel z-stack reached the bare-z fallback "
+                "with no channel_order — cannot infer a channel-major ordering "
+                "(would interleave channels). Pass channel_order (e.g. sbs_channel_order)."
+            )
         # Sort by z-plane and return all files
         z_sorted_df = filtered_df.sort_values("z")
         z_files = z_sorted_df["sample_fp"].tolist()
@@ -192,6 +177,29 @@ def get_sample_fps(
 
     # Otherwise return single file path
     return filtered_df["sample_fp"].iloc[0]
+
+
+def collect_channel_z_ordered(df, channel_order, z):
+    """Return sample_fps channel-major with all z-planes per channel, sorted.
+
+    For each channel in ``channel_order`` present in ``df``, appends that channel's
+    z-planes ascending (when a ``z`` column exists and ``z is None``), else one file.
+    This is the ordering ``convert_tiff_to_array`` expects
+    (``[ch0_z0, ch0_z1, ..., ch1_z0, ...]``), shared by :func:`get_sample_fps`'s
+    branches. A ``{channel: fp}`` dict must not be used here — it drops all but one
+    z-plane per channel, yielding single-channel arrays.
+    """
+    files = []
+    channel_groups = {chan: grp for chan, grp in df.groupby("channel")}
+    for chan in channel_order:
+        if chan not in channel_groups:
+            continue
+        chan_df = channel_groups[chan]
+        if "z" in chan_df.columns and z is None:
+            files.extend(chan_df.sort_values("z")["sample_fp"].tolist())
+        else:
+            files.append(chan_df["sample_fp"].iloc[0])
+    return files
 
 
 def get_metadata_wildcard_combos(

--- a/workflow/lib/shared/file_utils.py
+++ b/workflow/lib/shared/file_utils.py
@@ -1,5 +1,6 @@
 """Utility functions for handling and filtering sample file paths in the BrieFlow pipeline."""
 
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -426,10 +427,49 @@ def get_data_output_path(data_location, info_type, file_type, img_fmt="tiff"):
     return get_filename(data_location, info_type, file_type)
 
 
-def split_well_to_cols(df):
-    """Add ``row`` and ``col`` columns derived from ``well``.
+# Canonical well->(row,col) patterns; extend here (one source of truth), not at call sites.
+WELL_ROWCOL_PATTERNS = (
+    re.compile(r"^([A-Za-z]+)(\d+)$"),
+    re.compile(r"^([Rr]\d+)([Cc]\d+)$"),
+)
 
-    E.g. ``"A1"`` → ``row="A"``, ``col="1"``.
+
+def split_well(well):
+    """Split a well id into its ``(row, col)`` HCS-path components.
+
+    Canonical scalar derivation shared with the vectorized :func:`split_well_to_cols`
+    via ``WELL_ROWCOL_PATTERNS`` (alphanumeric ``"A1"`` -> ``("A", "1")``, Opera Phenix
+    ``"r02c05"`` -> ``("r02", "c05")``, prefixes kept so ``str(row)+str(col)`` round-trips).
+    Raises ``ValueError`` on an unrecognized convention rather than mis-splitting — the
+    naive ``well[0], well[1:]`` turned ``"r02c05"`` into ``("r", "02c05")`` and 404'd
+    every HCS-nested path.
+
+    Args:
+        well: Well identifier (e.g. ``"A1"``, ``"r02c05"``).
+
+    Returns:
+        tuple[str, str]: ``(row, col)``.
+
+    Raises:
+        ValueError: If ``well`` matches no known convention.
+    """
+    s = str(well)
+    for pattern in WELL_ROWCOL_PATTERNS:
+        m = pattern.match(s)
+        if m:
+            return m.group(1), m.group(2)
+    raise ValueError(
+        f"Cannot split well '{well}' into (row, col): matches no known convention "
+        f"(alphanumeric 'A1' or Opera Phenix 'r02c05'). Extend WELL_ROWCOL_PATTERNS."
+    )
+
+
+def split_well_to_cols(df):
+    """Add ``row`` and ``col`` columns derived from ``well`` (vectorized).
+
+    Vectorized twin of :func:`split_well`, sharing ``WELL_ROWCOL_PATTERNS`` so the two
+    derivations cannot drift. E.g. ``"A1"`` -> ``row="A"``, ``col="1"``; ``"r02c05"`` ->
+    ``row="r02"``, ``col="c05"``.
 
     Args:
         df (pd.DataFrame): DataFrame with a ``well`` column.
@@ -440,12 +480,9 @@ def split_well_to_cols(df):
     if len(df) > 0 and "well" in df.columns:
         df = df.copy()
         w = df["well"].astype(str)
-        # A1 / B12 style: alphabetic row + numeric col.
-        splits = w.str.extract(r"^([A-Za-z]+)(\d+)$")
-        # Opera Phenix rNNcNN style: numeric row AND col. Keep the r/c prefixes so
-        # get_well_from_wildcards' str(row)+str(col) round-trips to the original well
-        # (e.g. "r02c02" -> row="r02", col="c02" -> "r02c02").
-        phenix = w.str.extract(r"^([Rr]\d+)([Cc]\d+)$")
+        alpha_re, phenix_re = WELL_ROWCOL_PATTERNS
+        splits = w.str.extract(alpha_re.pattern)
+        phenix = w.str.extract(phenix_re.pattern)
         df["row"] = splits[0].fillna(phenix[0]).values
         df["col"] = splits[1].fillna(phenix[1]).values
     return df

--- a/workflow/lib/shared/hcs.py
+++ b/workflow/lib/shared/hcs.py
@@ -14,6 +14,8 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from lib.shared.file_utils import WELL_ROWCOL_PATTERNS, split_well
+
 from iohub.ngff import open_ome_zarr
 from iohub.ngff.display import channel_display_settings
 from iohub.ngff.models import OMEROMeta, RDefsMeta, TransformationMeta
@@ -95,9 +97,10 @@ def discover_plate_structure(plate_zarr_path):
             continue
 
         row, col, tile = parts[0], parts[1], parts[2]
-        if not re.match(r"^[A-Za-z]+$", str(row)):
+        if not str(tile).isdigit():
             continue
-        if not str(col).isdigit() or not str(tile).isdigit():
+        # Skip zarr.json paths whose (row, col) don't reconstruct to a recognized well.
+        if not any(p.match(f"{row}{col}") for p in WELL_ROWCOL_PATTERNS):
             continue
 
         key = (row, col, tile)
@@ -116,9 +119,10 @@ def discover_plate_structure(plate_zarr_path):
             continue
 
         row, col, tile = parts[0], parts[1], parts[2]
-        if not re.match(r"^[A-Za-z]+$", str(row)):
+        if not str(tile).isdigit():
             continue
-        if not str(col).isdigit() or not str(tile).isdigit():
+        # Skip zarr.json paths whose (row, col) don't reconstruct to a recognized well.
+        if not any(p.match(f"{row}{col}") for p in WELL_ROWCOL_PATTERNS):
             continue
 
         key = (row, col, tile)
@@ -333,11 +337,8 @@ def _normalize_channels_metadata(channels_metadata):
 
 
 def _split_well(well_str):
-    """Split a well identifier like 'A1' into (row, col) -> ('A', '1')."""
-    match = re.match(r"^([A-Za-z]+)(\d+)$", str(well_str))
-    if not match:
-        raise ValueError(f"Cannot parse well identifier: '{well_str}'")
-    return match.group(1), match.group(2)
+    """Deprecated shim — use ``lib.shared.file_utils.split_well`` (handles Phenix)."""
+    return split_well(well_str)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The first Opera Phenix screens (`rNNcNN` well naming, z-split tiffs; PoTC, zargun) surfaced two fundamental gaps in `zarr3`.

### 1. Well→(row,col) nomenclature (affects every Phenix screen)
The HCS-nested `<plate>/<row>/<col>/` layout needs a well split into path components. `split_well_to_cols` already handled Phenix, but scattered **scalar** sites used the naive `well[0], well[1:]` — correct for `A1`, but `r02c05` → `("r","02c05")`, so every HCS-nested path 404s. `discover_plate_structure`'s alpha-only guard also **silently dropped** Phenix wells from tile enumeration (no error).

**Fix:** one canonical `split_well` (shares `WELL_ROWCOL_PATTERNS` with `split_well_to_cols`, raises on an unknown convention instead of mis-splitting); routed `classify/shared.py` (3 sites), `aggregate/montage_utils.py`, and the `hcs.py` enumeration guards through it; retired the Phenix-hostile `hcs._split_well` to a shim.

### 2. SBS z-plane collapse → single-channel zarrs (multi-z SBS only)
`get_sample_fps`'s no-`round_order` (SBS) branch built `dict(zip(channel, sample_fp))`, collapsing the `n_z_planes` rows/channel to one — z-split SBS produced `(1,1,1,H,W)` single-channel zarrs that only failed later at `align_cycles`' 4-D assert (nothing checks channel count at convert). Phenotype escaped it (has `round_order`).

**Fix:** extracted `collect_channel_z_ordered` (channel-major, z-within-channel, per `convert_tiff_to_array`'s documented contract) shared by the round + SBS branches so they can't drift; guarded the bare-z fallback that would interleave channels without a `channel_order`. Single-z data (e.g. PoTC) is unaffected.

## Tests
`tests/test_phenix_wells.py` — 13 tests: `split_well` round-trips (alpha + Phenix), `discover_plate_structure` keeps Phenix wells, z-collapse keeps all channels×planes in the right order, bare-z guard raises.

## Rerun impact
- Write paths were correct (write side uses `split_well_to_cols`) → **no relayout / no re-run for the well fix**.
- Multi-z SBS zarrs written before this fix are single-channel and must be reconverted; single-z screens are fine.

## Note
`tests/test_omezarr.py` fails to *collect* on this branch due to a **pre-existing** stale import (`workflow.lib.shared.io`, renamed to `image_io` before this PR) — unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
