### PR TITLE
feat(aggregate,cluster,phenotype): grouped aggregation, custom features, reference-group nulls

### DIFF
--- a/tests/test_aggregate_grouping.py
+++ b/tests/test_aggregate_grouping.py
@@ -159,6 +159,22 @@ def test_control_mask_ignores_a_control_key_naming_a_group_value():
 # --- Bug class 3: well-annotation join -------------------------------------------
 
 
+def test_control_mask_list_survives_the_control_rename():
+    """prepare_alignment_data uniquifies controls to <name>_<pert_id>.
+
+    An exact-only list match stops seeing them after that rename, which silently
+    skips TVN normalization instead of failing. The suffixed form must still match,
+    while a longer name sharing the prefix (EGFP_10) must not.
+    """
+    values = pd.Series(
+        ["EGFP_1", "EGFP_1_CCTCCGGC", "H2B-EGFP_1_CCTCGCGT", "NES-EGFP_1", "EGFP_10"]
+    )
+
+    flagged = values[control_mask(values, ["EGFP_1", "H2B-EGFP_1"])].tolist()
+
+    assert flagged == ["EGFP_1", "EGFP_1_CCTCCGGC", "H2B-EGFP_1_CCTCGCGT"]
+
+
 def test_join_well_annotations_raises_on_unmapped_well(tmp_path):
     """An unmapped well becomes a NaN group that groupby drops without a word."""
     metadata = pd.DataFrame({"plate": [1, 1], "well": ["A1", "A2"], "cell": [10, 11]})

--- a/tests/test_aggregate_grouping.py
+++ b/tests/test_aggregate_grouping.py
@@ -77,6 +77,21 @@ def test_group_cols_empty_reproduces_single_key_aggregate():
     pd.testing.assert_frame_equal(meta, meta_default)
 
 
