### PR TITLE
fix(shared): aggregate segmentation_overview per well, not per column

### DIFF
--- a/tests/test_phenix_wells.py
+++ b/tests/test_phenix_wells.py
@@ -140,3 +140,49 @@ def test_get_sample_fps_bare_z_guard_raises_on_multichannel():
     df = _tile_df(["C", "T"], [1, 2, 3])
     with pytest.raises(ValueError):
         get_sample_fps(df, plate="1")  # no channel_order -> ambiguous ordering
+
+
+# 3. segmentation_overview must aggregate per WELL, not per column. The zarr-mode
+#    path parse guarded on `row.isalpha()`, which is False for Phenix `r03`, so every
+#    Phenix path fell through to the 3-level tiff parse and took `well` from the
+#    column component -- silently summing the six wells of a column into one row.
+def _write_stats(path, n):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "initial_nuclei": [n],
+            "initial_cells": [n],
+            "after_edge_removal_nuclei": [n],
+            "after_edge_removal_cells": [n],
+            "final_cells": [n],
+            "final_nuclei": [n],
+        }
+    ).to_csv(path, sep="\t", index=False)
+    return str(path)
+
+
+@pytest.mark.parametrize(
+    "rows,cols,expected",
+    [
+        (["r02", "r03"], ["c05"], {"r02c05", "r03c05"}),
+        (["A", "B"], ["1"], {"A1", "B1"}),
+    ],
+)
+def test_segmentation_overview_aggregates_per_well(tmp_path, rows, cols, expected):
+    from lib.shared.eval_segmentation import segmentation_overview
+
+    paths = []
+    for row in rows:
+        for col in cols:
+            for tile in (0, 1):
+                paths.append(
+                    _write_stats(
+                        tmp_path / "1" / row / col / str(tile) / "segmentation_stats.tsv",
+                        10,
+                    )
+                )
+    out = segmentation_overview(paths)
+    assert set(out["well"]) == expected
+    assert len(out) == len(expected)
+    # two tiles per well, 10 each -> distinct wells must not be summed together
+    assert set(out["final_cells"]) == {20}

--- a/workflow/lib/shared/eval_segmentation.py
+++ b/workflow/lib/shared/eval_segmentation.py
@@ -7,7 +7,7 @@ from lib.shared.image_io import read_image
 from microfilm.microplot import Microimage
 import matplotlib.pyplot as plt
 
-from lib.shared.file_utils import parse_filename, parse_nested_path
+from lib.shared.file_utils import parse_filename, parse_nested_path, split_well
 from lib.shared.eval import plot_plate_heatmap
 from lib.shared.configuration_utils import create_micropanel
 from lib.shared.configuration_utils import image_segmentation_annotations
@@ -48,13 +48,11 @@ def segmentation_overview(segmentation_stats_paths):
                 data_location, _, _ = parse_nested_path(
                     segmentation_stats_path, ["plate", "row", "col", "tile"]
                 )
-                # Validate: row should be alphabetic (e.g. 'A') in zarr mode
-                if str(data_location["row"]).isalpha():
-                    data_location["well"] = str(data_location["row"]) + str(
-                        data_location["col"]
-                    )
-                else:
-                    raise ValueError("Not a zarr-mode path")
+                # split_well accepts every supported convention, so a well it
+                # rejects is not a zarr-mode path
+                well_id = f"{data_location['row']}{data_location['col']}"
+                split_well(well_id)
+                data_location["well"] = well_id
             except (ValueError, KeyError):
                 data_location, _, _ = parse_nested_path(
                     segmentation_stats_path, ["plate", "well", "tile"]


### PR DESCRIPTION
## Problem

`segmentation_overview` parses the zarr-mode 4-level path (`plate/row/col/tile`) behind a `row.isalpha()` guard:

```python
if str(data_location["row"]).isalpha():
    data_location["well"] = str(data_location["row"]) + str(data_location["col"])
else:
    raise ValueError("Not a zarr-mode path")
except (ValueError, KeyError):
    data_location, _, _ = parse_nested_path(path, ["plate", "well", "tile"])
```

Opera Phenix rows are `r03`, so `isalpha()` is `False`. Every Phenix path raises, falls through to the 3-level tiff parse, and takes `well` from the **column** component. `groupby("well").sum()` then merges the six wells of each column into one row.

On a 60-well Phenix plate the output is 10 rows labelled `c02`…`c11`, each silently summing six wells:

```
well  initial_nuclei  initial_cells  ...  final_cells
c02            88799          93954  ...        71577   <- r02c02..r07c02 summed
c03            89464          93244  ...        72527
```

Nothing errors and no data goes missing, so the file looks complete. Per-well segmentation QC has therefore been column aggregates on every Phenix screen to date — the plate-level totals are right, the granularity is not.

This is the same family as the well-split sites fixed in #249 and the `int('c04')` sort in `hcs.write_hcs_metadata`. It was missed because it fails silently rather than crashing.

## Fix

Guard on `split_well` rather than `isalpha()`. It is the canonical derivation (alphanumeric `A1` and Phenix `r02c05` via `WELL_ROWCOL_PATTERNS`) and raises on anything else, so the existing `except` still catches genuine tiff-mode paths.

## Tests

Parametrized over both conventions in `tests/test_phenix_wells.py`. Without the fix the Phenix case fails with `{'c05'} != {'r02c05', 'r03c05'}`; the `A1`/`B1` case passes either way, confirming no regression to the existing convention. Full file: 21 passed.

## Impact

Anyone with Phenix screens should expect per-well rows where they previously saw per-column ones. Plate-level sums are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1fX4v9YTVtdLKrNJEQT5V