### PR TITLE
fix(phenotype): guard empty cytoplasms, reverting #250/#251

### DIFF
--- a/workflow/lib/phenotype/extract_phenotype_cp_emulator.py
+++ b/workflow/lib/phenotype/extract_phenotype_cp_emulator.py
@@ -163,8 +163,8 @@ def extract_phenotype_cp_emulator(
             .add_prefix("cell_")
         )
 
-    # Extract cytoplasmic features if cytoplasms are provided
-    if cytoplasms is not None:
+    # Extract cytoplasmic features if cytoplasms are provided and not empty
+    if cytoplasms is not None and np.sum(cytoplasms) > 0:
         cytoplasmic_columns = make_column_map(cytoplasm_channels)
         dfs.append(
             extract_features(
@@ -213,7 +213,7 @@ def extract_phenotype_cp_emulator(
             .add_prefix("cell_")
         )
 
-    if cytoplasms is not None:
+    if cytoplasms is not None and np.sum(cytoplasms) > 0:
         dfs.append(
             neighbor_measurements(cytoplasms, distances=[1])
             .set_index("label")

--- a/workflow/lib/shared/feature_table_utils.py
+++ b/workflow/lib/shared/feature_table_utils.py
@@ -26,10 +26,6 @@ def feature_table(data, labels, features, global_features=None):
     # Extract regions from the labeled segmentation mask
     regions = regionprops(labels, intensity_image=data)
 
-    # Return an empty table when a field segments to zero objects
-    if len(regions) == 0:
-        return pd.DataFrame({"label": pd.Series(dtype=int)})
-
     # Initialize a defaultdict to store feature values
     results = defaultdict(list)
 
@@ -66,10 +62,6 @@ def feature_table_multichannel(data, labels, features, global_features=None):
     """
     # Extract regions from the labeled segmentation mask
     regions = regionprops_multichannel(labels, intensity_image=data)
-
-    # Return an empty table when a field segments to zero objects
-    if len(regions) == 0:
-        return pd.DataFrame({"label": pd.Series(dtype=int)})
 
     # Initialize a defaultdict to store feature values
     results = defaultdict(list)


### PR DESCRIPTION
## Root cause

`extract_phenotype_cp_emulator` already has an empty-input convention. Every `cells` branch tests **both** existence and emptiness:

```python
if cells is not None and np.sum(cells) > 0:                      # line 151
foci_mask = cells if (cells is not None and np.sum(cells) > 0)   # line 185
if cells is not None and np.sum(cells) > 0:                      # line 209
```

Both `cytoplasms` branches were extended with only the first half:

```python
if cytoplasms is not None:      # line 167  -> feature extraction
if cytoplasms is not None:      # line 216  -> neighbor measurements
```

A cell whose nucleus fills it leaves no cytoplasmic ring, so a field can have nuclei **and** cells but **zero** cytoplasms. The top-level `if np.sum(nuclei) == 0` guard therefore never fires, and the two unguarded branches reach:

- `feature_table_multichannel` → `IndexError: list index out of range` on `regions[0]`
- `object_neighbors` → `KeyError: "None of ['label'] are in the columns"` on `.set_index("label")`

## Why this reverts #250 and #251

Those PRs hardened the two downstream helpers. That treated the symptom: fixing the first simply moved the failure to the second, and there was no reason to think the second was the last. The caller already knew how to handle empty inputs — it just wasn't applying that convention to `cytoplasms`.

So this restores `feature_table_utils.py` to its original form and fixes the asymmetry at source. Net **+3 / −11**.

## Evidence

zargun, 20-well U2OS plate. Tile `r02/c05/106` — 1 of 1494 — blocked phenotype at 9002/9014 steps across two consecutive runs.

## Verification

```
empty cytoplasms   -> shape=(2, 845)    no exception
non-empty          -> shape=(2, 1265)   420 cytoplasm cols, unchanged
without this fix   -> IndexError: list index out of range
```

The 420-column difference is the cytoplasm feature block correctly omitted when there are no cytoplasms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JQtNBvewaEmdvYnC4k7Dm