+def test_positional_call_still_binds_method_not_group_cols():
+    """group_cols must sit after method: 8_aggregate.py calls aggregate() positionally.
+
+    Inserting it before method silently bound AGG_METHOD ("median") to group_cols, and
+    list("median") splatted into single characters -> KeyError: 'm'.
+    """
+    metadata = pd.DataFrame({"gene": ["A", "A", "B", "B"]})
+    embeddings = np.array([[1.0], [3.0], [10.0], [30.0]])
+
+    _, meta = aggregate(embeddings, metadata, "gene", "median")
+
+    assert list(meta["gene"]) == ["A", "B"]
+    assert "group_cols" not in meta.columns
+
+
 def test_group_cols_yields_one_row_per_perturbation_and_group():
     embeddings = np.arange(14, dtype=float).reshape(7, 2)
     metadata = _cells(

--- a/tests/test_aggregate_grouping.py
+++ b/tests/test_aggregate_grouping.py
@@ -1,0 +1,196 @@
+"""Regression tests for aggregating by an arbitrary label column (split_col/group_cols).
+
+Covers the three bug classes that appear once an aggregated point is
+perturbation x group rather than perturbation alone:
+
+1. Grouping must be inert by default and exact when enabled: group_cols=[] must
+   reproduce the pre-change single-key output row for row, and group_cols=["treatment"]
+   must emit one point per (perturbation, treatment) that still accounts for every input
+   cell. The composite label folded into pert_col is what keeps AnnData obs_names unique
+   once a perturbation appears under several groups, so it must be unique and must not
+   consume the literal group column it was built from.
+2. Control identification must read only the perturbation half of a composite key.
+   The old whole-string `pert.str.contains(control_key)` let a group value satisfy
+   control_key, so a control_key naming a treatment silently relabelled every perturbed
+   cell in that treatment as a control, poisoning centering and the bootstrap null.
+3. `join_well_annotations` must fail loudly instead of corrupting the cell/feature
+   correspondence: an unmapped (plate, well) becomes a NaN group whose cells groupby
+   drops, a repeated (plate, well) multiplies cells through the left join, and the
+   merge's fresh RangeIndex desyncs the class mask from the separately held features
+   frame that split_datasets.py masks with it.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import the way the pipeline does at runtime (workflow/ on path -> top-level `lib`),
+# so aggregate.py's own `from lib.aggregate...` imports resolve too.
+_WORKFLOW = Path(__file__).resolve().parents[1] / "workflow"
+if str(_WORKFLOW) not in sys.path:
+    sys.path.insert(0, str(_WORKFLOW))
+
+from lib.aggregate.aggregate import aggregate  # noqa: E402
+from lib.aggregate.cell_data_utils import (  # noqa: E402
+    GROUP_KEY_SEP,
+    control_mask,
+    join_well_annotations,
+)
+
+PERT_COL = "gene_symbol_0"
+
+
+def _cells(perturbations, treatments):
+    return pd.DataFrame({PERT_COL: perturbations, "treatment": treatments})
+
+
+def _annotations_tsv(tmp_path, rows):
+    fp = tmp_path / "well_annotations.tsv"
+    pd.DataFrame(rows).to_csv(fp, sep="\t", index=False)
+    return fp
+
+
+# --- Bug class 1: grouping keys --------------------------------------------------
+
+
+def test_group_cols_empty_reproduces_single_key_aggregate():
+    """Pinned to the literal pre-group_cols output, so the new grouping path stays inert."""
+    embeddings = np.arange(12, dtype=float).reshape(6, 2)
+    metadata = _cells(
+        ["MYC", "TP53", "MYC", "nontargeting", "TP53", "nontargeting"],
+        ["DMSO", "DMSO", "Cort", "Cort", "Cort", "DMSO"],
+    )
+    expected_meta = pd.DataFrame(
+        {PERT_COL: ["MYC", "TP53", "nontargeting"], "cell_count": [2, 2, 2]}
+    )
+
+    emb, meta = aggregate(embeddings, metadata, PERT_COL, group_cols=[], method="mean")
+
+    assert np.array_equal(emb, np.array([[2.0, 3.0], [5.0, 6.0], [8.0, 9.0]]))
+    pd.testing.assert_frame_equal(meta, expected_meta)
+
+    emb_default, meta_default = aggregate(embeddings, metadata, PERT_COL, method="mean")
+    assert np.array_equal(emb, emb_default)
+    pd.testing.assert_frame_equal(meta, meta_default)
+
+
+def test_group_cols_yields_one_row_per_perturbation_and_group():
+    embeddings = np.arange(14, dtype=float).reshape(7, 2)
+    metadata = _cells(
+        ["MYC", "MYC", "MYC", "TP53", "TP53", "nontargeting", "nontargeting"],
+        ["DMSO", "DMSO", "Cort", "DMSO", "Cort", "DMSO", "Cort"],
+    )
+
+    emb, meta = aggregate(
+        embeddings, metadata, PERT_COL, group_cols=["treatment"], method="mean"
+    )
+
+    assert len(meta) == 6
+    assert emb.shape == (6, 2)
+    assert dict(zip(meta[PERT_COL], meta["cell_count"])) == {
+        "MYC=DMSO": 2,
+        "MYC=Cort": 1,
+        "TP53=DMSO": 1,
+        "TP53=Cort": 1,
+        "nontargeting=DMSO": 1,
+        "nontargeting=Cort": 1,
+    }
+    assert meta["cell_count"].sum() == len(metadata)
+
+
+def test_composite_pert_col_is_unique_and_keeps_literal_group_col():
+    """The composite is the AnnData obs name: MYC under two treatments must not collide,
+    while downstream grouping still needs the literal treatment column beside it."""
+    embeddings = np.arange(8, dtype=float).reshape(4, 2)
+    metadata = _cells(["MYC", "MYC", "TP53", "TP53"], ["DMSO", "Cort", "DMSO", "Cort"])
+
+    _, meta = aggregate(
+        embeddings, metadata, PERT_COL, group_cols=["treatment"], method="mean"
+    )
+
+    assert meta[PERT_COL].is_unique
+    assert set(meta[PERT_COL]) == {"MYC=DMSO", "MYC=Cort", "TP53=DMSO", "TP53=Cort"}
+    assert sorted(meta["treatment"]) == ["Cort", "Cort", "DMSO", "DMSO"]
+    for perturbation, treatment in zip(meta[PERT_COL], meta["treatment"]):
+        assert perturbation.endswith(f"{GROUP_KEY_SEP}{treatment}")
+
+
+# --- Bug class 2: control identification under composite keys --------------------
+
+
+@pytest.mark.parametrize(
+    "keys,expected",
+    [
+        (["nontargeting=Cort", "MYC=Cort"], [True, False]),
+        (["nontargeting_1=DMSO", "TP53=DMSO"], [True, False]),
+        (["nontargeting_1", "TP53"], [True, False]),  # no grouping: unchanged behaviour
+    ],
+)
+def test_control_mask_flags_controls_under_grouping(keys, expected):
+    assert list(control_mask(pd.Series(keys), "nontargeting")) == expected
+
+
+def test_control_mask_ignores_a_control_key_naming_a_group_value():
+    """A control_key matching the group half must flag nothing; the old whole-string
+    contains() flagged 3 of these 4 perturbed rows as controls."""
+    keys = pd.Series(["MYC=DMSO", "TP53=DMSO", "nontargeting_1=DMSO", "MYC=Cort"])
+
+    assert list(control_mask(keys, "DMSO")) == [False, False, False, False]
+
+
+# --- Bug class 3: well-annotation join -------------------------------------------
+
+
+def test_join_well_annotations_raises_on_unmapped_well(tmp_path):
+    """An unmapped well becomes a NaN group that groupby drops without a word."""
+    metadata = pd.DataFrame({"plate": [1, 1], "well": ["A1", "A2"], "cell": [10, 11]})
+    fp = _annotations_tsv(tmp_path, [{"plate": 1, "well": "A1", "treatment": "DMSO"}])
+
+    with pytest.raises(ValueError, match="absent from"):
+        join_well_annotations(metadata, fp)
+
+
+def test_join_well_annotations_raises_on_repeated_well(tmp_path):
+    """A repeated (plate, well) multiplies cells through the left join, desyncing the
+    metadata from the features frame it is carried alongside."""
+    metadata = pd.DataFrame({"plate": [1], "well": ["A1"], "cell": [10]})
+    fp = _annotations_tsv(
+        tmp_path,
+        [
+            {"plate": 1, "well": "A1", "treatment": "DMSO"},
+            {"plate": 1, "well": "A1", "treatment": "Cort"},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="repeats"):
+        join_well_annotations(metadata, fp)
+
+
+def test_join_well_annotations_preserves_index_for_feature_masking(tmp_path):
+    """split_datasets.py masks a separately held features frame with a mask built from
+    the joined metadata, so a merge-fresh RangeIndex misaligns cells from their features
+    whenever the incoming metadata does not already carry a trivial index."""
+    index = [7, 9, 11]
+    metadata = pd.DataFrame(
+        {"plate": [1, 1, 1], "well": ["A1", "A2", "A1"]}, index=index
+    )
+    features = pd.DataFrame({"feature_0": [0.1, 0.2, 0.3]}, index=index)
+    fp = _annotations_tsv(
+        tmp_path,
+        [
+            {"plate": 1, "well": "A1", "treatment": "DMSO"},
+            {"plate": 1, "well": "A2", "treatment": "Cort"},
+        ],
+    )
+
+    joined = join_well_annotations(metadata, fp)
+
+    assert joined.index.equals(pd.Index(index))
+    assert list(joined["treatment"]) == ["DMSO", "Cort", "DMSO"]
+
+    mask = joined["treatment"] == "DMSO"
+    assert list(joined[mask]["well"]) == ["A1", "A1"]
+    assert list(features[mask]["feature_0"]) == [0.1, 0.3]

--- a/tests/test_bootstrap_control_scope.py
+++ b/tests/test_bootstrap_control_scope.py
@@ -1,0 +1,198 @@
+"""Regression tests for which controls the construct bootstrap draws its null from.
+
+`bootstrap_control_scope` picks the control pool once an aggregated point is
+perturbation x group. "pooled" and "within_group" are the historical scopes and must
+stay byte-identical. "reference_group" is for a library where the group is a treatment
+acting on the perturbation itself: an over-expressed receptor moved by its ligand has
+to be tested against the unliganded control state, so the null is pinned to the vehicle
+group rather than to controls that saw the same ligand. Pinning the wrong pool is
+silent — it returns p-values, just against the treated baseline — so the scopes must be
+demonstrably different pools, and a mis-set reference group must raise.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Import the way the pipeline does at runtime (workflow/ on path -> top-level `lib`),
+# so bootstrap.py's own `from lib.aggregate...` imports resolve too.
+_WORKFLOW = Path(__file__).resolve().parents[1] / "workflow"
+if str(_WORKFLOW) not in sys.path:
+    sys.path.insert(0, str(_WORKFLOW))
+
+from lib.aggregate.bootstrap import select_control_pool  # noqa: E402
+from lib.aggregate.cell_data_utils import GROUP_KEY_SEP  # noqa: E402
+
+PERT_COL = "gene_symbol_0"
+GROUP_COLS = ["treatment"]
+
+
+def _controls(keys):
+    """Controls array as bootstrap_construct.py reads it: key column, then features."""
+    return pd.DataFrame(
+        {PERT_COL: keys, "feature_0": [float(i) for i in range(len(keys))]}
+    )
+
+
+CONTROLS = _controls(
+    [
+        "EGFP_1=Ethanol",
+        "H2B-EGFP_1=Ethanol",
+        "EGFP_1=Corticosterone",
+        "H2B-EGFP_1=Corticosterone",
+        "EGFP_1=Progesterone",
+    ]
+)
+
+
+def _keys(control_pool):
+    return list(control_pool[PERT_COL])
+
+
+# --- Historical scopes ------------------------------------------------------------
+
+
+def test_pooled_keeps_every_control():
+    pool = select_control_pool(CONTROLS, "NR3C1_5=Corticosterone", "pooled")
+
+    pd.testing.assert_frame_equal(pool, CONTROLS)
+
+
+def test_within_group_keeps_the_constructs_own_group():
+    pool = select_control_pool(CONTROLS, "NR3C1_5=Corticosterone", "within_group")
+
+    assert _keys(pool) == ["EGFP_1=Corticosterone", "H2B-EGFP_1=Corticosterone"]
+
+
+def test_within_group_is_inert_without_a_composite_key():
+    """No group_cols means no group half to split on, so the pool stays pooled."""
+    controls = _controls(["EGFP_1", "H2B-EGFP_1"])
+
+    pool = select_control_pool(controls, "NR3C1_5", "within_group")
+
+    pd.testing.assert_frame_equal(pool, controls)
+
+
+def test_within_group_raises_on_a_group_with_no_controls():
+    with pytest.raises(
+        ValueError, match="No control cells found for group 'Estradiol'"
+    ):
+        select_control_pool(CONTROLS, "NR3C1_5=Estradiol", "within_group")
+
+
+def test_unknown_scope_raises():
+    with pytest.raises(ValueError, match="Unknown bootstrap_control_scope: vehicle"):
+        select_control_pool(CONTROLS, "NR3C1_5=Ethanol", "vehicle")
+
+
+# --- Reference group scope --------------------------------------------------------
+
+
+def test_reference_group_pins_the_pool_across_groups():
+    for construct_id in ["NR3C1_5=Corticosterone", "NR3C1_5=Progesterone"]:
+        pool = select_control_pool(
+            CONTROLS,
+            construct_id,
+            "reference_group",
+            reference_group="Ethanol",
+            group_cols=GROUP_COLS,
+        )
+
+        assert _keys(pool) == ["EGFP_1=Ethanol", "H2B-EGFP_1=Ethanol"]
+
+
+def test_reference_group_pool_differs_from_within_group_pool():
+    """The whole point of the scope: same construct, a different set of control cells."""
+    construct_id = "NR3C1_5=Corticosterone"
+
+    reference_pool = select_control_pool(
+        CONTROLS,
+        construct_id,
+        "reference_group",
+        reference_group="Ethanol",
+        group_cols=GROUP_COLS,
+    )
+    within_pool = select_control_pool(CONTROLS, construct_id, "within_group")
+
+    assert set(_keys(reference_pool)).isdisjoint(_keys(within_pool))
+    assert all(k.endswith(f"{GROUP_KEY_SEP}Ethanol") for k in _keys(reference_pool))
+
+
+def test_reference_group_matches_within_group_inside_the_reference_group():
+    """A construct already in the reference group must see the same null either way."""
+    construct_id = "NR3C1_5=Ethanol"
+
+    reference_pool = select_control_pool(
+        CONTROLS,
+        construct_id,
+        "reference_group",
+        reference_group="Ethanol",
+        group_cols=GROUP_COLS,
+    )
+
+    pd.testing.assert_frame_equal(
+        reference_pool, select_control_pool(CONTROLS, construct_id, "within_group")
+    )
+
+
+def test_reference_group_absent_from_the_control_pool_raises():
+    with pytest.raises(ValueError, match="'DMSO' is absent from the control pool"):
+        select_control_pool(
+            CONTROLS,
+            "NR3C1_5=Corticosterone",
+            "reference_group",
+            reference_group="DMSO",
+            group_cols=GROUP_COLS,
+        )
+
+
+def test_reference_group_error_lists_the_groups_that_are_present():
+    with pytest.raises(ValueError) as excinfo:
+        select_control_pool(
+            CONTROLS,
+            "NR3C1_5=Corticosterone",
+            "reference_group",
+            reference_group="Etahnol",
+            group_cols=GROUP_COLS,
+        )
+
+    assert "Corticosterone" in str(excinfo.value)
+    assert "Ethanol" in str(excinfo.value)
+
+
+def test_reference_group_raises_without_group_cols():
+    """Ungrouped controls carry no group, so silently falling back to pooled would
+    swap the null the operator asked for without a word."""
+    controls = _controls(["EGFP_1", "H2B-EGFP_1"])
+
+    with pytest.raises(ValueError, match="needs aggregate group_cols"):
+        select_control_pool(
+            controls, "NR3C1_5", "reference_group", reference_group="Ethanol"
+        )
+
+
+def test_reference_group_raises_without_a_reference_group_value():
+    with pytest.raises(ValueError, match="requires bootstrap_reference_group"):
+        select_control_pool(
+            CONTROLS, "NR3C1_5=Corticosterone", "reference_group", group_cols=GROUP_COLS
+        )
+
+
+def test_reference_group_spans_several_group_cols():
+    """Several group_cols fold into one key joined by GROUP_KEY_SEP, so the reference
+    value is the whole joined key, not just the first column's value."""
+    controls = _controls(
+        ["EGFP_1=Ethanol=6h", "EGFP_1=Ethanol=24h", "EGFP_1=Corticosterone=6h"]
+    )
+
+    pool = select_control_pool(
+        controls,
+        "NR3C1_5=Corticosterone=6h",
+        "reference_group",
+        reference_group=f"Ethanol{GROUP_KEY_SEP}6h",
+        group_cols=["treatment", "timepoint"],
+    )
+
+    assert _keys(pool) == ["EGFP_1=Ethanol=6h"]

--- a/tests/test_cluster_control_scope.py
+++ b/tests/test_cluster_control_scope.py
@@ -1,0 +1,288 @@
+"""Regression tests for which controls the cluster potential is measured against.
+
+`control_scope` picks the control rows `calculate_potential_to_nontargeting` averages
+each point's diffusion-potential distance over. "pooled" is the historical scope and
+must stay byte-identical. "reference_group" is for a library where the group is a
+treatment acting on the perturbation itself: an over-expressed receptor moved by its
+ligand has to be scored against the unliganded control state, so the null is pinned to
+the vehicle group rather than to a control cloud averaged across every treatment.
+Pinning the wrong pool is silent — it returns distances, just to the treated baseline —
+so the scopes must be demonstrably different pools, and a mis-set reference group must
+raise.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.spatial.distance import pdist, squareform
+
+# Import the way the pipeline does at runtime (workflow/ on path -> top-level `lib`),
+# so phate_leiden_clustering.py's own `from lib.aggregate...` imports resolve too.
+_WORKFLOW = Path(__file__).resolve().parents[1] / "workflow"
+if str(_WORKFLOW) not in sys.path:
+    sys.path.insert(0, str(_WORKFLOW))
+
+from lib.aggregate.cell_data_utils import GROUP_KEY_SEP  # noqa: E402
+from lib.cluster.phate_leiden_clustering import (  # noqa: E402
+    calculate_potential_to_nontargeting,
+    select_control_indices,
+)
+
+PERT_COL = "gene_symbol_0"
+CONTROL_KEY = ["EGFP_1", "H2B-EGFP_1"]
+GROUP_COLS = ["treatment"]
+
+KEYS = [
+    "NR3C1_5=Corticosterone",
+    "NR3C1_5=Ethanol",
+    "NR3C1_5=Progesterone",
+    "EGFP_1=Ethanol",
+    "H2B-EGFP_1=Ethanol",
+    "EGFP_1=Corticosterone",
+    "H2B-EGFP_1=Corticosterone",
+    "EGFP_1=Progesterone",
+    "H2B-EGFP_1=Progesterone",
+]
+PERTURBATIONS = pd.Series(KEYS, name=PERT_COL)
+
+
+def _potential(keys):
+    """Potential frame as phate_leiden_pipeline emits it: key column, then potentials."""
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            PERT_COL: keys,
+            "potential_0": rng.normal(size=len(keys)),
+            "potential_1": rng.normal(size=len(keys)),
+        }
+    )
+
+
+def _keys(indices):
+    return [KEYS[i] for i in indices]
+
+
+# --- Pooled scope -----------------------------------------------------------------
+
+
+def test_pooled_scores_every_point_against_every_control():
+    scoped = select_control_indices(PERTURBATIONS, CONTROL_KEY)
+
+    assert set(scoped) == set(PERTURBATIONS.index)
+    for indices in scoped.values():
+        assert _keys(indices) == KEYS[3:]
+
+
+def test_pooled_is_the_default_and_reproduces_the_unscoped_distances():
+    """The historical null: mean distance to every control row, in index order."""
+    potential_df = _potential(KEYS)
+    distances = squareform(pdist(potential_df[["potential_0", "potential_1"]].values))
+    expected = [np.mean(distances[i, 3:]) for i in range(len(KEYS))]
+
+    result = calculate_potential_to_nontargeting(potential_df, CONTROL_KEY)
+
+    assert result["mean_potential_to_nontargeting"].tolist() == pytest.approx(expected)
+
+
+# --- Within group scope -----------------------------------------------------------
+
+
+def test_within_group_scores_each_point_against_its_own_group():
+    scoped = select_control_indices(PERTURBATIONS, CONTROL_KEY, "within_group")
+
+    assert _keys(scoped[0]) == ["EGFP_1=Corticosterone", "H2B-EGFP_1=Corticosterone"]
+    assert _keys(scoped[1]) == ["EGFP_1=Ethanol", "H2B-EGFP_1=Ethanol"]
+    assert _keys(scoped[2]) == ["EGFP_1=Progesterone", "H2B-EGFP_1=Progesterone"]
+
+
+def test_within_group_is_inert_without_a_composite_key():
+    """No group_cols means no group half to split on, so the null stays pooled."""
+    perturbations = pd.Series(["NR3C1_5", "EGFP_1", "H2B-EGFP_1"])
+
+    scoped = select_control_indices(perturbations, CONTROL_KEY, "within_group")
+
+    assert all(indices == [1, 2] for indices in scoped.values())
+
+
+def test_within_group_raises_on_a_group_with_no_controls():
+    perturbations = pd.concat(
+        [PERTURBATIONS, pd.Series(["NR3C1_5=Estradiol"])], ignore_index=True
+    )
+
+    with pytest.raises(
+        ValueError, match="No control cells found for group 'Estradiol'"
+    ):
+        select_control_indices(perturbations, CONTROL_KEY, "within_group")
+
+
+def test_unknown_scope_raises():
+    with pytest.raises(ValueError, match="Unknown control_scope: vehicle"):
+        select_control_indices(PERTURBATIONS, CONTROL_KEY, "vehicle")
+
+
+# --- Reference group scope --------------------------------------------------------
+
+
+def test_reference_group_pins_every_point_to_one_group():
+    scoped = select_control_indices(
+        PERTURBATIONS,
+        CONTROL_KEY,
+        "reference_group",
+        reference_group="Ethanol",
+        group_cols=GROUP_COLS,
+    )
+
+    for indices in scoped.values():
+        assert _keys(indices) == ["EGFP_1=Ethanol", "H2B-EGFP_1=Ethanol"]
+
+
+def test_reference_group_set_is_disjoint_from_the_rest_of_the_pooled_set():
+    """The reference null is a strict subset of the pooled null, and the controls it
+    drops — every non-vehicle control — share no row with the ones it keeps."""
+    pooled = select_control_indices(PERTURBATIONS, CONTROL_KEY)[0]
+    reference = select_control_indices(
+        PERTURBATIONS,
+        CONTROL_KEY,
+        "reference_group",
+        reference_group="Ethanol",
+        group_cols=GROUP_COLS,
+    )[0]
+
+    assert set(reference) < set(pooled)
+    assert set(reference).isdisjoint(set(pooled) - set(reference))
+    assert all(k.endswith(f"{GROUP_KEY_SEP}Ethanol") for k in _keys(reference))
+
+
+def test_reference_group_pool_differs_from_within_group_pool():
+    """The whole point of the scope: same point, a different set of control rows."""
+    treated = 0
+
+    reference = select_control_indices(
+        PERTURBATIONS,
+        CONTROL_KEY,
+        "reference_group",
+        reference_group="Ethanol",
+        group_cols=GROUP_COLS,
+    )[treated]
+    within = select_control_indices(PERTURBATIONS, CONTROL_KEY, "within_group")[treated]
+
+    assert set(reference).isdisjoint(within)
+
+
+def test_reference_group_moves_the_measured_distances():
+    """A pinned null must reach the emitted column, not just the index selection."""
+    potential_df = _potential(KEYS)
+
+    pooled = calculate_potential_to_nontargeting(potential_df, CONTROL_KEY)
+    reference = calculate_potential_to_nontargeting(
+        potential_df,
+        CONTROL_KEY,
+        control_scope="reference_group",
+        reference_group="Ethanol",
+        group_cols=GROUP_COLS,
+    )
+
+    distances = squareform(pdist(potential_df[["potential_0", "potential_1"]].values))
+    expected = [np.mean(distances[i, [3, 4]]) for i in range(len(KEYS))]
+    assert reference["mean_potential_to_nontargeting"].tolist() == pytest.approx(
+        expected
+    )
+    assert not np.allclose(
+        reference["mean_potential_to_nontargeting"],
+        pooled["mean_potential_to_nontargeting"],
+    )
+
+
+def test_reference_group_matches_within_group_inside_the_reference_group():
+    """A point already in the reference group must see the same null either way."""
+    vehicle = 1
+
+    reference = select_control_indices(
+        PERTURBATIONS,
+        CONTROL_KEY,
+        "reference_group",
+        reference_group="Ethanol",
+        group_cols=GROUP_COLS,
+    )[vehicle]
+
+    assert (
+        reference
+        == select_control_indices(PERTURBATIONS, CONTROL_KEY, "within_group")[vehicle]
+    )
+
+
+def test_reference_group_absent_from_the_control_pool_raises():
+    with pytest.raises(ValueError, match="'DMSO' is absent from the control pool"):
+        select_control_indices(
+            PERTURBATIONS,
+            CONTROL_KEY,
+            "reference_group",
+            reference_group="DMSO",
+            group_cols=GROUP_COLS,
+        )
+
+
+def test_reference_group_error_lists_the_groups_that_are_present():
+    with pytest.raises(ValueError) as excinfo:
+        select_control_indices(
+            PERTURBATIONS,
+            CONTROL_KEY,
+            "reference_group",
+            reference_group="Etahnol",
+            group_cols=GROUP_COLS,
+        )
+
+    assert "Corticosterone" in str(excinfo.value)
+    assert "Ethanol" in str(excinfo.value)
+
+
+def test_reference_group_raises_without_group_cols():
+    """Ungrouped points carry no group, so silently falling back to pooled would swap
+    the null the operator asked for without a word."""
+    with pytest.raises(ValueError, match="needs aggregate group_cols"):
+        select_control_indices(
+            PERTURBATIONS, CONTROL_KEY, "reference_group", reference_group="Ethanol"
+        )
+
+
+def test_reference_group_raises_without_a_reference_group_value():
+    with pytest.raises(ValueError, match="requires control_reference_group"):
+        select_control_indices(
+            PERTURBATIONS, CONTROL_KEY, "reference_group", group_cols=GROUP_COLS
+        )
+
+
+def test_reference_group_raises_on_ungrouped_perturbation_names():
+    """group_cols set but an aggregated table written before grouping: the suffix the
+    scope splits on is simply absent, so pinning cannot be honoured."""
+    perturbations = pd.Series(["NR3C1_5", "EGFP_1", "H2B-EGFP_1"])
+
+    with pytest.raises(ValueError, match="needs grouped perturbation names"):
+        select_control_indices(
+            perturbations,
+            CONTROL_KEY,
+            "reference_group",
+            reference_group="Ethanol",
+            group_cols=GROUP_COLS,
+        )
+
+
+def test_reference_group_spans_several_group_cols():
+    """Several group_cols fold into one key joined by GROUP_KEY_SEP, so the reference
+    value is the whole joined key, not just the first column's value."""
+    perturbations = pd.Series(
+        ["NR3C1_5=Corticosterone=6h", "EGFP_1=Ethanol=6h", "EGFP_1=Ethanol=24h"]
+    )
+
+    scoped = select_control_indices(
+        perturbations,
+        CONTROL_KEY,
+        "reference_group",
+        reference_group=f"Ethanol{GROUP_KEY_SEP}6h",
+        group_cols=["treatment", "timepoint"],
+    )
+
+    assert scoped[0] == [1]

--- a/tests/test_custom_phenotype_features.py
+++ b/tests/test_custom_phenotype_features.py
@@ -1,0 +1,349 @@
+"""Tests for user-defined per-cell phenotype features registered from the notebook.
+
+Covers the four properties a registered feature has to hold for a hand-designed
+measurement to be comparable against an external pipeline:
+
+1. A named callable over a regionprops-like region becomes a real column in the
+   cp_emulator output, alongside the built-in features rather than instead of them.
+2. The column is namespaced and carries a hash of the definition, so a reader of
+   merge_final.parquet can tell which definition produced it and a silent edit to
+   the definition cannot masquerade as the same measurement.
+3. The definition survives the notebook -> config.yml -> workflow hop, which is a
+   YAML round trip into a separate process, and the rebuilt function measures the
+   same values as the original. A definition that would not survive it, because it
+   closes over a notebook name, is refused in the notebook instead.
+4. A feature that raises, or that returns something other than a number, fails with
+   the feature name instead of writing NaN into a column nobody audits.
+5. The feature is measured on the compartment it declares, and the column says which
+   one, so a nuclear measurement is not silently taken over the cell mask.
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+# Import the way the pipeline does at runtime (workflow/ on path -> top-level `lib`).
+_WORKFLOW = Path(__file__).resolve().parents[1] / "workflow"
+if str(_WORKFLOW) not in sys.path:
+    sys.path.insert(0, str(_WORKFLOW))
+
+from lib.aggregate.cell_data_utils import (  # noqa: E402
+    channel_combo_subset,
+    get_feature_table_cols,
+    split_cell_data,
+)
+from lib.phenotype.constants import DEFAULT_METADATA_COLS  # noqa: E402
+from lib.phenotype.custom_features import (  # noqa: E402
+    custom_feature_column,
+    load_custom_features,
+    register_custom_features,
+)
+from lib.phenotype.extract_phenotype_cp_emulator import (  # noqa: E402
+    extract_phenotype_cp_emulator,
+)
+from lib.shared.file_utils import validate_dtypes  # noqa: E402
+
+CHANNEL_NAMES = ["dapi", "v5"]
+
+
+def puncta_count(region):
+    return int((region.intensity_image[..., 1] > 400).sum())
+
+
+def _uses_a_notebook_import(region):
+    return int(np.count_nonzero(region.intensity_image[..., 1] > 400))
+
+
+def _synthetic_tile():
+    rng = np.random.default_rng(0)
+    height = width = 40
+    nuclei = np.zeros((height, width), dtype=np.uint16)
+    cells = np.zeros((height, width), dtype=np.uint16)
+    for label, (i, j) in enumerate([(8, 8), (8, 28), (28, 8)], start=1):
+        cells[i - 6 : i + 6, j - 6 : j + 6] = label
+        nuclei[i - 3 : i + 3, j - 3 : j + 3] = label
+    data = rng.integers(0, 500, size=(2, height, width)).astype(np.uint16)
+    cytoplasms = np.where(nuclei > 0, 0, cells)
+
+    return data, nuclei, cells, cytoplasms
+
+
+def _extract(custom_features, segment_cells=True, segment_cytoplasms=False):
+    data, nuclei, cells, cytoplasms = _synthetic_tile()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        return extract_phenotype_cp_emulator(
+            data,
+            nuclei,
+            cells if segment_cells else None,
+            wildcards={"well": "A1", "tile": 1},
+            cytoplasms=cytoplasms if segment_cytoplasms else None,
+            channel_names=CHANNEL_NAMES,
+            custom_features=custom_features,
+        )
+
+
+# --- Property 1: a registered callable becomes a column ---------------------------
+
+
+def test_registered_feature_becomes_a_column():
+    definitions = register_custom_features([puncta_count])
+    column = definitions[0]["column"]
+
+    result = _extract(load_custom_features(definitions))
+
+    assert column in result.columns
+    assert result[column].tolist() == [9, 6, 10]
+
+
+def test_built_in_features_are_unchanged_by_registration():
+    baseline = _extract(None)
+    with_custom = _extract(
+        load_custom_features(register_custom_features([puncta_count]))
+    )
+
+    shared = [col for col in baseline.columns if col in with_custom.columns]
+    assert shared == baseline.columns.tolist()
+    pd.testing.assert_frame_equal(with_custom[shared], baseline)
+
+
+def test_no_registration_leaves_the_output_free_of_custom_columns():
+    result = _extract(load_custom_features(None))
+
+    assert [col for col in result.columns if "custom" in col] == []
+
+
+# --- Property 2: namespaced, and the definition travels with the column -----------
+
+
+def test_column_is_namespaced_and_carries_the_definition_hash():
+    definitions = register_custom_features([puncta_count])
+    definition = definitions[0]
+
+    assert definition["column"] == custom_feature_column(
+        "puncta_count", definition["hash"], definition["compartment"]
+    )
+    assert definition["column"].startswith("nucleus_custom_puncta_count_")
+    assert definition["source"].lstrip().startswith("def puncta_count(region):")
+
+
+def test_editing_the_definition_changes_the_column():
+    def drifted(region):
+        return int((region.intensity_image[..., 1] > 401).sum())
+
+    drifted.__name__ = "puncta_count"
+
+    original = register_custom_features([puncta_count])[0]
+    edited = register_custom_features([drifted])[0]
+
+    assert original["name"] == edited["name"]
+    assert original["column"] != edited["column"]
+
+
+def test_a_column_colliding_with_a_built_in_feature_raises():
+    with pytest.raises(ValueError, match="collide"):
+        _extract({"nucleus": {"nucleus_area": lambda region: 1}})
+
+
+def test_registering_the_same_name_twice_raises():
+    with pytest.raises(ValueError, match="registered more than once"):
+        register_custom_features([puncta_count, puncta_count])
+
+
+def test_registering_a_lambda_raises():
+    with pytest.raises(ValueError, match="named functions"):
+        register_custom_features([lambda region: 1])
+
+
+# --- Property 3: the definition survives the config hop ---------------------------
+
+
+def test_definitions_survive_a_yaml_round_trip(tmp_path):
+    config_fp = tmp_path / "config.yml"
+    definitions = register_custom_features([puncta_count, (puncta_count, "cell")])
+    config_fp.write_text(yaml.dump({"phenotype": {"custom_features": definitions}}))
+
+    loaded = yaml.safe_load(config_fp.read_text())["phenotype"]["custom_features"]
+    assert loaded == definitions
+
+    result = _extract(load_custom_features(loaded))
+    assert result[definitions[0]["column"]].tolist() == [9, 6, 10]
+    assert result[definitions[1]["column"]].tolist() == [34, 28, 32]
+
+
+def test_registering_a_feature_that_closes_over_a_notebook_name_raises():
+    threshold = 400
+
+    def uses_a_notebook_name(region):
+        return int((region.intensity_image[..., 1] > threshold).sum())
+
+    with pytest.raises(ValueError, match="uses names it does not define"):
+        register_custom_features([uses_a_notebook_name])
+
+
+def test_registering_a_feature_using_a_notebook_import_raises():
+    with pytest.raises(ValueError, match=r"does not define: \['np'\]"):
+        register_custom_features([_uses_a_notebook_import])
+
+
+# --- Property 4: new columns are features downstream, and failures are loud -------
+
+
+def test_custom_column_is_treated_as_a_feature_not_metadata():
+    definitions = register_custom_features([puncta_count])
+    column = definitions[0]["column"]
+    # validate_dtypes is what the merge steps run before aggregate splits the frame
+    result = validate_dtypes(_extract(load_custom_features(definitions)))
+
+    metadata, features = split_cell_data(result, DEFAULT_METADATA_COLS)
+
+    assert column not in DEFAULT_METADATA_COLS
+    assert column not in metadata.columns
+    assert column in features.columns
+    assert pd.api.types.is_numeric_dtype(features[column])
+
+
+def test_a_feature_that_raises_names_itself_instead_of_emitting_nan():
+    def brittle_count(region):
+        if region.label == 2:
+            raise ZeroDivisionError("division by zero")
+        return 1
+
+    definitions = register_custom_features([brittle_count])
+
+    with pytest.raises(ValueError, match="brittle_count.*label 2"):
+        _extract(load_custom_features(definitions))
+
+
+def test_a_feature_returning_a_non_number_names_itself():
+    def per_channel_count(region):
+        return (region.intensity_image > 400).sum(axis=(0, 1))
+
+    definitions = register_custom_features([per_channel_count])
+
+    with pytest.raises(ValueError, match="per_channel_count.*expected a single number"):
+        _extract(load_custom_features(definitions))
+
+
+def test_a_boolean_feature_is_accepted():
+    def is_bright(region):
+        return bool(region.intensity_image[..., 1].mean() > 250)
+
+    definitions = register_custom_features([is_bright])
+    result = _extract(load_custom_features(definitions))
+
+    assert result[definitions[0]["column"]].dtype == bool
+
+
+# --- Property 5: the feature is measured on the compartment it declares -----------
+
+
+def test_a_bare_feature_is_measured_on_the_nucleus():
+    definitions = register_custom_features([puncta_count])
+    column = definitions[0]["column"]
+
+    result = _extract(load_custom_features(definitions))
+
+    assert definitions[0]["compartment"] == "nucleus"
+    assert column.startswith("nucleus_custom_")
+    assert result[column].tolist() == [9, 6, 10]
+
+
+def test_declaring_the_cell_is_measured_on_the_cell_mask():
+    definitions = register_custom_features([(puncta_count, "cell")])
+    column = definitions[0]["column"]
+
+    result = _extract(load_custom_features(definitions))
+
+    assert column.startswith("cell_custom_")
+    assert result[column].tolist() == [34, 28, 32]
+
+
+def test_declaring_the_cytoplasm_is_measured_on_the_cytoplasm_mask():
+    definitions = register_custom_features([(puncta_count, "cytoplasm")])
+    column = definitions[0]["column"]
+
+    result = _extract(load_custom_features(definitions), segment_cytoplasms=True)
+
+    assert column.startswith("cytoplasm_custom_")
+    assert result[column].tolist() == [25, 22, 22]
+
+
+def test_one_definition_measured_on_two_compartments_gives_two_columns():
+    nucleus, cell = register_custom_features(
+        [(puncta_count, "nucleus"), (puncta_count, "cell")]
+    )
+
+    result = _extract(load_custom_features([nucleus, cell]))
+
+    assert nucleus["hash"] == cell["hash"]
+    assert nucleus["column"] != cell["column"]
+    assert result[nucleus["column"]].tolist() == [9, 6, 10]
+    assert result[cell["column"]].tolist() == [34, 28, 32]
+
+
+def test_a_column_sorts_with_the_compartment_it_measures():
+    definitions = register_custom_features(
+        [(puncta_count, "nucleus"), (puncta_count, "cell")]
+    )
+
+    columns = _extract(load_custom_features(definitions)).columns.tolist()
+
+    assert columns.index(definitions[0]["column"]) < columns.index("cell_area")
+    assert columns.index(definitions[1]["column"]) > columns.index("nucleus_area")
+
+
+def test_declaring_the_cytoplasm_without_cytoplasm_segmentation_raises():
+    definitions = register_custom_features([(puncta_count, "cytoplasm")])
+
+    with pytest.raises(
+        ValueError, match="cytoplasm compartment, which is not segmented"
+    ):
+        _extract(load_custom_features(definitions))
+
+
+def test_declaring_the_cell_without_cell_segmentation_raises():
+    definitions = register_custom_features([(puncta_count, "cell")])
+
+    with pytest.raises(ValueError, match="cell compartment, which is not segmented"):
+        _extract(load_custom_features(definitions), segment_cells=False)
+
+
+def test_declaring_an_unknown_compartment_raises():
+    with pytest.raises(ValueError, match="unknown compartment 'nuclei'"):
+        register_custom_features([(puncta_count, "nuclei")])
+
+
+def test_registering_the_same_name_on_two_compartments_is_allowed():
+    definitions = register_custom_features(
+        [(puncta_count, "nucleus"), (puncta_count, "cell")]
+    )
+
+    assert [definition["compartment"] for definition in definitions] == [
+        "nucleus",
+        "cell",
+    ]
+
+    with pytest.raises(ValueError, match="registered more than once"):
+        register_custom_features([(puncta_count, "cell"), (puncta_count, "cell")])
+
+
+def test_the_compartment_prefix_drives_downstream_column_selection():
+    definitions = register_custom_features(
+        [(puncta_count, "nucleus"), (puncta_count, "cytoplasm")]
+    )
+    result = _extract(load_custom_features(definitions), segment_cytoplasms=True)
+
+    # get_feature_table_cols keeps the nucleus and cell compartments only
+    selected = get_feature_table_cols(result.columns.tolist(), extra_tags=["custom"])
+    assert definitions[0]["column"] in selected
+    assert definitions[1]["column"] not in selected
+
+    kept = channel_combo_subset(result, ["dapi"], CHANNEL_NAMES)
+    assert definitions[0]["column"] in kept.columns

--- a/workflow/lib/aggregate/aggregate.py
+++ b/workflow/lib/aggregate/aggregate.py
@@ -8,6 +8,8 @@ and cell counts.
 import numpy as np
 import pandas as pd
 
+from lib.aggregate.cell_data_utils import GROUP_KEY_SEP
+
 
 def aggregate(
     embeddings: np.ndarray,
@@ -79,6 +81,12 @@ def aggregate(
         # groupby yields a scalar key for one column and a tuple for several
         keys = keys if isinstance(keys, tuple) else (keys,)
         agg_meta = dict(zip(group_keys, keys))
+
+        # pert_col carries the composite so it stays unique as an obs name and matches the
+        # bootstrap tables; the group columns are kept alongside it for grouping downstream
+        if group_cols:
+            agg_meta[pert_col] = GROUP_KEY_SEP.join(str(key) for key in keys)
+
         agg_meta["cell_count"] = len(group)
 
         # Always include perturbation_auc if present (needed for gene-level filtering in clustering)

--- a/workflow/lib/aggregate/aggregate.py
+++ b/workflow/lib/aggregate/aggregate.py
@@ -15,10 +15,10 @@ def aggregate(
     embeddings: np.ndarray,
     metadata: pd.DataFrame,
     pert_col: str,
-    group_cols: list = None,
     method="mean",
     ps_probability_threshold=None,
     ps_percentile_threshold=None,
+    group_cols: list = None,
 ) -> tuple[np.ndarray, pd.DataFrame]:
     """Apply mean or median aggregation to replicate embeddings and perturbation scores for each perturbation.
 

--- a/workflow/lib/aggregate/aggregate.py
+++ b/workflow/lib/aggregate/aggregate.py
@@ -13,6 +13,7 @@ def aggregate(
     embeddings: np.ndarray,
     metadata: pd.DataFrame,
     pert_col: str,
+    group_cols: list = None,
     method="mean",
     ps_probability_threshold=None,
     ps_percentile_threshold=None,
@@ -27,6 +28,8 @@ def aggregate(
         embeddings (numpy.ndarray): The embeddings to be aggregated.
         metadata (pandas.DataFrame): The metadata containing information about the embeddings.
         pert_col (str): The column in the metadata containing perturbation information.
+        group_cols (list, optional): Additional metadata columns to aggregate within, so a
+            point becomes perturbation x these columns (e.g. ["treatment"]). Defaults to None.
         method (str, optional): The aggregation method to use. Must be either "mean" or "median".
             Defaults to "mean".
         ps_probability_threshold (float, optional): Threshold for filtering based on perturbation score.
@@ -67,15 +70,16 @@ def aggregate(
         metadata = metadata.loc[mask].reset_index(drop=True)
         embeddings = embeddings[mask.to_numpy(), :]
 
-    grouping = metadata.groupby(pert_col)
-    for pert, group in grouping:
+    group_keys = [pert_col] + list(group_cols or [])
+    grouping = metadata.groupby(group_keys)
+    for keys, group in grouping:
         final_emb = aggr_func(embeddings[group.index.values, :], axis=0)
         aggregated_embeddings.append(final_emb)
 
-        agg_meta = {
-            pert_col: pert,
-            "cell_count": len(group),
-        }
+        # groupby yields a scalar key for one column and a tuple for several
+        keys = keys if isinstance(keys, tuple) else (keys,)
+        agg_meta = dict(zip(group_keys, keys))
+        agg_meta["cell_count"] = len(group)
 
         # Always include perturbation_auc if present (needed for gene-level filtering in clustering)
         if "perturbation_auc" in metadata.columns:

--- a/workflow/lib/aggregate/align.py
+++ b/workflow/lib/aggregate/align.py
@@ -11,6 +11,8 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.decomposition import PCA
 from scipy import linalg
 
+from lib.aggregate.cell_data_utils import control_mask
+
 
 def prepare_alignment_data(
     metadata, features, batch_cols, pert_col, control_key, pert_id_col
@@ -22,7 +24,7 @@ def prepare_alignment_data(
         features (pd.DataFrame): DataFrame containing feature data.
         batch_cols (list): List of column names used to generate batch values.
         pert_col (str): Column name representing perturbation labels.
-        control_key (str): Key for identifying control samples in the metadata.
+        control_key (str | list): Key for identifying control samples in the metadata.
         pert_id_col (str): Column name for perturbation IDs.
 
     Returns:
@@ -40,9 +42,11 @@ def prepare_alignment_data(
 
     # Add unique number suffix to perturbation names based on pert_id_col
     if control_key is not None and pert_col is not None and pert_id_col is not None:
-        control_mask = metadata[pert_col] == control_key
-        metadata.loc[control_mask, pert_col] = (
-            control_key + "_" + metadata.loc[control_mask, pert_id_col].astype(str)
+        mask = control_mask(metadata[pert_col], control_key, match="startswith")
+        metadata.loc[mask, pert_col] = (
+            metadata.loc[mask, pert_col].astype(str)
+            + "_"
+            + metadata.loc[mask, pert_id_col].astype(str)
         )
 
     # Extract feature data
@@ -140,7 +144,7 @@ def tvn_on_controls(
     embeddings: np.ndarray,
     metadata: pd.DataFrame,
     pert_col: str,
-    control_key: str,
+    control_key: str | list,
     batch_col: str | None = None,
     control_col: str | None = None,
 ) -> np.ndarray:
@@ -152,7 +156,7 @@ def tvn_on_controls(
         embeddings (np.ndarray): The embeddings to be normalized.
         metadata (pd.DataFrame): The metadata containing information about the samples.
         pert_col (str): The column name in the metadata DataFrame that represents the perturbation labels.
-        control_key (str): The control perturbation label.
+        control_key (str | list): The control perturbation label.
         batch_col (str, optional): Column name in the metadata DataFrame representing the batch labels
             to be used for CORAL normalization. Defaults to None.
         control_col (str, optional): Column name to use for identifying control cells.
@@ -163,7 +167,9 @@ def tvn_on_controls(
         np.ndarray: The normalized embeddings.
     """
     lookup_col = control_col if control_col is not None else pert_col
-    ctrl_ind = metadata[lookup_col].str.startswith(control_key).to_list()
+    ctrl_ind = control_mask(
+        metadata[lookup_col], control_key, match="startswith"
+    ).to_list()
     n_controls = sum(ctrl_ind)
     if n_controls == 0:
         print("Warning: no control cells found, skipping TVN normalization")
@@ -185,7 +191,10 @@ def tvn_on_controls(
         for batch in batches:
             batch_ind = metadata[batch_col] == batch
             batch_control_ind = (
-                batch_ind & (metadata[lookup_col].str.startswith(control_key)).to_list()
+                batch_ind
+                & control_mask(
+                    metadata[lookup_col], control_key, match="startswith"
+                ).to_list()
             )
             n_controls = np.sum(batch_control_ind)
             if n_controls < embeddings.shape[1]:
@@ -258,7 +267,7 @@ def centerscale_on_controls(
     embeddings: np.ndarray,
     metadata: pd.DataFrame,
     pert_col: str,
-    control_key: str,
+    control_key: str | list,
     batch_col: str | None = None,
     method: str = "standard",
     control_col: str | None = None,
@@ -271,7 +280,7 @@ def centerscale_on_controls(
         embeddings (numpy.ndarray): The embeddings to be aligned.
         metadata (pandas.DataFrame): The metadata containing information about the embeddings.
         pert_col (str): The column in the metadata containing perturbation information.
-        control_key (str): The key for non-targeting controls in the metadata.
+        control_key (str | list): The key for non-targeting controls in the metadata.
         batch_col (str, optional): Column name in the metadata representing the batch labels.
             Defaults to None.
         method (str, optional): Scaling method to use. Options are "standard" (mean/std)
@@ -294,7 +303,7 @@ def centerscale_on_controls(
 
     # boolean mask for "control" rows uses startswith on stringified column, handles NaNs
     lookup_col = control_col if control_col is not None else pert_col
-    ctrl_mask_all = metadata[lookup_col].astype(str).str.startswith(control_key)
+    ctrl_mask_all = control_mask(metadata[lookup_col], control_key, match="startswith")
 
     if batch_col is not None:
         for batch in metadata[batch_col].unique():

--- a/workflow/lib/aggregate/bootstrap.py
+++ b/workflow/lib/aggregate/bootstrap.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Tuple, List, Dict, Any, Optional, Union
 from scipy.stats import false_discovery_control
 
+from lib.aggregate.cell_data_utils import GROUP_KEY_SEP
+
 
 @numba.njit(cache=True)
 def _bootstrap_inner_numba(
@@ -62,6 +64,83 @@ def _bootstrap_inner_numba(
         for j in range(n_features):
             null_medians[i, j] = np.median(sample[:, j])
     return null_medians
+
+
+def select_control_pool(
+    controls_df: pd.DataFrame,
+    construct_id: str,
+    control_scope: str = "pooled",
+    reference_group: Optional[str] = None,
+    group_cols: Optional[List[str]] = None,
+) -> pd.DataFrame:
+    """Restrict the bootstrap null pool to the controls a scope names.
+
+    "reference_group" pins the null to one fixed group whatever the construct's own
+    group, so an over-expression library is tested against the unliganded control
+    state rather than against controls that saw the same ligand.
+
+    Args:
+        controls_df (pd.DataFrame): Control cells, perturbation key in the first column.
+        construct_id (str): Construct being tested, composite when group_cols is set.
+        control_scope (str, optional): "pooled" keeps every control, "within_group"
+            keeps controls sharing the construct's own group, "reference_group" keeps
+            controls in `reference_group`. Defaults to "pooled".
+        reference_group (str, optional): Group key the "reference_group" scope pins the
+            pool to; several group_cols join their values with GROUP_KEY_SEP.
+            Defaults to None.
+        group_cols (list, optional): Columns folded into the composite key.
+            Defaults to None.
+
+    Returns:
+        pd.DataFrame: Controls the scope selects.
+
+    Raises:
+        ValueError: If the scope is unknown, if "reference_group" is requested without
+            group_cols or without a reference_group, or if the selected group matches
+            no control cells.
+    """
+    if control_scope not in ("pooled", "within_group", "reference_group"):
+        raise ValueError(f"Unknown bootstrap_control_scope: {control_scope}")
+
+    if control_scope == "pooled":
+        return controls_df
+
+    if control_scope == "within_group":
+        if GROUP_KEY_SEP not in str(construct_id):
+            return controls_df
+        group_key = str(construct_id).split(GROUP_KEY_SEP, 1)[1]
+    else:
+        if not group_cols:
+            raise ValueError(
+                "bootstrap_control_scope 'reference_group' needs aggregate group_cols; "
+                "without them controls carry no group to pin the null to"
+            )
+        if reference_group is None:
+            raise ValueError(
+                "bootstrap_control_scope 'reference_group' requires "
+                "bootstrap_reference_group to be set"
+            )
+        group_key = str(reference_group)
+
+    control_groups = (
+        controls_df.iloc[:, 0].astype(str).str.split(GROUP_KEY_SEP, n=1).str[1]
+    )
+    group_mask = control_groups == group_key
+    print(
+        f"Restricting controls to group '{group_key}': {int(group_mask.sum())} of {len(controls_df)} rows"
+    )
+    control_pool = controls_df[group_mask]
+    if len(control_pool) == 0:
+        if control_scope == "reference_group":
+            raise ValueError(
+                f"bootstrap_reference_group '{group_key}' is absent from the control pool; "
+                f"control groups present: {sorted(control_groups.dropna().unique())}"
+            )
+        raise ValueError(
+            f"No control cells found for group '{group_key}' (construct {construct_id})"
+        )
+
+    return control_pool
 
 
 def get_construct_features(

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -33,6 +33,66 @@ def load_metadata_cols(metadata_cols_fp, include_classification_cols=False):
     return metadata_cols
 
 
+def join_well_annotations(metadata, well_annotations_fp):
+    """Join per-well annotations onto cell metadata for splitting or grouping.
+
+    Annotations are experimental variables assigned by plate map rather than derived
+    from images, e.g. treatment, confluency, or timepoint. Keyed on (plate, well) so a
+    multi-plate screen can carry a different map per plate.
+
+    Args:
+        metadata (pd.DataFrame): Cell metadata containing plate and well columns.
+        well_annotations_fp (str): Path to a TSV with plate, well, and annotation columns.
+
+    Returns:
+        pd.DataFrame: Metadata with the annotation columns added.
+
+    Raises:
+        ValueError: If the map repeats a (plate, well), or if a (plate, well) present in
+            the data has no row in the map.
+    """
+    annotations = pd.read_csv(well_annotations_fp, sep="\t")
+    for col in ("plate", "well"):
+        if col not in annotations.columns:
+            raise ValueError(f"{well_annotations_fp} is missing required column '{col}'")
+
+    # a repeated well would multiply cells through the join and desync them from features
+    duplicated = annotations[annotations.duplicated(subset=["plate", "well"], keep=False)]
+    if len(duplicated) > 0:
+        raise ValueError(
+            f"{well_annotations_fp} repeats (plate, well): "
+            f"{sorted(map(tuple, duplicated[['plate', 'well']].to_numpy()))}"
+        )
+
+    # join on strings so plate 1 and "1" cannot silently fail to match
+    keys = ["plate", "well"]
+    metadata = metadata.copy()
+    for col in keys:
+        metadata[col] = metadata[col].astype(str)
+        annotations[col] = annotations[col].astype(str)
+
+    data_wells = set(map(tuple, metadata[keys].drop_duplicates().to_numpy()))
+    map_wells = set(map(tuple, annotations[keys].drop_duplicates().to_numpy()))
+
+    # an unmapped well would become a NaN group that silently drops its cells
+    unmapped = sorted(data_wells - map_wells)
+    if unmapped:
+        raise ValueError(
+            f"{len(unmapped)} (plate, well) in the data are absent from "
+            f"{well_annotations_fp}: {unmapped}"
+        )
+
+    unused = sorted(map_wells - data_wells)
+    if unused:
+        print(f"Note: {len(unused)} annotated wells are not in the data: {unused}")
+
+    # merge returns a fresh RangeIndex; features still carry the original one
+    joined = metadata.merge(annotations, on=keys, how="left")
+    joined.index = metadata.index
+
+    return joined
+
+
 def split_cell_data(
     cell_data, metadata_cols, validate_dtypes=True, raise_on_invalid=True
 ):

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -60,7 +60,12 @@ def control_mask(perturbation_values, control_key, match="contains"):
     perturbations = perturbation_values.astype(str).str.split(GROUP_KEY_SEP, n=1).str[0]
 
     if isinstance(control_key, (list, tuple, set)):
-        return perturbations.isin(set(control_key))
+        keys = set(control_key)
+        # prepare_alignment_data uniquifies controls to <name>_<pert_id>, so an exact
+        # match alone would stop seeing them downstream of that rename
+        renamed = perturbations.str.startswith(tuple(f"{key}_" for key in keys))
+
+        return perturbations.isin(keys) | renamed
     if match == "startswith":
         return perturbations.str.startswith(control_key, na=False)
 

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -9,6 +9,10 @@ import pandas as pd
 
 from lib.phenotype.constants import DEFAULT_METADATA_COLS
 
+# joins a perturbation to its group values; not "__" (the filename separator parsed
+# in lib/shared/rule_utils.py), not a glob metacharacter, not regex-special
+GROUP_KEY_SEP = "="
+
 
 def load_metadata_cols(metadata_cols_fp, include_classification_cols=False):
     """Load metadata column names from a file.
@@ -31,6 +35,25 @@ def load_metadata_cols(metadata_cols_fp, include_classification_cols=False):
         ]
 
     return metadata_cols
+
+
+def control_mask(perturbation_values, control_key):
+    """Flag control perturbations, ignoring any group suffix on a composite key.
+
+    Matching the whole composite would let a group value satisfy control_key, silently
+    labelling perturbed cells as controls (e.g. control_key "DMSO" matching "MYC=DMSO").
+    A no-op when group_cols is unset, since there is no separator to strip.
+
+    Args:
+        perturbation_values (pd.Series): Perturbation names, composite or plain.
+        control_key (str): Substring identifying a control perturbation.
+
+    Returns:
+        pd.Series: Boolean mask of control rows.
+    """
+    perturbations = perturbation_values.astype(str).str.split(GROUP_KEY_SEP, n=1).str[0]
+
+    return perturbations.str.contains(control_key, na=False)
 
 
 def join_well_annotations(metadata, well_annotations_fp):

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -37,21 +37,32 @@ def load_metadata_cols(metadata_cols_fp, include_classification_cols=False):
     return metadata_cols
 
 
-def control_mask(perturbation_values, control_key):
+def control_mask(perturbation_values, control_key, match="contains"):
     """Flag control perturbations, ignoring any group suffix on a composite key.
 
     Matching the whole composite would let a group value satisfy control_key, silently
     labelling perturbed cells as controls (e.g. control_key "DMSO" matching "MYC=DMSO").
-    A no-op when group_cols is unset, since there is no separator to strip.
+    Stripping the suffix is a no-op when group_cols is unset.
+
+    A list control_key matches exactly against any element, for libraries whose controls
+    share no usable prefix (an ORF screen's EGFP_1 and H2B-EGFP_1). A string keeps the
+    caller's historical convention, so existing screens are unaffected.
 
     Args:
         perturbation_values (pd.Series): Perturbation names, composite or plain.
-        control_key (str): Substring identifying a control perturbation.
+        control_key (str | list): Control identifier, or a list of exact names.
+        match (str, optional): How a string key matches, "contains" or "startswith".
+            Ignored for a list. Defaults to "contains".
 
     Returns:
         pd.Series: Boolean mask of control rows.
     """
     perturbations = perturbation_values.astype(str).str.split(GROUP_KEY_SEP, n=1).str[0]
+
+    if isinstance(control_key, (list, tuple, set)):
+        return perturbations.isin(set(control_key))
+    if match == "startswith":
+        return perturbations.str.startswith(control_key, na=False)
 
     return perturbations.str.contains(control_key, na=False)
 

--- a/workflow/lib/aggregate/perturbation_score.py
+++ b/workflow/lib/aggregate/perturbation_score.py
@@ -16,14 +16,14 @@ from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.metrics import roc_auc_score
 
 from lib.aggregate.align import prepare_alignment_data, centerscale_on_controls
-from lib.aggregate.cell_data_utils import split_cell_data
+from lib.aggregate.cell_data_utils import split_cell_data, control_mask
 
 
 def perturbation_score(
     cell_data: pd.DataFrame,
     metadata_cols: list[str],
     perturbation_name_col: str,
-    control_key: str,
+    control_key: str | list,
     minimum_cell_count: int = 100,
     n_jobs: int = -1,
 ) -> None:
@@ -37,18 +37,17 @@ def perturbation_score(
         cell_data (pd.DataFrame): DataFrame containing cell data that will be modified in-place.
         metadata_cols (list[str]): List of metadata column names that will be updated to include 'perturbation_score'.
         perturbation_name_col (str): Column name containing perturbation identifiers.
-        control_key (str): Prefix identifying control perturbations (e.g., 'nontargeting').
+        control_key (str | list): Prefix identifying control perturbations (e.g., 'nontargeting').
         minimum_cell_count (int, optional): Minimum number of cells required to process a perturbation. Defaults to 100.
         n_jobs (int, optional): Number of parallel jobs. -1 uses all available CPUs. Defaults to -1.
     """
     perturbation_col = cell_data[perturbation_name_col]
-    perturbed_genes = [
-        gene
-        for gene in perturbation_col.unique().tolist()
-        if not gene.startswith(control_key)
-    ]
+    unique_perts = perturbation_col.drop_duplicates()
+    perturbed_genes = unique_perts[
+        ~control_mask(unique_perts, control_key, match="startswith")
+    ].tolist()
     nt_idx = perturbation_col.index[
-        perturbation_col.str.startswith(control_key)
+        control_mask(perturbation_col, control_key, match="startswith")
     ].to_numpy()
 
     print(f"Processing {len(perturbed_genes)} genes with {n_jobs} parallel jobs...")
@@ -99,6 +98,8 @@ def perturbation_score(
                 original_idx,
                 metadata_cols,
                 minimum_cell_count,
+                perturbation_name_col,
+                control_key,
             )
             for gene, gene_idx, gene_subset_df, original_idx in batch_data
         )
@@ -179,6 +180,8 @@ def _process_gene_subset(
     original_idx: pd.Index,
     metadata_cols: list[str],
     minimum_cell_count: int,
+    perturbation_name_col: str,
+    control_key: str | list,
 ) -> tuple[str, np.ndarray, pd.Series, float] | None:
     """Process a pre-sliced gene subset and return perturbation scores.
 
@@ -189,6 +192,8 @@ def _process_gene_subset(
         original_idx: Original indices before reset (for mapping scores back).
         metadata_cols: Metadata column names.
         minimum_cell_count: Minimum cells required.
+        perturbation_name_col: Column name containing perturbation labels.
+        control_key: Control identifier, or a list of exact control names.
 
     Returns:
         Tuple of (gene, gene_idx, perturbation_scores, auc) or None if skipped.
@@ -204,8 +209,8 @@ def _process_gene_subset(
         metadata,
         features,
         ["plate", "well"],
-        "gene_symbol_0",
-        "nontargeting",
+        perturbation_name_col,
+        control_key,
         "cell_barcode_0",
     )
 
@@ -213,8 +218,8 @@ def _process_gene_subset(
     features = centerscale_on_controls(
         features,
         metadata,
-        "gene_symbol_0",
-        "nontargeting",
+        perturbation_name_col,
+        control_key,
         "batch_values",
     )
     features = pd.DataFrame(features, columns=feature_cols)
@@ -225,7 +230,7 @@ def _process_gene_subset(
         gene_subset_df,
         gene,
         feature_cols,
-        perturbation_col="gene_symbol_0",
+        perturbation_col=perturbation_name_col,
     )
 
     print(

--- a/workflow/lib/cluster/benchmark_clusters.py
+++ b/workflow/lib/cluster/benchmark_clusters.py
@@ -26,6 +26,7 @@ from statsmodels.stats.multitest import multipletests
 import seaborn as sns
 import matplotlib.pyplot as plt
 
+from lib.aggregate.cell_data_utils import control_mask
 from lib.cluster.phate_leiden_clustering import phate_leiden_pipeline
 from lib.cluster.scrape_benchmarks import filter_complexes
 
@@ -47,7 +48,7 @@ def run_benchmark_analysis(
         corum_group_benchmark (pd.DataFrame): CORUM group benchmark.
         kegg_group_benchmark (pd.DataFrame): KEGG group benchmark.
         perturbation_col_name (str): Column name for gene identifiers.
-        control_key (str): Prefix for control perturbations.
+        control_key (str | list): Prefix for control perturbations.
         max_clusters (int): Maximum clusters to analyze.
 
     Returns:
@@ -146,7 +147,7 @@ def evaluate_resolution(
         leiden_resolutions (list): List of resolution parameters to evaluate.
         group_benchmarks (dict): Dictionary of benchmark DataFrames with known gene groups. Must have a group column.
         perturbation_col_name (str): Column name for gene identifiers.
-        control_key (str, optional): Prefix for control perturbations to filter out.
+        control_key (str | list, optional): Prefix for control perturbations to filter out.
 
     Returns:
         tuple:
@@ -335,7 +336,7 @@ def calculate_group_enrichment(
         group_benchmark (pd.DataFrame): DataFrame with 'group' and 'gene_name' columns.
         phate_leiden_clustering (pd.DataFrame): Clustering results.
         perturbation_col_name (str, optional): Column name for gene identifiers.
-        control_key (str, optional): Prefix for control perturbations to filter out.
+        control_key (str | list, optional): Prefix for control perturbations to filter out.
         return_full_table (bool, optional): Whether to return the full table.
         max_clusters (int, optional): Maximum number of clusters to analyze before stopping.
 
@@ -346,7 +347,9 @@ def calculate_group_enrichment(
     cluster_df = phate_leiden_clustering.sort_values(by="cluster")
     if control_key is not None:
         cluster_df = cluster_df[
-            ~cluster_df[perturbation_col_name].str.startswith(control_key)
+            ~control_mask(
+                cluster_df[perturbation_col_name], control_key, match="startswith"
+            )
         ]
 
     background_genes = set(phate_leiden_clustering[perturbation_col_name])
@@ -424,7 +427,7 @@ def calculate_pair_enrichment(
         pair_benchmark (pd.DataFrame): DataFrame with 'pair' and 'gene_name' columns.
         phate_leiden_clustering (pd.DataFrame): Clustering results.
         perturbation_col_name (str, optional): Column name for gene identifiers.
-        control_key (str, optional): Prefix for control perturbations to filter out.
+        control_key (str | list, optional): Prefix for control perturbations to filter out.
         max_clusters (int, optional): Maximum number of clusters to analyze.
         return_cluster_details (bool, optional): Whether to return per-cluster details.
         adjust_precision (bool, optional): If True, calculates precision more conservatively by
@@ -438,7 +441,11 @@ def calculate_pair_enrichment(
     # Filter non-targeting genes
     if control_key is not None:
         cluster_df = phate_leiden_clustering[
-            ~phate_leiden_clustering[perturbation_col_name].str.startswith(control_key)
+            ~control_mask(
+                phate_leiden_clustering[perturbation_col_name],
+                control_key,
+                match="startswith",
+            )
         ]
     else:
         cluster_df = phate_leiden_clustering
@@ -664,7 +671,7 @@ def run_integrated_benchmarks(
         pair_benchmarks (dict): Mapping from benchmark name to pair benchmark DataFrame.
         group_benchmarks (dict): Mapping from benchmark name to group benchmark DataFrame.
         perturbation_col_name (str): Column name for gene identifiers.
-        control_key (str): Prefix for control perturbations to filter out.
+        control_key (str | list): Prefix for control perturbations to filter out.
         max_clusters (int): Maximum number of clusters to analyze.
 
     Returns:

--- a/workflow/lib/cluster/phate_leiden_clustering.py
+++ b/workflow/lib/cluster/phate_leiden_clustering.py
@@ -14,7 +14,7 @@ from igraph import Graph
 import leidenalg
 import phate
 
-from lib.aggregate.cell_data_utils import control_mask
+from lib.aggregate.cell_data_utils import GROUP_KEY_SEP, control_mask
 
 
 def phate_leiden_pipeline(
@@ -305,8 +305,103 @@ def plot_phate_leiden_clusters(
     return fig
 
 
+def select_control_indices(
+    perturbation_values,
+    control_key,
+    control_scope="pooled",
+    reference_group=None,
+    group_cols=None,
+):
+    """Map every point to the control rows its null is drawn from.
+
+    "reference_group" pins the null to one fixed group whatever the point's own group,
+    so an over-expression library is scored against the unliganded control state rather
+    than against a control cloud pooled across every treatment.
+
+    Args:
+        perturbation_values (pd.Series): Perturbation names, composite when group_cols is set.
+        control_key (str | list): Control identifier, or a list of exact names.
+        control_scope (str, optional): "pooled" scores every point against all controls,
+            "within_group" against controls sharing the point's own group,
+            "reference_group" against controls in `reference_group`. Defaults to "pooled".
+        reference_group (str, optional): Group key the "reference_group" scope pins the
+            null to; several group_cols join their values with GROUP_KEY_SEP.
+            Defaults to None.
+        group_cols (list, optional): Columns folded into the composite key.
+            Defaults to None.
+
+    Returns:
+        dict: Point index label mapped to the control index labels scoring it.
+
+    Raises:
+        ValueError: If the scope is unknown, if "reference_group" is requested without
+            group_cols, without a reference_group, or against ungrouped perturbation
+            names, or if the selected group matches no control rows.
+    """
+    if control_scope not in ("pooled", "within_group", "reference_group"):
+        raise ValueError(f"Unknown control_scope: {control_scope}")
+
+    is_control = control_mask(perturbation_values, control_key)
+    control_indices = perturbation_values.index[is_control].tolist()
+
+    if control_scope == "pooled":
+        return {idx: control_indices for idx in perturbation_values.index}
+
+    point_groups = perturbation_values.astype(str).str.split(GROUP_KEY_SEP, n=1).str[1]
+    control_groups = point_groups[is_control]
+
+    if control_scope == "within_group":
+        if point_groups.isna().all():
+            return {idx: control_indices for idx in perturbation_values.index}
+        indices_by_group = {
+            group_key: group.index.tolist()
+            for group_key, group in control_groups.groupby(control_groups)
+        }
+        scoped_indices = {}
+        for idx, group_key in point_groups.items():
+            if group_key not in indices_by_group:
+                raise ValueError(f"No control cells found for group '{group_key}'")
+            scoped_indices[idx] = indices_by_group[group_key]
+
+        return scoped_indices
+
+    if not group_cols:
+        raise ValueError(
+            "control_scope 'reference_group' needs aggregate group_cols; "
+            "without them points carry no group to pin the null to"
+        )
+    if reference_group is None:
+        raise ValueError(
+            "control_scope 'reference_group' requires control_reference_group to be set"
+        )
+    if control_groups.isna().all():
+        raise ValueError(
+            "control_scope 'reference_group' needs grouped perturbation names; "
+            "without them points carry no group to pin the null to"
+        )
+
+    group_key = str(reference_group)
+    reference_indices = control_groups.index[control_groups == group_key].tolist()
+    print(
+        f"Restricting controls to group '{group_key}': {len(reference_indices)} of {len(control_indices)} rows"
+    )
+    if len(reference_indices) == 0:
+        raise ValueError(
+            f"control_reference_group '{group_key}' is absent from the control pool; "
+            f"control groups present: {sorted(control_groups.dropna().unique())}"
+        )
+
+    return {idx: reference_indices for idx in perturbation_values.index}
+
+
 def calculate_potential_to_nontargeting(
-    potential_df, control_key, distance_metric="euclidean", normalize=True
+    potential_df,
+    control_key,
+    distance_metric="euclidean",
+    normalize=True,
+    control_scope="pooled",
+    reference_group=None,
+    group_cols=None,
 ):
     """Calculate the average distance from each row to nontargeting controls.
 
@@ -315,6 +410,9 @@ def calculate_potential_to_nontargeting(
         control_key (str | list): String pattern used to identify control rows
         distance_metric (str): Distance metric to use (default: 'euclidean')
         normalize (bool): Whether to min-max normalize the distances (default: True)
+        control_scope (str): Controls each row is scored against (default: 'pooled')
+        reference_group (str): Group the 'reference_group' scope pins the null to (default: None)
+        group_cols (list): Columns folded into the composite perturbation key (default: None)
 
     Returns:
         pd.DataFrame: DataFrame with gene_symbol_0, mean_potential_to_nontargeting,
@@ -328,9 +426,14 @@ def calculate_potential_to_nontargeting(
         col for col in potential_df.columns if col.startswith("potential_")
     ]
 
-    # Identify nontargeting control rows
-    nontargeting_mask = control_mask(potential_df["gene_symbol_0"], control_key)
-    nontargeting_indices = potential_df.index[nontargeting_mask].tolist()
+    # Identify the nontargeting control rows this scope names
+    control_indices = select_control_indices(
+        potential_df["gene_symbol_0"],
+        control_key,
+        control_scope,
+        reference_group,
+        group_cols,
+    )
 
     # Extract only the potential values for calculation
     potential_values = potential_df[potential_cols].values
@@ -350,7 +453,7 @@ def calculate_potential_to_nontargeting(
 
         # Get distances from this row to all nontargeting controls
         distances_to_nontargeting = [
-            distance_df.loc[idx, control_idx] for control_idx in nontargeting_indices
+            distance_df.loc[idx, control_idx] for control_idx in control_indices[idx]
         ]
 
         # Calculate average distance

--- a/workflow/lib/cluster/phate_leiden_clustering.py
+++ b/workflow/lib/cluster/phate_leiden_clustering.py
@@ -14,6 +14,8 @@ from igraph import Graph
 import leidenalg
 import phate
 
+from lib.aggregate.cell_data_utils import control_mask
+
 
 def phate_leiden_pipeline(
     aggregated_data,
@@ -176,7 +178,7 @@ def plot_phate_leiden_clusters(
         phate_leiden_clustering (pd.DataFrame): Output from phate_leiden_pipeline with
             'PHATE_0', 'PHATE_1', and 'cluster' columns.
         perturbation_name_col (str): Column name containing perturbation identifiers.
-        control_key (str): Prefix or value in perturbation_name_col that identifies controls.
+        control_key (str | list): Prefix or value in perturbation_name_col that identifies controls.
         figsize (tuple, optional): Figure dimensions (width, height). Defaults to (8, 8).
         clusters_of_interest (list or int, optional): Cluster ID(s) to highlight. If None,
             all clusters are colored. Defaults to None.
@@ -198,11 +200,11 @@ def plot_phate_leiden_clusters(
             clusters_of_interest = [clusters_of_interest]
 
     # Split data into experimental and control groups
-    control_mask = phate_leiden_clustering[perturbation_name_col].str.startswith(
-        control_key
+    is_control = control_mask(
+        phate_leiden_clustering[perturbation_name_col], control_key, match="startswith"
     )
-    control_data = phate_leiden_clustering[control_mask]
-    exp_data = phate_leiden_clustering[~control_mask]
+    control_data = phate_leiden_clustering[is_control]
+    exp_data = phate_leiden_clustering[~is_control]
 
     if clusters_of_interest is None:
         # Original behavior - plot all experimental data colored by cluster
@@ -310,7 +312,7 @@ def calculate_potential_to_nontargeting(
 
     Args:
         potential_df (pd.DataFrame): DataFrame with gene_symbol_0 and potential columns
-        control_key (str): String pattern used to identify control rows
+        control_key (str | list): String pattern used to identify control rows
         distance_metric (str): Distance metric to use (default: 'euclidean')
         normalize (bool): Whether to min-max normalize the distances (default: True)
 
@@ -327,9 +329,7 @@ def calculate_potential_to_nontargeting(
     ]
 
     # Identify nontargeting control rows
-    nontargeting_mask = potential_df["gene_symbol_0"].str.contains(
-        control_key, na=False
-    )
+    nontargeting_mask = control_mask(potential_df["gene_symbol_0"], control_key)
     nontargeting_indices = potential_df.index[nontargeting_mask].tolist()
 
     # Extract only the potential values for calculation

--- a/workflow/lib/cluster/scrape_benchmarks.py
+++ b/workflow/lib/cluster/scrape_benchmarks.py
@@ -39,6 +39,8 @@ _MSIGDB_CP_COLLECTION_BY_SPECIES = {
 
 import pandas as pd
 
+from lib.aggregate.cell_data_utils import control_mask
+
 
 def generate_string_pair_benchmark(
     aggregated_data, uniprot_data, gene_col="gene_symbol_0", species_id="9606"
@@ -413,17 +415,16 @@ def filter_complexes(
         group_df (pd.DataFrame): DataFrame with columns ['gene_name', 'group'].
         cluster_df (pd.DataFrame): DataFrame with perturbation data.
         perturbation_col_name (str): Column name for gene identifiers.
-        control_key (str, optional): Prefix for control perturbations to filter out.
+        control_key (str | list, optional): Substring, or list of exact names, marking controls.
 
     Returns:
         pd.DataFrame: Filtered group DataFrame.
     """
     # Generate the screening gene list directly from the cluster_df
-    gene_list = [
-        gene
-        for gene in cluster_df[perturbation_col_name].unique()
-        if control_key is None or control_key not in gene
-    ]
+    genes = cluster_df[perturbation_col_name].drop_duplicates()
+    if control_key is not None:
+        genes = genes[~control_mask(genes, control_key)]
+    gene_list = genes.tolist()
 
     # 1. Build a dictionary: complex -> set of genes
     complex_to_genes = group_df.groupby("group")["gene_name"].apply(set).to_dict()

--- a/workflow/lib/phenotype/custom_features.py
+++ b/workflow/lib/phenotype/custom_features.py
@@ -1,0 +1,210 @@
+"""Registration of user-defined per-cell phenotype features."""
+
+import hashlib
+import inspect
+import textwrap
+from numbers import Number
+
+import numpy as np
+
+CUSTOM_FEATURE_PREFIX = "custom"
+CUSTOM_FEATURE_COMPARTMENTS = ("nucleus", "cell", "cytoplasm")
+DEFAULT_CUSTOM_FEATURE_COMPARTMENT = "nucleus"
+
+
+def custom_feature_column(
+    name, source_hash, compartment=DEFAULT_CUSTOM_FEATURE_COMPARTMENT
+):
+    """Build the namespaced column name for a registered feature.
+
+    Args:
+        name (str): Name of the feature function.
+        source_hash (str): Short hash of the feature source.
+        compartment (str, optional): Compartment the feature is measured on. Default
+            is "nucleus".
+
+    Returns:
+        str: Column name of the form {compartment}_custom_{name}_{source_hash}.
+    """
+    return f"{compartment}_{CUSTOM_FEATURE_PREFIX}_{name}_{source_hash}"
+
+
+def register_custom_features(features):
+    """Convert feature functions into config-serializable definitions.
+
+    Each function is stored as its own source text so the workflow, which runs in a
+    separate process from the notebook, can rebuild it, and so the definition behind
+    a column is recoverable from the config alone. That only holds for a self-contained
+    function, so one closing over a notebook name is rejected here rather than on a
+    compute node hours later.
+
+    Args:
+        features (list): Feature functions taking a regionprops-like region and
+            returning a single number, matching the foci_features convention. Each
+            must define or import every name it uses. An entry may instead be a
+            (function, compartment) pair, where compartment is one of "nucleus",
+            "cell", or "cytoplasm"; a bare function is measured on the nucleus.
+
+    Returns:
+        list: Definitions with name, source, hash, compartment, and column keys.
+
+    Raises:
+        ValueError: If a function is anonymous, is registered twice on the same
+            compartment, declares an unknown compartment, closes over names it does
+            not define, or its source cannot be captured.
+    """
+    definitions = []
+    registered = set()
+
+    for entry in features:
+        if isinstance(entry, (tuple, list)):
+            if len(entry) != 2:
+                raise ValueError(
+                    "Custom features declared with a compartment must be a "
+                    f"(function, compartment) pair, got {entry!r}"
+                )
+            func, compartment = entry
+        else:
+            func, compartment = entry, DEFAULT_CUSTOM_FEATURE_COMPARTMENT
+
+        name = getattr(func, "__name__", None)
+        if name is None or not name.isidentifier():
+            raise ValueError(
+                "Custom features must be named functions defined with def, "
+                f"got {func!r}"
+            )
+
+        compartment = _validated_compartment(name, compartment)
+        if (name, compartment) in registered:
+            raise ValueError(
+                f"Custom feature '{name}' is registered more than once on the "
+                f"{compartment} compartment"
+            )
+        registered.add((name, compartment))
+
+        try:
+            source = textwrap.dedent(inspect.getsource(func))
+        except (OSError, TypeError) as error:
+            raise ValueError(
+                f"Could not capture the source of custom feature '{name}'; define it "
+                "with def in a notebook cell or module"
+            ) from error
+
+        closure = inspect.getclosurevars(func)
+        closed_over = sorted(closure.globals) + sorted(closure.nonlocals)
+        if closed_over:
+            raise ValueError(
+                f"Custom feature '{name}' uses names it does not define: {closed_over}. "
+                "Only the source is carried to the workflow, so inline the values and "
+                "move any imports inside the function"
+            )
+
+        source_hash = hashlib.sha256(source.encode()).hexdigest()[:8]
+        definitions.append(
+            {
+                "name": name,
+                "source": source,
+                "hash": source_hash,
+                "compartment": compartment,
+                "column": custom_feature_column(name, source_hash, compartment),
+            }
+        )
+
+    return definitions
+
+
+def load_custom_features(definitions):
+    """Rebuild registered features as per-compartment feature dictionaries for extraction.
+
+    Sources are executed in an empty namespace, matching the self-contained definitions
+    register_custom_features accepts.
+
+    Args:
+        definitions (list or None): Definitions produced by register_custom_features.
+
+    Returns:
+        dict: Mapping of compartment to a mapping of namespaced column name to feature
+            function, in CUSTOM_FEATURE_COMPARTMENTS order.
+
+    Raises:
+        ValueError: If a definition declares an unknown compartment, or its source does
+            not define its named function.
+    """
+    features = {}
+
+    for definition in definitions or []:
+        name = definition["name"]
+        compartment = _validated_compartment(
+            name, definition.get("compartment", DEFAULT_CUSTOM_FEATURE_COMPARTMENT)
+        )
+        namespace = {}
+        exec(definition["source"], namespace)
+
+        func = namespace.get(name)
+        if not callable(func):
+            raise ValueError(
+                f"Source of custom feature '{name}' does not define a function "
+                f"named '{name}'"
+            )
+
+        features.setdefault(compartment, {})[definition["column"]] = _checked_feature(
+            name, func
+        )
+
+    return {
+        compartment: features[compartment]
+        for compartment in CUSTOM_FEATURE_COMPARTMENTS
+        if compartment in features
+    }
+
+
+def _validated_compartment(name, compartment):
+    """Check that a declared compartment is one the extraction measures on.
+
+    Args:
+        name (str): Name of the feature function.
+        compartment (str): Declared compartment.
+
+    Returns:
+        str: The declared compartment.
+
+    Raises:
+        ValueError: If the compartment is not one of CUSTOM_FEATURE_COMPARTMENTS.
+    """
+    if compartment not in CUSTOM_FEATURE_COMPARTMENTS:
+        raise ValueError(
+            f"Custom feature '{name}' declares unknown compartment {compartment!r}, "
+            f"expected one of {list(CUSTOM_FEATURE_COMPARTMENTS)}"
+        )
+
+    return compartment
+
+
+def _checked_feature(name, func):
+    """Wrap a feature function so a bad cell names the feature instead of emitting NaN.
+
+    Args:
+        name (str): Name of the feature function.
+        func (callable): Feature function to wrap.
+
+    Returns:
+        callable: Feature function that raises on failure or a non-numeric result.
+    """
+
+    def checked(region):
+        try:
+            value = func(region)
+        except Exception as error:
+            raise ValueError(
+                f"Custom feature '{name}' failed on label {region.label}: {error}"
+            ) from error
+
+        if not isinstance(value, (Number, np.bool_)):
+            raise ValueError(
+                f"Custom feature '{name}' returned {type(value).__name__} on label "
+                f"{region.label}, expected a single number"
+            )
+
+        return value
+
+    return checked

--- a/workflow/lib/phenotype/extract_phenotype_cp_emulator.py
+++ b/workflow/lib/phenotype/extract_phenotype_cp_emulator.py
@@ -36,6 +36,7 @@ def extract_phenotype_cp_emulator(
     cytoplasm_channels="all",
     foci_channel=None,
     channel_names=["dapi", "tubulin", "gh2ax", "phalloidin"],
+    custom_features=None,
 ):
     """Extract phenotype features from CellProfiler-like data with multi-channel functionality.
 
@@ -63,11 +64,23 @@ def extract_phenotype_cp_emulator(
             Default is None.
         channel_names (list, optional): List of channel names used for labeling output
             columns. Default is ["dapi", "tubulin", "gh2ax", "phalloidin"].
+        custom_features (dict, optional): Mapping of compartment ("nucleus", "cell", or
+            "cytoplasm") to a mapping of namespaced column name to feature function, as
+            returned by lib.phenotype.custom_features.load_custom_features. Each
+            compartment's features are measured over that compartment's mask on the full
+            multichannel image, so a feature indexes channels in channel_names order
+            regardless of the compartment channel selections. If None, no custom features
+            are extracted. Default is None.
 
     Returns:
         pandas.DataFrame: DataFrame containing extracted features with columns ordered as:
             label, metadata (well, tile, etc.), nucleus features, cell features,
-            cytoplasm features (if applicable), and foci features (if applicable).
+            cytoplasm features (if applicable), and foci features (if applicable). Custom
+            features (if applicable) are ordered with the compartment they measure.
+
+    Raises:
+        ValueError: If a custom feature declares a compartment that is not segmented in
+            this run, or a custom feature column collides with a built-in feature column.
     """
     # If nuclei are empty, return an empty DataFrame
     if np.sum(nuclei) == 0:
@@ -219,6 +232,45 @@ def extract_phenotype_cp_emulator(
             .set_index("label")
             .add_prefix("cytoplasm_")
         )
+
+    # Extract user-registered custom features on the compartment each one declares
+    if custom_features:
+        custom_masks = {"nucleus": nuclei, "cell": cells, "cytoplasm": cytoplasms}
+
+        unknown = sorted(set(custom_features) - set(custom_masks))
+        if unknown:
+            raise ValueError(f"Custom features declare unknown compartments: {unknown}")
+
+        for compartment, custom_mask in custom_masks.items():
+            compartment_features = custom_features.get(compartment)
+            if not compartment_features:
+                continue
+
+            # A compartment that was never segmented cannot stand in for another one
+            if custom_mask is None:
+                raise ValueError(
+                    f"Custom features {sorted(compartment_features)} are measured on "
+                    f"the {compartment} compartment, which is not segmented in this run"
+                )
+            if np.sum(custom_mask) == 0:
+                continue
+
+            custom_df = extract_features_bare(
+                data_phenotype,
+                custom_mask,
+                features=compartment_features,
+                multichannel=True,
+            ).set_index("label")
+
+            collisions = [
+                col for col in custom_df.columns if any(col in df.columns for df in dfs)
+            ]
+            if collisions:
+                raise ValueError(
+                    f"Custom feature columns collide with built-in features: {collisions}"
+                )
+
+            dfs.append(custom_df)
 
     # Concatenate data frames and reset index
     result_df = pd.concat(dfs, axis=1, join="outer", sort=False).reset_index()

--- a/workflow/lib/shared/metrics.py
+++ b/workflow/lib/shared/metrics.py
@@ -434,7 +434,7 @@ def _calculate_batch_effects(
     control_key,
 ):
     """Calculate batch effect metrics (pre/post alignment)."""
-    from lib.aggregate.cell_data_utils import DEFAULT_METADATA_COLS
+    from lib.aggregate.cell_data_utils import DEFAULT_METADATA_COLS, control_mask
     from lib.shared.file_utils import load_parquet_subset
     from sklearn.feature_selection import f_classif
 
@@ -466,7 +466,9 @@ def _calculate_batch_effects(
 
     # Pre-alignment batch effects
     filtered = filtered.dropna(axis=1)
-    control_data = filtered[filtered[perturbation_col].str.startswith(control_key)]
+    control_data = filtered[
+        control_mask(filtered[perturbation_col], control_key, match="startswith")
+    ]
 
     # Skip if no control data
     if len(control_data) == 0:
@@ -511,7 +513,7 @@ def _calculate_batch_effects(
     aligned = load_parquet_subset(aligned_path, sample_rows)
 
     control_aligned = aligned[
-        aligned[perturbation_col].str.startswith(control_key)
+        control_mask(aligned[perturbation_col], control_key, match="startswith")
     ].copy()
 
     # Skip if no control data

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -21,6 +21,8 @@ rule split_datasets:
         confidence_thresholds=config.get("classify", {}).get("confidence_thresholds"),
         class_title=config.get("classify", {}).get("class_title"),
         class_mapping=config.get("classify", {}).get("class_mapping"),
+        well_annotations_fp=config.get("aggregate", {}).get("well_annotations_fp"),
+        split_col=config.get("aggregate", {}).get("split_col", "class"),
         cell_classes=aggregate_wildcard_combos["cell_class"].unique(),
         channel_combos=aggregate_wildcard_combos["channel_combo"].unique(),
     script:
@@ -71,6 +73,7 @@ rule generate_feature_table:
         use_classifier=config.get("classify", {}).get("classifier_path") is not None,
         perturbation_name_col=config.get("aggregate", {}).get("perturbation_name_col"),
         perturbation_id_col=config.get("aggregate", {}).get("perturbation_id_col"),
+        group_cols=config.get("aggregate", {}).get("group_cols", []),
         control_key=config.get("aggregate", {}).get("control_key"),
         batch_cols=config.get("aggregate", {}).get("batch_cols", ["plate", "well"]),
         num_align_batches=config.get("aggregate", {}).get("num_align_batches", 1),
@@ -119,6 +122,7 @@ rule aggregate:
         metadata_cols_fp=config.get("aggregate", {}).get("metadata_cols_fp"),
         use_classifier=config.get("classify", {}).get("classifier_path") is not None,
         perturbation_name_col=config.get("aggregate", {}).get("perturbation_name_col"),
+        group_cols=config.get("aggregate", {}).get("group_cols", []),
         agg_method=config.get("aggregate", {}).get("agg_method", "median"),
         ps_probability_threshold=config.get("aggregate", {}).get("ps_probability_threshold"),
         ps_percentile_threshold=config.get("aggregate", {}).get("ps_percentile_threshold"),
@@ -281,6 +285,7 @@ checkpoint prepare_bootstrap_data:
         use_classifier=config.get("classify", {}).get("classifier_path") is not None,
         perturbation_name_col=config.get("aggregate", {}).get("perturbation_name_col"),
         perturbation_id_col=config.get("aggregate", {}).get("perturbation_id_col"),
+        group_cols=config.get("aggregate", {}).get("group_cols", []),
         control_key=config.get("aggregate", {}).get("control_key"),
         exclusion_string=config.get("aggregate", {}).get("exclusion_string"),
         bootstrap_features_fp=config.get("aggregate", {}).get("bootstrap_features_fp", None),
@@ -307,6 +312,7 @@ rule bootstrap_construct:
         BOOTSTRAP_OUTPUTS["bootstrap_construct_pvals"],
     params:
         num_sims=config.get("aggregate", {}).get("num_sims", 100000),
+        bootstrap_control_scope=config.get("aggregate", {}).get("bootstrap_control_scope", "pooled"),
     script:
         "../scripts/aggregate/bootstrap_construct.py"
 
@@ -337,6 +343,7 @@ rule bootstrap_gene:
         BOOTSTRAP_OUTPUTS["bootstrap_gene_pvals"],
     params:
         num_sims=config.get("aggregate", {}).get("num_sims", 100000),
+        perturbation_name_col=config.get("aggregate", {}).get("perturbation_name_col"),
         construct_nulls_pattern=lambda wildcards: str(BOOTSTRAP_OUTPUTS["bootstrap_construct_nulls"]).format(
             cell_class=wildcards.cell_class,
             channel_combo=wildcards.channel_combo,

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -313,6 +313,8 @@ rule bootstrap_construct:
     params:
         num_sims=config.get("aggregate", {}).get("num_sims", 100000),
         bootstrap_control_scope=config.get("aggregate", {}).get("bootstrap_control_scope", "pooled"),
+        bootstrap_reference_group=config.get("aggregate", {}).get("bootstrap_reference_group", None),
+        group_cols=config.get("aggregate", {}).get("group_cols", []),
     script:
         "../scripts/aggregate/bootstrap_construct.py"
 

--- a/workflow/rules/cluster.smk
+++ b/workflow/rules/cluster.smk
@@ -22,6 +22,9 @@ rule phate_leiden_clustering:
         phate_distance_metric=config.get("cluster", {}).get("phate_distance_metric", "cosine"),
         perturbation_name_col=config.get("aggregate", {}).get("perturbation_name_col"),
         control_key=config.get("aggregate", {}).get("control_key"),
+        control_scope=config.get("cluster", {}).get("control_scope", "pooled"),
+        control_reference_group=config.get("cluster", {}).get("control_reference_group", None),
+        group_cols=config.get("aggregate", {}).get("group_cols", []),
         uniprot_data_fp=config.get("cluster", {}).get("uniprot_data_fp"),
         perturbation_auc_threshold=config.get("cluster", {}).get("perturbation_auc_threshold"),
     script:

--- a/workflow/rules/phenotype.smk
+++ b/workflow/rules/phenotype.smk
@@ -96,6 +96,7 @@ rule extract_phenotype:
         channel_names=config.get("phenotype", {}).get("channel_names"),
         cp_method=config.get("phenotype", {}).get("cp_method"),
         segment_cells=config.get("phenotype", {}).get("segment_cells", True),
+        custom_features=config.get("phenotype", {}).get("custom_features"),
     script:
         "../scripts/phenotype/extract_phenotype.py"
 

--- a/workflow/scripts/aggregate/aggregate.py
+++ b/workflow/scripts/aggregate/aggregate.py
@@ -36,6 +36,7 @@ aggregated_embeddings, aggregated_metadata = aggregate(
     tvn_normalized,
     metadata,
     snakemake.params.perturbation_name_col,
+    group_cols=snakemake.params.group_cols,
     method=snakemake.params.agg_method,
     ps_probability_threshold=snakemake.params.ps_probability_threshold,
     ps_percentile_threshold=snakemake.params.ps_percentile_threshold,

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -56,9 +56,10 @@ n_sample = min(PCA_SUBSET, total_rows)
 random_indices = np.random.choice(total_rows, size=n_sample, replace=False)
 random_indices.sort()
 
-# load sample df
+# load sample df; drop null columns as the batch loop below does, since filter drops
+# columns per well and pyarrow fills the missing ones with nulls the PCA cannot consume
 sample_df = cell_dataset.scanner().take(random_indices)
-sample_df = sample_df.to_pandas(use_threads=True, memory_pool=None)
+sample_df = sample_df.to_pandas(use_threads=True, memory_pool=None).dropna(axis=1)
 
 # load sample df as pandas dataframe
 use_classifier = snakemake.params.use_classifier

--- a/workflow/scripts/aggregate/bootstrap_construct.py
+++ b/workflow/scripts/aggregate/bootstrap_construct.py
@@ -3,8 +3,7 @@
 import pandas as pd
 import numpy as np
 
-from lib.aggregate.bootstrap import run_construct_bootstrap
-from lib.aggregate.cell_data_utils import GROUP_KEY_SEP
+from lib.aggregate.bootstrap import run_construct_bootstrap, select_control_pool
 
 # Load construct data to get construct ID and gene
 construct_data = pd.read_csv(snakemake.input.construct_data, sep="\t")
@@ -16,24 +15,14 @@ print(f"Running bootstrap analysis for construct: {construct_id} (gene: {gene})"
 print("Loading bootstrap input arrays...")
 controls_df = pd.read_csv(snakemake.input.controls_arr, sep="\t")
 
-# Restrict the null pool to controls sharing this construct's group key
-control_scope = snakemake.params.get("bootstrap_control_scope", "pooled")
-if control_scope not in ("pooled", "within_group"):
-    raise ValueError(f"Unknown bootstrap_control_scope: {control_scope}")
-if control_scope == "within_group" and GROUP_KEY_SEP in str(construct_id):
-    group_key = str(construct_id).split(GROUP_KEY_SEP, 1)[1]
-    group_mask = (
-        controls_df.iloc[:, 0].astype(str).str.split(GROUP_KEY_SEP, n=1).str[1]
-        == group_key
-    )
-    print(
-        f"Restricting controls to group '{group_key}': {int(group_mask.sum())} of {len(controls_df)} rows"
-    )
-    controls_df = controls_df[group_mask]
-    if len(controls_df) == 0:
-        raise ValueError(
-            f"No control cells found for group '{group_key}' (construct {construct_id})"
-        )
+# Restrict the null pool to the controls this scope names
+controls_df = select_control_pool(
+    controls_df,
+    construct_id,
+    snakemake.params.get("bootstrap_control_scope", "pooled"),
+    reference_group=snakemake.params.get("bootstrap_reference_group", None),
+    group_cols=snakemake.params.get("group_cols", None),
+)
 
 controls_arr = controls_df.values
 

--- a/workflow/scripts/aggregate/bootstrap_construct.py
+++ b/workflow/scripts/aggregate/bootstrap_construct.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 
 from lib.aggregate.bootstrap import run_construct_bootstrap
+from lib.aggregate.cell_data_utils import GROUP_KEY_SEP
 
 # Load construct data to get construct ID and gene
 construct_data = pd.read_csv(snakemake.input.construct_data, sep="\t")
@@ -14,6 +15,26 @@ print(f"Running bootstrap analysis for construct: {construct_id} (gene: {gene})"
 # Load bootstrap input arrays
 print("Loading bootstrap input arrays...")
 controls_df = pd.read_csv(snakemake.input.controls_arr, sep="\t")
+
+# Restrict the null pool to controls sharing this construct's group key
+control_scope = snakemake.params.get("bootstrap_control_scope", "pooled")
+if control_scope not in ("pooled", "within_group"):
+    raise ValueError(f"Unknown bootstrap_control_scope: {control_scope}")
+if control_scope == "within_group" and GROUP_KEY_SEP in str(construct_id):
+    group_key = str(construct_id).split(GROUP_KEY_SEP, 1)[1]
+    group_mask = (
+        controls_df.iloc[:, 0].astype(str).str.split(GROUP_KEY_SEP, n=1).str[1]
+        == group_key
+    )
+    print(
+        f"Restricting controls to group '{group_key}': {int(group_mask.sum())} of {len(controls_df)} rows"
+    )
+    controls_df = controls_df[group_mask]
+    if len(controls_df) == 0:
+        raise ValueError(
+            f"No control cells found for group '{group_key}' (construct {construct_id})"
+        )
+
 controls_arr = controls_df.values
 
 construct_features_df = pd.read_csv(snakemake.input.construct_features_arr, sep="\t")

--- a/workflow/scripts/aggregate/bootstrap_gene.py
+++ b/workflow/scripts/aggregate/bootstrap_gene.py
@@ -13,6 +13,7 @@ gene_id = snakemake.wildcards.gene
 cell_class = snakemake.wildcards.cell_class
 channel_combo = snakemake.wildcards.channel_combo
 num_sims = snakemake.params.num_sims
+perturbation_col = snakemake.params.perturbation_name_col
 bootstrap_features_fp = snakemake.params.bootstrap_features_fp
 bootstrap_extra_features = snakemake.params.get("bootstrap_extra_features", None)
 
@@ -43,16 +44,16 @@ construct_null_arrays = load_construct_null_arrays(construct_null_paths)
 
 # Load gene table to get observed gene values
 gene_table = pd.read_csv(snakemake.input.gene_table, sep="\t")
-gene_row = gene_table[gene_table["gene_symbol_0"] == gene_id]
+gene_row = gene_table[gene_table[perturbation_col] == gene_id]
 
 if len(gene_row) == 0:
     print(f"Gene {gene_id} not found in gene table")
-    print(f"Available genes: {sorted(gene_table['gene_symbol_0'].unique())}")
+    print(f"Available genes: {sorted(gene_table[perturbation_col].unique())}")
     raise ValueError(f"Gene {gene_id} not found in gene table")
 
 # Get available features from gene table (same filtering as prepare_bootstrap_data.py)
 all_features = [
-    col for col in gene_table.columns if col not in ["gene_symbol_0", "cell_count"]
+    col for col in gene_table.columns if col not in [perturbation_col, "cell_count"]
 ]
 
 # Filter features for bootstrap analysis (must match prepare_bootstrap_data.py)

--- a/workflow/scripts/aggregate/format_singlecell_anndata.py
+++ b/workflow/scripts/aggregate/format_singlecell_anndata.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import anndata as ad
 
-from lib.aggregate.cell_data_utils import load_metadata_cols
+from lib.aggregate.cell_data_utils import load_metadata_cols, control_mask
 
 # Parameters
 metadata_cols_fp = snakemake.params.metadata_cols_fp
@@ -107,9 +107,7 @@ if cols_to_drop:
     obs = obs.drop(columns=cols_to_drop)
 
 # Add is_control boolean
-obs["is_control"] = (
-    obs[perturbation_name_col].str.contains(control_key, na=False).astype(bool)
-)
+obs["is_control"] = control_mask(obs[perturbation_name_col], control_key).astype(bool)
 
 # Compose region as plate_well for cross-well grouping.
 obs["region"] = obs["plate"].astype(str) + "_" + obs["well"].astype(str)

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -9,8 +9,15 @@ import numpy as np
 from pandas.api.types import is_numeric_dtype
 
 from lib.aggregate.align import prepare_alignment_data, centerscale_on_controls
-from lib.aggregate.cell_data_utils import load_metadata_cols, split_cell_data
+from lib.aggregate.cell_data_utils import (
+    load_metadata_cols,
+    split_cell_data,
+    control_mask,
+)
 from lib.aggregate.bootstrap import create_pseudogene_groups
+
+# folds group values into perturbation labels; not "__" (reserved in filenames), glob, or regex
+GROUP_KEY_SEP = "="
 
 # Validate required params
 for _param_name in ["perturbation_name_col", "control_key", "metadata_cols_fp"]:
@@ -22,6 +29,7 @@ pert_col = snakemake.params.perturbation_name_col
 pert_id_col = snakemake.params.perturbation_id_col or pert_col
 control_key = snakemake.params.control_key
 num_batches = snakemake.params.num_align_batches
+group_cols = list(snakemake.params.get("group_cols", None) or [])
 
 # Load cell data using PyArrow dataset (lazy - no data loaded yet)
 print("Loading cell data as PyArrow dataset...")
@@ -43,6 +51,12 @@ cell_dataset = ds.dataset(non_empty_paths, format="parquet")
 cell_data_cols = cell_dataset.schema.names
 use_classifier = snakemake.params.use_classifier
 metadata_cols = load_metadata_cols(snakemake.params.metadata_cols_fp, use_classifier)
+missing_group_cols = [col for col in group_cols if col not in cell_data_cols]
+if missing_group_cols:
+    raise ValueError(
+        f"aggregate group_cols not found in cell data: {missing_group_cols}"
+    )
+metadata_cols += [col for col in group_cols if col not in metadata_cols]
 feature_cols = [col for col in cell_dataset.schema.names if col not in metadata_cols]
 
 # Filter metadata_cols to only include columns that exist in the parquet
@@ -78,6 +92,7 @@ construct_feature_sums = {}  # {construct_id: [sum of features]}
 construct_feature_counts = {}  # {construct_id: count for averaging}
 # For median, we need all values - store them
 construct_feature_values = {}  # {construct_id: list of feature arrays}
+construct_group_map = {}  # {construct_id: group label}
 
 # Process each batch
 for batch_idx, indices in enumerate(subset_indices):
@@ -125,6 +140,19 @@ for batch_idx, indices in enumerate(subset_indices):
         method=snakemake.params.feature_normalization,
     ).astype(np.float32)
 
+    # fold group values into the perturbation labels so a point is perturbation x group
+    if group_cols:
+        group_labels = metadata[group_cols[0]].astype(str)
+        for col in group_cols[1:]:
+            group_labels = group_labels + GROUP_KEY_SEP + metadata[col].astype(str)
+        metadata[pert_col] = (
+            metadata[pert_col].astype(str) + GROUP_KEY_SEP + group_labels
+        )
+        if pert_id_col != pert_col:
+            metadata[pert_id_col] = (
+                metadata[pert_id_col].astype(str) + GROUP_KEY_SEP + group_labels
+            )
+
     # OUTPUT 1: Write center-scaled single-cell data incrementally
     print(f"Writing batch {batch_idx + 1} to parquet...")
     aligned_batch = pd.concat(
@@ -152,6 +180,8 @@ for batch_idx, indices in enumerate(subset_indices):
             construct_cell_counts[construct_id] = 0
             construct_gene_map[construct_id] = gene_name
             construct_feature_values[construct_id] = []
+            if group_cols:
+                construct_group_map[construct_id] = group_labels[mask].iloc[0]
 
         construct_cell_counts[construct_id] += mask.sum()
         construct_feature_values[construct_id].append(construct_features)
@@ -203,7 +233,7 @@ print("\n=== Creating gene-level table ===")
 
 # Filter out controls for gene-level aggregation
 non_control_constructs = construct_table[
-    ~construct_table[pert_col].str.contains(control_key, na=False)
+    ~control_mask(construct_table[pert_col], control_key)
 ]
 
 # Calculate gene-level sample sizes (sum of construct cell counts)
@@ -225,7 +255,7 @@ gene_table = pd.merge(gene_features, gene_sample_sizes, on=pert_col, how="left")
 
 # Add controls to gene table (controls are their own "genes")
 control_constructs = construct_table[
-    construct_table[pert_col].str.contains(control_key, na=False)
+    control_mask(construct_table[pert_col], control_key)
 ]
 control_gene_table = control_constructs[[pert_col, "cell_count"] + feature_cols].copy()
 
@@ -247,10 +277,24 @@ if pseudogene_patterns:
     # Import the pseudo-gene grouping function
     from lib.aggregate.bootstrap import create_pseudogene_groups
 
-    # Create pseudo-gene groups from construct table
-    pseudogene_groups, remaining_constructs = create_pseudogene_groups(
-        construct_table, pseudogene_patterns, pert_col, seed=42
-    )
+    if group_cols:
+        pseudogene_groups = []
+        construct_groups = construct_table[pert_id_col].map(construct_group_map)
+        for group_label in sorted(construct_groups.dropna().unique()):
+            group_pseudogenes, _ = create_pseudogene_groups(
+                construct_table[construct_groups == group_label],
+                pseudogene_patterns,
+                pert_col,
+                seed=42,
+            )
+            for pseudogene_group in group_pseudogenes:
+                pseudogene_group["pseudogene_id"] += f"{GROUP_KEY_SEP}{group_label}"
+            pseudogene_groups.extend(group_pseudogenes)
+    else:
+        # Create pseudo-gene groups from construct table
+        pseudogene_groups, remaining_constructs = create_pseudogene_groups(
+            construct_table, pseudogene_patterns, pert_col, seed=42
+        )
 
     pseudogene_rows = []
 

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -13,11 +13,9 @@ from lib.aggregate.cell_data_utils import (
     load_metadata_cols,
     split_cell_data,
     control_mask,
+    GROUP_KEY_SEP,
 )
 from lib.aggregate.bootstrap import create_pseudogene_groups
-
-# folds group values into perturbation labels; not "__" (reserved in filenames), glob, or regex
-GROUP_KEY_SEP = "="
 
 # Validate required params
 for _param_name in ["perturbation_name_col", "control_key", "metadata_cols_fp"]:

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -200,8 +200,10 @@ construct_rows = []
 for construct_id in construct_cell_counts.keys():
     # Concatenate all feature arrays for this construct
     all_features = np.vstack(construct_feature_values[construct_id])
-    # Compute median across all cells
-    median_features = np.median(all_features, axis=0)
+    # Compute median across all cells; nanmedian because per-well filtering drops
+    # different columns in different wells, so the unified schema carries NaN for
+    # columns absent from a construct's well
+    median_features = np.nanmedian(all_features, axis=0)
 
     row = {
         pert_id_col: construct_id,

--- a/workflow/scripts/aggregate/prepare_bootstrap_data.py
+++ b/workflow/scripts/aggregate/prepare_bootstrap_data.py
@@ -10,6 +10,7 @@ from lib.aggregate.cell_data_utils import (
     load_metadata_cols,
     split_cell_data,
     get_feature_table_cols,
+    control_mask,
 )
 from lib.aggregate.bootstrap import write_construct_data
 from lib.shared.parquet_io import read_parquet
@@ -27,6 +28,7 @@ exclusion_string = snakemake.params.exclusion_string
 metadata_cols_fp = snakemake.params.metadata_cols_fp
 bootstrap_features_fp = snakemake.params.bootstrap_features_fp
 bootstrap_extra_features = snakemake.params.get("bootstrap_extra_features", None)
+group_cols = list(snakemake.params.get("group_cols", None) or [])
 
 print("Loading single-cell features data...")
 all_features_cells = read_parquet(snakemake.input.features_singlecell)
@@ -50,8 +52,8 @@ print(f"Construct table shape: {construct_table.shape}")
 print(f"Gene table shape: {gene_table.shape}")
 
 # Filter for control cells (already center-scaled)
-control_mask = all_features_cells[perturbation_col].str.contains(control_key, na=False)
-control_cells = all_features_cells[control_mask]
+is_control = control_mask(all_features_cells[perturbation_col], control_key)
+control_cells = all_features_cells[is_control]
 print(f"Control cells for bootstrap sampling: {len(control_cells)}")
 
 # Load metadata columns and split control cell data
@@ -59,6 +61,16 @@ use_classifier = snakemake.params.use_classifier
 metadata_cols = load_metadata_cols(
     metadata_cols_fp, include_classification_cols=use_classifier
 )
+# group cols are literal columns in the single-cell data, but folded into the
+# composite key in the construct/gene tables
+missing_group_cols = [
+    col for col in group_cols if col not in all_features_cells.columns
+]
+if missing_group_cols:
+    raise ValueError(
+        f"aggregate group_cols not found in cell data: {missing_group_cols}"
+    )
+metadata_cols += [col for col in group_cols if col not in metadata_cols]
 # Add batch_values to metadata_cols (created by prepare_alignment_data in upstream scripts)
 if "batch_values" not in metadata_cols:
     metadata_cols.append("batch_values")

--- a/workflow/scripts/aggregate/split_datasets.py
+++ b/workflow/scripts/aggregate/split_datasets.py
@@ -7,6 +7,7 @@ from lib.aggregate.cell_data_utils import (
     load_metadata_cols,
     split_cell_data,
     channel_combo_subset,
+    join_well_annotations,
 )
 
 
@@ -111,6 +112,11 @@ cell_data = read_parquet(snakemake.input[0])
 metadata_cols = load_metadata_cols(snakemake.params.metadata_cols_fp)
 metadata, features = split_cell_data(cell_data, metadata_cols)
 
+# join per-well annotations before splitting so they are available to split and group
+well_annotations_fp = snakemake.params.well_annotations_fp
+if well_annotations_fp is not None:
+    metadata = join_well_annotations(metadata, well_annotations_fp)
+
 # Classify cells only if classifier path is provided
 classifier_path = snakemake.params.classifier_path
 confidence_thresholds = snakemake.params.confidence_thresholds
@@ -160,7 +166,7 @@ for cell_class in snakemake.params.cell_classes:
         cell_class_metadata = metadata
         cell_class_features = features
     else:
-        cell_class_mask = metadata["class"] == cell_class
+        cell_class_mask = metadata[snakemake.params.split_col] == cell_class
         cell_class_metadata = metadata[cell_class_mask]
         cell_class_features = features[cell_class_mask]
 

--- a/workflow/scripts/cluster/benchmark_clusters.py
+++ b/workflow/scripts/cluster/benchmark_clusters.py
@@ -9,6 +9,7 @@ plt.rcParams.update(
     }
 )
 
+from lib.aggregate.cell_data_utils import control_mask
 from lib.cluster.phate_leiden_clustering import phate_leiden_pipeline
 from lib.cluster.benchmark_clusters import (
     run_benchmark_analysis,
@@ -29,8 +30,10 @@ phate_leiden_clustering = pd.read_csv(snakemake.input[1], sep="\t")
 if snakemake.params.perturbation_auc_threshold is not None:
     aggregated_data = aggregated_data[
         (
-            aggregated_data[snakemake.params.perturbation_name_col].str.startswith(
-                snakemake.params.control_key
+            control_mask(
+                aggregated_data[snakemake.params.perturbation_name_col],
+                snakemake.params.control_key,
+                match="startswith",
             )
         )
         | (

--- a/workflow/scripts/cluster/phate_leiden_clustering.py
+++ b/workflow/scripts/cluster/phate_leiden_clustering.py
@@ -82,7 +82,11 @@ phate_leiden_clustering = phate_leiden_clustering.merge(
 
 # calculate potential to nontargeting
 average_distance_df = calculate_potential_to_nontargeting(
-    potential_df, snakemake.params.control_key
+    potential_df,
+    snakemake.params.control_key,
+    control_scope=snakemake.params.get("control_scope", "pooled"),
+    reference_group=snakemake.params.get("control_reference_group", None),
+    group_cols=snakemake.params.get("group_cols", None),
 )
 
 # merge clustering data with potential_df

--- a/workflow/scripts/cluster/phate_leiden_clustering.py
+++ b/workflow/scripts/cluster/phate_leiden_clustering.py
@@ -8,6 +8,7 @@ plt.rcParams.update(
     }
 )
 
+from lib.aggregate.cell_data_utils import control_mask
 from lib.cluster.cluster_eval import plot_cluster_sizes
 from lib.cluster.phate_leiden_clustering import (
     phate_leiden_pipeline,
@@ -29,8 +30,10 @@ if snakemake.params.perturbation_auc_threshold is not None:
     )
     aggregated_data = aggregated_data[
         (
-            aggregated_data[snakemake.params.perturbation_name_col].str.startswith(
-                snakemake.params.control_key
+            control_mask(
+                aggregated_data[snakemake.params.perturbation_name_col],
+                snakemake.params.control_key,
+                match="startswith",
             )
         )
         | (

--- a/workflow/scripts/phenotype/extract_phenotype.py
+++ b/workflow/scripts/phenotype/extract_phenotype.py
@@ -18,6 +18,7 @@ if not segment_cells:
     cytoplasms = None
 
 cp_method = snakemake.params.cp_method
+custom_feature_definitions = getattr(snakemake.params, "custom_features", None)
 
 # Build wildcards dict, synthesizing 'well' from 'row'+'col' in zarr mode
 wc = dict(snakemake.wildcards)
@@ -25,6 +26,9 @@ if "row" in wc and "col" in wc and "well" not in wc:
     wc["well"] = wc["row"] + wc["col"]
 
 if cp_method == "cp_measure":
+    if custom_feature_definitions:
+        raise ValueError("Custom phenotype features require cp_method 'cp_emulator'")
+
     from lib.phenotype.extract_phenotype_cp_measure import (
         extract_phenotype_cp_measure,
     )
@@ -38,6 +42,7 @@ if cp_method == "cp_measure":
         channel_names=snakemake.params.channel_names,
     )
 elif cp_method == "cp_emulator":
+    from lib.phenotype.custom_features import load_custom_features
     from lib.phenotype.extract_phenotype_cp_emulator import (
         extract_phenotype_cp_emulator,
     )
@@ -51,6 +56,7 @@ elif cp_method == "cp_emulator":
         foci_channel=snakemake.params.foci_channel_index,
         channel_names=snakemake.params.channel_names,
         wildcards=wc,
+        custom_features=load_custom_features(custom_feature_definitions),
     )
 else:
     raise ValueError(


### PR DESCRIPTION
Supersedes and absorbs #256 — that branch is contained here, so this is the single PR for
the whole line of work. 12 commits, run end to end on the zargun screen.

zargun is a barcoded nuclear-receptor over-expression library: V5 tags the receptor, and
the readout is where it sits in the cell under a ligand versus under ethanol. Two things
follow, and they motivate everything below. A point is no longer one perturbation but a
perturbation under a treatment, and the right null for a treated point is the *untreated*
control, not a control that saw the same treatment.

## Grouped aggregation (was #256)

- join per-well experimental variables (`well_annotations_fp`) onto cell metadata, so a
  screen can split or group on a plate-map column rather than only on classifier output
- `group_cols` makes a point perturbation x group while keeping one shared embedding
  space; `split_col` gives each value its own dataset instead
- the bootstrap follows the grouping, with `bootstrap_control_scope` `"pooled"` or
  `"within_group"`
- `control_key` accepts a list of exact names, for libraries whose controls share no
  usable prefix (an ORF screen's `EGFP_1` and `H2B-EGFP_1`), matched through
  `control_mask` so a composite key's group suffix cannot satisfy it
- drop null columns from the PCA sample, as the batch loop already did

## Custom phenotype features

`phenotype.custom_features` takes callables that receive a regionprops region and return a
scalar. They run beside the built-ins and land in the same table as
`<compartment>_custom_<name>_<hash>`.

- the name carries a sha256 prefix of the function source, so redefining a feature cannot
  silently reuse a column computed from different code
- `inspect.getclosurevars` rejects a function that closes over a global, which would not
  survive the config hop to a worker
- compartment selection runs a feature on nucleus, cell or cytoplasm rather than all three
- raises on the `cp_measure` path, which has no equivalent hook

## reference_group control scope

`pooled` and `within_group` both assume the group is a batch nuisance. When the group is a
treatment acting on the perturbation itself, that assumption inverts the test: a receptor
moved by its ligand gets scored against controls that saw the same ligand and moved with
it. `bootstrap_control_scope="reference_group"` with `bootstrap_reference_group` pins the
null to the vehicle group, and `cluster.control_scope` does the same for
`calculate_potential_to_nontargeting`, which previously always averaged over every control.

A missing reference group raises, because the failure is otherwise silent — it still
returns p-values, just against the treated baseline. Existing scopes are byte-identical
and `pooled` remains the default.

## nanmedian in the construct feature table

Per-well filtering drops different columns in different wells, so the unified schema
carries NaN where a column is absent from a construct's own well. `np.median` propagated
one NaN to the whole column: on this four-treatment screen, 13 haralick columns came out
NaN for every construct in two treatments.

## Tests

`test_aggregate_grouping.py`, `test_bootstrap_control_scope.py`,
`test_cluster_control_scope.py`, `test_custom_phenotype_features.py`. 86 pass,
`ruff check` clean. `test_omezarr.py` has a collection error that predates this branch and
is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKRF7b1hnWVb32fs6quWGX
