### PR TITLE
fix(shared): sort HCS plate columns by their digits, not int(label)

### DIFF
--- a/workflow/lib/shared/hcs.py
+++ b/workflow/lib/shared/hcs.py
@@ -395,6 +395,12 @@ def _write_zarr_v3_group_metadata(path):
         json.dump(metadata, f, indent=2)
 
 
+def _column_order(label):
+    """Sort key for an HCS column label: its digits, so `c10` follows `c9`."""
+    digits = "".join(ch for ch in str(label) if ch.isdigit())
+    return (0, int(digits)) if digits else (1, str(label))
+
+
 def _write_plate_metadata(
     plate_zarr_path, wells_by_row_col, channels_metadata=None, field_count=1
 ):
@@ -403,7 +409,7 @@ def _write_plate_metadata(
     plate_path.mkdir(parents=True, exist_ok=True)
 
     rows = sorted(set(rc[0] for rc in wells_by_row_col.keys()))
-    cols = sorted(set(rc[1] for rc in wells_by_row_col.keys()), key=lambda x: int(x))
+    cols = sorted(set(rc[1] for rc in wells_by_row_col.keys()), key=_column_order)
 
     plate_name = plate_path.stem  # e.g. "aligned_1"
 


### PR DESCRIPTION
## Problem

`_write_plate_metadata` ordered columns with:

```python
cols = sorted(set(rc[1] for rc in wells_by_row_col.keys()), key=lambda x: int(x))
```

That assumes the alphanumeric well convention, where the column component of `"A1"` is `"1"`. Under Opera Phenix the component is `"c04"`, so it raises:

```
File "workflow/lib/shared/hcs.py", line 406, in _write_plate_metadata
    cols = sorted(..., key=lambda x: int(x))
ValueError: invalid literal for int() with base 10: 'c04'
```

`hcs.py` already imports `split_well` / `WELL_ROWCOL_PATTERNS` and is convention-aware everywhere else — this sort was the one place that wasn't.

## Fix

Sort on the digits in the label. This also orders `c9` before `c10`, which plain alphabetical sorting would get wrong.

Rows are deliberately untouched: they already sort correctly in both conventions (`A`, `B` … and zero-padded `r02`, `r03` …).

## Impact

Hit twice on zargun (20-well U2OS, Phenix `rNNcNN` wells):

- `finalize_hcs_preprocess_sbs` / `_phenotype` — **cosmetic** there; the plate-level OME-NGFF metadata is for viewers and interop, and per-tile reads are unaffected, so preprocess still passed QC.
- `finalize_hcs_phenotype` — **blocking**; it fails the phenotype phase at the last step (10 of 12 remaining steps done).

## Verification

```
Phenix               ['c05','c02','c04','c03'] -> ['c02','c03','c04','c05']
Phenix >9 unpadded   ['c10','c9','c2']         -> ['c2','c9','c10']
alphanumeric         ['10','9','2','1']        -> ['1','2','9','10']
old key on Phenix    -> ValueError: invalid literal for int() with base 10: 'c04'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JQtNBvewaEmdvYnC4k7Dm