### PR TITLE
fix(classify): leave unrecognized well ids unchanged in well_for_filename

### DIFF
--- a/tests/test_phenix_wells.py
+++ b/tests/test_phenix_wells.py
@@ -7,6 +7,8 @@ Covers the two bug classes fixed for the first Phenix screens (PoTC, zargun):
    in lib.shared.file_utils. The naive `well[0], well[1:]` split turned r02c05 into
    ("r","02c05") and 404'd every HCS-nested path; `discover_plate_structure`'s
    alpha-only guard also silently dropped Phenix wells from tile enumeration.
+   `well_for_filename` likewise uppercased anything it did not recognize, turning
+   r02c02 into R02C02 and building parquet paths that matched nothing on disk.
 2. `get_sample_fps` must not collapse z-planes for SBS (no round_order): keying a
    dict by channel dropped the n_z_planes rows/channel, yielding single-channel zarrs.
 """
@@ -24,6 +26,7 @@ if str(_WORKFLOW) not in sys.path:
     sys.path.insert(0, str(_WORKFLOW))
 
 from lib.shared.file_utils import split_well, split_well_to_cols  # noqa: E402
+from lib.classify.shared import well_for_filename  # noqa: E402
 from lib.preprocess.file_utils import get_sample_fps  # noqa: E402
 from lib.shared.hcs import discover_plate_structure  # noqa: E402
 
@@ -74,6 +77,29 @@ def test_discover_plate_structure_includes_phenix(tmp_path):
     found = set(discover_plate_structure(plate))
     assert ("A", "1", "1") in found
     assert ("r02", "c03", "1") in found  # would be dropped by the old alpha-only guard
+
+
+@pytest.mark.parametrize(
+    "well,expected",
+    [
+        ("A1", "A1"),
+        ("A01", "A1"),      # unpadded column
+        ("b12", "B12"),     # row letter uppercased
+        ("r02c02", "r02c02"),   # Phenix: unchanged, NOT "R02C02"
+        ("r06c10", "r06c10"),
+    ],
+)
+def test_well_for_filename(well, expected):
+    assert well_for_filename(well) == expected
+
+
+def test_well_for_filename_roundtrips_phenix_parquet_name():
+    """The normalized well must reproduce the name the pipeline actually writes."""
+    from lib.shared.file_utils import get_filename
+
+    well = "r02c02"
+    name = get_filename({"plate": 1, "well": well_for_filename(well)}, "merge_final", "parquet")
+    assert name == "P-1_W-r02c02__merge_final.parquet"
 
 
 # --- Bug class 2: SBS z-plane convert -------------------------------------------

--- a/workflow/lib/classify/shared.py
+++ b/workflow/lib/classify/shared.py
@@ -129,15 +129,17 @@ def well_for_filename(well: Union[str, int]) -> str:
       - 'A01' -> 'A1'  (strip leading zeros)
       - 'b12' -> 'B12'
 
-    If the pattern doesn't match Letter+digits, returns uppercased string as-is.
+    Ids that are not Letter+digits are returned unchanged: Opera Phenix "r02c05"
+    has no unpadded form, and uppercasing it to "R02C05" built filenames that
+    matched nothing on disk.
     """
-    s = str(well).strip().upper()
-    m = re.match(r"^([A-Z])0*(\d{1,2})$", s)
+    s = str(well).strip()
+    m = re.match(r"^([A-Za-z])0*(\d{1,2})$", s)
     if not m:
         return s
     row, col = m.group(1), m.group(2)
     # int() removes any leading zeros
-    return f"{row}{int(col)}"
+    return f"{row.upper()}{int(col)}"
 
 
 def load_aligned_stack(


### PR DESCRIPTION
Fifth Phenix-nomenclature bug from the zargun screen, same family as #250/#251/#252/#254. Latent rather than hit — nothing in the aggregate or cluster rule paths imports `classify` — but it breaks every `classify` lookup on a Phenix screen.

## The bug

`well_for_filename` uppercased its input *before* matching, then returned that uppercased string when the pattern didn't match:

```python
s = str(well).strip().upper()
m = re.match(r"^([A-Z])0*(\d{1,2})$", s)
if not m:
    return s          # "r02c02" -> "R02C02"
```

Opera Phenix ids never match Letter+digits, so they fall through to the uppercased return and every parquet path built from them points at a file that does not exist:

```
'r02c02' -> well_for_filename='R02C02' -> P-1_W-R02C02__merge_final.parquet   exists=False
                                 actual: P-1_W-r02c02__merge_final.parquet
```

Six call sites in `lib/classify/labeling.py` are affected — `merge_final`, `phenotype_cp`, `phenotype_cp_min`, and `phenotype_vacuoles` lookups.

`lib/classify/shared.py` was already half-aware: at lines 160-164 and 230-233 it confines `well_for_filename` to the TIFF-fallback name and calls `split_well` for the real path, with the comment *"Split the raw well canonically"*. `labeling.py` never got that treatment.

## The fix

Match case-insensitively, uppercase only the row letter, and return unrecognized ids untouched. There is no unpadded form of `r02c05` to normalize toward, so the correct action is to leave it alone.

## Tests

Added to `tests/test_phenix_wells.py` under bug class 1, where the `split_well` regressions already live.

Verified they fail without the source change:

```
without fix:  3 failed, 16 passed
with fix:    19 passed
```

The 16 passing without the fix include every alphanumeric case, so `A1`/`A01`/`b12` behaviour is provably unchanged.

`tests/test_omezarr.py` errors at collection on `ModuleNotFoundError: No module named 'workflow.lib.shared.io'` — pre-existing on clean `zarr3`, unrelated to this change, so it is excluded from the run above rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JQtNBvewaEmdvYnC4k7Dm