### PR TITLE
fix(shared): return empty feature table when a field segments to zero objects

### DIFF
--- a/workflow/lib/shared/feature_table_utils.py
+++ b/workflow/lib/shared/feature_table_utils.py
@@ -63,6 +63,12 @@ def feature_table_multichannel(data, labels, features, global_features=None):
     # Extract regions from the labeled segmentation mask
     regions = regionprops_multichannel(labels, intensity_image=data)
 
+    # An empty or out-of-focus field segments to zero objects; probing regions[0]
+    # below would raise IndexError and fail the whole tile. Return an empty table
+    # instead, matching feature_table, whose per-region loop simply does not run.
+    if len(regions) == 0:
+        return pd.DataFrame()
+
     # Initialize a defaultdict to store feature values
     results = defaultdict(list)
 

--- a/workflow/lib/shared/feature_table_utils.py
+++ b/workflow/lib/shared/feature_table_utils.py
@@ -63,9 +63,7 @@ def feature_table_multichannel(data, labels, features, global_features=None):
     # Extract regions from the labeled segmentation mask
     regions = regionprops_multichannel(labels, intensity_image=data)
 
-    # An empty or out-of-focus field segments to zero objects; probing regions[0]
-    # below would raise IndexError and fail the whole tile. Return an empty table
-    # instead, matching feature_table, whose per-region loop simply does not run.
+    # Return an empty table when a field segments to zero objects
     if len(regions) == 0:
         return pd.DataFrame()
 


### PR DESCRIPTION
## Problem

`feature_table_multichannel` probes the first region to decide whether a feature function returns a scalar or a sequence:

```python
result_0 = func(regions[0])
```

An empty or out-of-focus field segments to zero objects, so `regions` is empty and the probe raises:

```
File "workflow/lib/shared/feature_table_utils.py", line 72, in feature_table_multichannel
    result_0 = func(regions[0])
IndexError: list index out of range
```

Because the phenotype rules run as one grouped Slurm job (`phenotype_tile_group`), a single bad tile kills the whole group and surfaces as **six** rule errors — `align_phenotype`, `apply_ic_field_phenotype`, `segment_phenotype`, `extract_phenotype_info`, `identify_cytoplasm`, `extract_phenotype`. Under `--keep-going` the phase then exits non-zero even though every other tile finished.

## Fix

Return an empty `DataFrame` when there are no regions.

This matches `feature_table`, the single-channel sibling in the same module, which already degrades this way — it iterates `for region in regions`, so an empty mask simply yields an empty frame. No behaviour change when regions exist.

## Evidence

Observed on zargun (20-well U2OS plate, 1362 grouped phenotype jobs). Tile `r02/c05/106` has no nuclear signal, so CellPose correctly returned zero objects:

| tile | nucleus mean | nucleus p99 |
|---|---|---|
| `r02/c05/106` (failing) | 202.9 | **321** |
| `r02/c04/24` (healthy) | 1281.4 | **16057** |

The field is genuinely empty — this is legitimate data at a well edge, not a segmentation failure, so the extractor should tolerate it. Phenotype stopped at 9002/9014 steps on this one tile.

This may be the same defect recorded as an open item in the 2026-04-30 speed-branch handoff notes ("`phenotype_tile_group` has a real rule-code bug at well scale … real code error inside the python step; needs separate triage"), which matched the same signature (fast failure, low memory, not OOM, not timeout).

## Verification

```
empty tile  -> multichannel: DataFrame shape=(0, 0)   # was IndexError
empty tile  -> single-chan : DataFrame shape=(0, 0)   # unchanged
2 objects   -> multichannel: shape=(2, 4) cols=['area','mean_0','mean_1','mean_2']   # unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JQtNBvewaEmdvYnC4k7Dm