### PR TITLE
Secondary object detection on zarr3 (port of #171)

### DIFF
--- a/tests/small_test_analysis/config/aggregate_combo.tsv
+++ b/tests/small_test_analysis/config/aggregate_combo.tsv
@@ -1,5 +1,7 @@
-cell_class	channel_combo	plate	well
-Interphase	DAPI_COXIV_CENPA_WGA	1	A1
-Interphase	DAPI_COXIV_CENPA_WGA	1	A2
-Mitotic	DAPI_COXIV_CENPA_WGA	1	A1
-Mitotic	DAPI_COXIV_CENPA_WGA	1	A2
+cell_class	channel_combo	compartment_combo	plate	well
+Interphase	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	1	A1
+Interphase	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	1	A2
+Mitotic	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	1	A1
+Mitotic	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	1	A2
+Interphase	DAPI	nucleus	1	A1
+Interphase	DAPI	nucleus	1	A2

--- a/tests/small_test_analysis/config/cluster_combo.tsv
+++ b/tests/small_test_analysis/config/cluster_combo.tsv
@@ -1,3 +1,4 @@
-cell_class	channel_combo	leiden_resolution
-Interphase	DAPI_COXIV_CENPA_WGA	1
-Interphase	DAPI_COXIV_CENPA_WGA	2
+cell_class	channel_combo	compartment_combo	leiden_resolution
+Interphase	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	1
+Interphase	DAPI_COXIV_CENPA_WGA	cell-nucleus-cytoplasm	2
+Interphase	DAPI	nucleus	2

--- a/tests/small_test_analysis/config/config.yml
+++ b/tests/small_test_analysis/config/config.yml
@@ -194,6 +194,7 @@ phenotype:
   nuclei_diameter: 41.97813156768016
   reconcile: contained_in_cells
   heatmap_plate: 6W
+  second_obj_detection: false
 merge:
   approach: fast
   merge_combo_fp: config/merge_combo.tsv
@@ -240,6 +241,7 @@ classify:
       1: Mitotic
       2: Interphase
 aggregate:
+  split_by_compartment: true
   agg_method: median
   aggregate_combo_fp: config/aggregate_combo.tsv
   batch_cols:
@@ -270,6 +272,10 @@ aggregate:
   bootstrap_combinations:
   - cell_class: Interphase
     channel_combo: DAPI_COXIV_CENPA_WGA
+    compartment_combo: cell-nucleus-cytoplasm
+  - cell_class: Interphase
+    channel_combo: DAPI
+    compartment_combo: nucleus
 cluster:
   cluster_combo_fp: config/cluster_combo.tsv
   uniprot_data_fp: config/benchmark_clusters/uniprot_data.tsv

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,6 +2,10 @@ import warnings
 from pathlib import Path
 import pandas as pd
 
+from lib.shared.compartment_utils import (
+    get_default_compartment_combo,
+    normalize_compartment_combo_table,
+)
 from lib.preprocess.file_utils import get_metadata_wildcard_combos
 from lib.shared.file_utils import (
     get_filename,
@@ -26,6 +30,12 @@ wildcard_constraints:
     col=r"[A-Za-z]*\d+",
     tile=r"[0-9]+",
     plate=r"[0-9]+",
+SPLIT_BY_COMPARTMENT = config.get("aggregate", {}).get(
+    "split_by_compartment", False
+)
+DEFAULT_COMPARTMENT_COMBO = get_default_compartment_combo(
+    config.get("phenotype", {}).get("second_obj_detection", False)
+)
 
 # Get paths to the sample and combo files dfs
 SBS_SAMPLES_FP = Path(config["preprocess"]["sbs_samples_fp"])
@@ -205,7 +215,13 @@ if _bool_cfg("merge_rules_enabled") and config.get("merge", {}).get("enabled", T
 
 if "aggregate" in config:
     AGGREGATE_COMBO_FP = Path(config["aggregate"]["aggregate_combo_fp"])
-    aggregate_wildcard_combos = pd.read_csv(AGGREGATE_COMBO_FP, sep="\t")
+    aggregate_wildcard_combos = normalize_compartment_combo_table(
+        pd.read_csv(AGGREGATE_COMBO_FP, sep="\t"),
+        SPLIT_BY_COMPARTMENT,
+        DEFAULT_COMPARTMENT_COMBO,
+    )
+
+    # Include target and rule files
     include: "targets/aggregate.smk"
 if _bool_cfg("aggregate_rules_enabled") and config.get("aggregate", {}).get("enabled", True) and "aggregate" in config:
     include: "rules/aggregate.smk"
@@ -213,7 +229,13 @@ if _bool_cfg("aggregate_rules_enabled") and config.get("aggregate", {}).get("ena
 
 if "cluster" in config:
     CLUSTER_COMBO_FP = Path(config["cluster"]["cluster_combo_fp"])
-    cluster_wildcard_combos = pd.read_csv(CLUSTER_COMBO_FP, sep="\t")
+    cluster_wildcard_combos = normalize_compartment_combo_table(
+        pd.read_csv(CLUSTER_COMBO_FP, sep="\t"),
+        SPLIT_BY_COMPARTMENT,
+        DEFAULT_COMPARTMENT_COMBO,
+    )
+
+    # Include target and rule files
     include: "targets/cluster.smk"
 if _bool_cfg("cluster_rules_enabled") and config.get("cluster", {}).get("enabled", True) and "cluster" in config:
     include: "rules/cluster.smk"

--- a/workflow/lib/aggregate/aggregate.py
+++ b/workflow/lib/aggregate/aggregate.py
@@ -19,6 +19,7 @@ def aggregate(
     ps_probability_threshold=None,
     ps_percentile_threshold=None,
     group_cols: list = None,
+    carry_cols: list[str] | None = None,
 ) -> tuple[np.ndarray, pd.DataFrame]:
     """Apply mean or median aggregation to replicate embeddings and perturbation scores for each perturbation.
 
@@ -36,6 +37,13 @@ def aggregate(
             Defaults to "mean".
         ps_probability_threshold (float, optional): Threshold for filtering based on perturbation score.
         ps_percentile_threshold (float, optional): Percentile threshold for filtering based on perturbation score.
+        carry_cols (list[str], optional): Metadata columns functionally determined by
+            `pert_col` to preserve (one value per group) in the output. Typical use:
+            when `pert_col` is a construct ID (e.g. `cell_barcode_0`), carry the
+            human-readable gene symbol (`gene_symbol_0`) through so downstream
+            clustering / benchmarking / lookups can match by gene name. Raises
+            ValueError if a carry_col is missing from metadata or has more than one
+            unique value within a group.
 
     Returns:
         tuple:
@@ -52,6 +60,21 @@ def aggregate(
     )
     if aggr_func is None:
         raise ValueError(f"Invalid aggregation method: {method}")
+
+    if carry_cols is None:
+        carry_cols = []
+    else:
+        missing = [c for c in carry_cols if c not in metadata.columns]
+        if missing:
+            raise ValueError(
+                f"carry_cols not found in metadata: {missing}. "
+                f"Available columns: {list(metadata.columns)}"
+            )
+        overlap = [c for c in carry_cols if c == pert_col]
+        if overlap:
+            raise ValueError(
+                f"carry_cols overlap with pert_col: {overlap}. Remove duplicates."
+            )
 
     # filter by ps_probability_threshold; keep NaNs
     if ps_probability_threshold is not None:
@@ -92,6 +115,16 @@ def aggregate(
         # Always include perturbation_auc if present (needed for gene-level filtering in clustering)
         if "perturbation_auc" in metadata.columns:
             agg_meta["perturbation_auc"] = group["perturbation_auc"].iloc[0]
+
+        # Carry through columns that are functionally determined by pert_col.
+        for c in carry_cols:
+            nuniq = group[c].nunique(dropna=False)
+            if nuniq > 1:
+                raise ValueError(
+                    f"carry_col {c!r} has {nuniq} unique values within group "
+                    f"{pert_col}={agg_meta[pert_col]!r}; not functionally determined by {pert_col}."
+                )
+            agg_meta[c] = group[c].iloc[0]
 
         if ps_probability_threshold is not None or ps_percentile_threshold is not None:
             # aggregate perturbation score with same function

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -137,6 +137,8 @@ def join_well_annotations(metadata, well_annotations_fp):
 
 
 RESERVED_METADATA_PREFIXES = ("offset_",)
+# per-cell list of secondary object labels; a record, not a feature
+RESERVED_METADATA_COLS = ("second_obj_ids",)
 
 
 def is_reserved_metadata_col(col):
@@ -144,9 +146,10 @@ def is_reserved_metadata_col(col):
 
     Per-cell alignment-offset QC columns (offset_*) have screen-specific names (the
     alignment step/cycle count varies by screen), so they are matched by prefix rather
-    than enumerated in the metadata_cols file.
+    than enumerated in the metadata_cols file. Non-numeric per-cell records written by
+    secondary object detection are reserved by name.
     """
-    return col.startswith(RESERVED_METADATA_PREFIXES)
+    return col in RESERVED_METADATA_COLS or col.startswith(RESERVED_METADATA_PREFIXES)
 
 
 def split_cell_data(

--- a/workflow/lib/aggregate/cell_data_utils.py
+++ b/workflow/lib/aggregate/cell_data_utils.py
@@ -93,10 +93,14 @@ def join_well_annotations(metadata, well_annotations_fp):
     annotations = pd.read_csv(well_annotations_fp, sep="\t")
     for col in ("plate", "well"):
         if col not in annotations.columns:
-            raise ValueError(f"{well_annotations_fp} is missing required column '{col}'")
+            raise ValueError(
+                f"{well_annotations_fp} is missing required column '{col}'"
+            )
 
     # a repeated well would multiply cells through the join and desync them from features
-    duplicated = annotations[annotations.duplicated(subset=["plate", "well"], keep=False)]
+    duplicated = annotations[
+        annotations.duplicated(subset=["plate", "well"], keep=False)
+    ]
     if len(duplicated) > 0:
         raise ValueError(
             f"{well_annotations_fp} repeats (plate, well): "
@@ -132,6 +136,19 @@ def join_well_annotations(metadata, well_annotations_fp):
     return joined
 
 
+RESERVED_METADATA_PREFIXES = ("offset_",)
+
+
+def is_reserved_metadata_col(col):
+    """Return True for columns always treated as metadata regardless of METADATA_COLS.
+
+    Per-cell alignment-offset QC columns (offset_*) have screen-specific names (the
+    alignment step/cycle count varies by screen), so they are matched by prefix rather
+    than enumerated in the metadata_cols file.
+    """
+    return col.startswith(RESERVED_METADATA_PREFIXES)
+
+
 def split_cell_data(
     cell_data, metadata_cols, validate_dtypes=True, raise_on_invalid=True
 ):
@@ -156,6 +173,14 @@ def split_cell_data(
     """
     # Ensure all metadata columns exist in the data
     existing_metadata_cols = [col for col in metadata_cols if col in cell_data.columns]
+
+    # Reserved metadata (offset_* QC) matched by pattern, not enumeration
+    reserved_metadata_cols = [
+        col
+        for col in cell_data.columns
+        if col not in existing_metadata_cols and is_reserved_metadata_col(col)
+    ]
+    existing_metadata_cols = existing_metadata_cols + reserved_metadata_cols
 
     # Get metadata columns
     metadata = cell_data[existing_metadata_cols].copy()
@@ -291,3 +316,122 @@ def get_feature_table_cols(feature_cols, extra_tags=None):
     selected_columns.extend(extra_cols)
 
     return selected_columns
+
+
+COMPARTMENT_PREFIXES = {
+    "cell": "cell_",
+    "nucleus": "nucleus_",
+    "cytoplasm": "cytoplasm_",
+    "second_obj": "second_obj_",
+}
+
+# Second-object-derived per-cell summary columns lacking the second_obj_ prefix.
+SECOND_OBJ_EXTRA_COLS = frozenset(
+    {
+        "total_second_obj_area",
+        "mean_second_obj_diameter",
+        "mean_distance_to_nucleus",
+    }
+)
+
+
+def compartment_combo_subset(
+    features: pd.DataFrame, compartment_combo: str, all_compartments: list[str]
+) -> pd.DataFrame:
+    """Filter features to keep only columns belonging to the requested compartments.
+
+    Args:
+        features (pd.DataFrame): Feature columns (metadata already split out).
+        compartment_combo (list[str]): Compartments to keep, e.g. ["cell", "nucleus"].
+        all_compartments (list[str]): Compartments present in the input. Used to
+            determine which prefixes to exclude.
+
+    Returns:
+        pd.DataFrame: features without columns belonging to excluded compartments.
+    """
+    excluded = [c for c in all_compartments if c not in compartment_combo]
+    excluded_prefixes = [COMPARTMENT_PREFIXES[c] for c in excluded]
+
+    cols_to_drop = [
+        col
+        for col in features.columns
+        if any(col.startswith(p) for p in excluded_prefixes)
+    ]
+    if "second_obj" in excluded:
+        cols_to_drop += [c for c in SECOND_OBJ_EXTRA_COLS if c in features.columns]
+
+    return features.drop(columns=cols_to_drop)
+
+
+def resolve_aggregate_combos(
+    aggregate_combos: list[dict], second_obj_detection: bool
+) -> list[dict]:
+    """Normalize and validate AGGREGATE_COMBOS entries.
+
+    For each entry:
+    - Fills in default compartments (all 4 if detection on, 3 otherwise) when missing.
+    - Dedupes compartments within the combo (preserving order).
+    - Validates compartment names, non-empty channels/compartments, and
+      second_obj-vs-detection consistency.
+    After normalization, duplicate (channels, compartments) pairs are deduped.
+
+    Args:
+        aggregate_combos (list[dict]): Each dict has "channels" (list[str]) and
+            optionally "compartments" (list[str]).
+        second_obj_detection (bool): From config["phenotype"]["second_obj_detection"].
+
+    Returns:
+        list[dict]: Normalized, validated, and de-duplicated combos.
+
+    Raises:
+        ValueError: On any validation failure.
+    """
+    valid_compartments = set(COMPARTMENT_PREFIXES)
+    default_compartments = (
+        ["cell", "nucleus", "cytoplasm", "second_obj"]
+        if second_obj_detection
+        else ["cell", "nucleus", "cytoplasm"]
+    )
+
+    resolved = []
+    seen = set()
+    for idx, combo in enumerate(aggregate_combos):
+        channels = list(combo.get("channels") or [])
+        if not channels:
+            raise ValueError(
+                f"AGGREGATE_COMBOS[{idx}] must specify at least one channel"
+            )
+
+        comps = combo.get("compartments")
+        if comps is None:
+            comps = list(default_compartments)
+        else:
+            comps = list(comps)
+        if not comps:
+            raise ValueError(
+                f"AGGREGATE_COMBOS[{idx}] must specify at least one compartment"
+            )
+
+        # Dedupe compartments while preserving order
+        deduped = []
+        for c in comps:
+            if c not in valid_compartments:
+                raise ValueError(
+                    f"AGGREGATE_COMBOS[{idx}] has unknown compartment {c!r}; "
+                    f"must be one of {sorted(valid_compartments)}"
+                )
+            if c == "second_obj" and not second_obj_detection:
+                raise ValueError(
+                    f"AGGREGATE_COMBOS[{idx}] lists 'second_obj' but "
+                    f"config['phenotype']['second_obj_detection'] is False"
+                )
+            if c not in deduped:
+                deduped.append(c)
+
+        key = (tuple(channels), tuple(deduped))
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append({"channels": channels, "compartments": deduped})
+
+    return resolved

--- a/workflow/lib/aggregate/eval_aggregate.py
+++ b/workflow/lib/aggregate/eval_aggregate.py
@@ -8,7 +8,6 @@ It provides the following functionalities:
 """
 
 import pandas as pd
-import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
 
@@ -108,6 +107,21 @@ def plot_feature_distributions(
     Returns:
         matplotlib.figure.Figure: Figure containing the violin plots.
     """
+    # Defensive: return a placeholder figure when feature selection is empty (avoids nrows=0 in plt.subplots).
+    if not original_feature_cols or not aligned_feature_cols:
+        fig, ax = plt.subplots(figsize=(8, 2))
+        ax.text(
+            0.5,
+            0.5,
+            "No intensity features available for this compartment_combo; "
+            "feature-distribution plot skipped.",
+            ha="center",
+            va="center",
+            wrap=True,
+        )
+        ax.axis("off")
+        return fig
+
     # Melt original features
     df_orig = original_cell_data[["plate", "well"] + original_feature_cols].melt(
         id_vars=["plate", "well"], var_name="Feature", value_name="Value"

--- a/workflow/lib/aggregate/filter.py
+++ b/workflow/lib/aggregate/filter.py
@@ -5,12 +5,128 @@ Available filters:
 - perturbation_filter: Remove cells without perturbation assignments
 - missing_values_filter: Handle missing values through dropping or imputation
 - intensity_filter: Remove outliers based on channel intensities using LocalOutlierFactor
+- harmonize_pool_schema: Compute a consistent feature-column set for a pool of per-well parquets
 """
 
 import pandas as pd
 import numpy as np
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
 from sklearn.impute import KNNImputer
 from sklearn.neighbors import LocalOutlierFactor
+
+from lib.aggregate.cell_data_utils import is_reserved_metadata_col
+
+
+def harmonize_pool_schema(
+    paths: list[str],
+    metadata_cols: list[str],
+    drop_cols_threshold: float | None = None,
+) -> tuple[list[str], list[str], dict]:
+    """Compute a consistent (metadata, feature) column set for a multi-file pool.
+
+    When per-well filter decisions diverge — e.g. missing_values_filter drops
+    different columns in different wells because class composition varies — naive
+    pool reads via pyarrow's dataset union produce NaN blocks that break
+    downstream operations (PCA, center-scale). This helper produces a single
+    harmonized column set to use across every scan of the pool, matching the
+    drop-column convention from missing_values_filter.
+
+    Steps:
+      1. Schema intersection across `paths`. Columns present in some but not all
+         files are "lost to per-well schema mismatch" (typically driven by
+         class-composition differences across wells) and logged per-file.
+      2. If `drop_cols_threshold` is provided, scan the intersected pool once and
+         drop any feature column whose pool-level NaN proportion is >= threshold.
+         Uses the same comparison as missing_values_filter.
+    Row-level NaN cleanup (drop_rows_threshold, impute) is intentionally
+    deferred to the caller so it can be applied on each working subset.
+
+    Args:
+        paths (list[str]): parquet file paths forming the pool.
+        metadata_cols (list[str]): canonical metadata column names. Only those
+            present in every file are returned.
+        drop_cols_threshold (float | None): pool-level NaN proportion threshold
+            above which a feature column is dropped. None disables this step.
+
+    Returns:
+        tuple:
+            kept_metadata_cols (list[str]) — the surviving `metadata_cols`, plus any
+                reserved metadata columns (see is_reserved_metadata_col) found in the
+                intersection but absent from `metadata_cols`,
+            kept_feature_cols (list[str]),
+            report (dict) — keys: "schema_mismatch" (dict file -> missing cols),
+                                  "threshold_dropped" (list of col names).
+    """
+    if not paths:
+        return [], [], {"schema_mismatch": {}, "threshold_dropped": []}
+
+    per_file_schemas = {p: set(pq.read_schema(p).names) for p in paths}
+    union_cols = set().union(*per_file_schemas.values())
+    intersection_cols = set.intersection(*per_file_schemas.values())
+    schema_mismatch = {
+        p: sorted(union_cols - cols)
+        for p, cols in per_file_schemas.items()
+        if union_cols - cols
+    }
+
+    if schema_mismatch:
+        total_lost = len(union_cols - intersection_cols)
+        print(
+            f"[pool] dropping {total_lost} column(s) present in some but not all "
+            f"of {len(paths)} input files (per-file missingness — typically driven "
+            f"by class composition differences across wells):"
+        )
+        for p, missing in schema_mismatch.items():
+            preview = ", ".join(missing[:5]) + (
+                f", ...(+{len(missing) - 5} more)" if len(missing) > 5 else ""
+            )
+            print(f"  {p.split('/')[-1]}: missing {len(missing)} col(s): {preview}")
+
+    # Preserve caller order for metadata cols; sort feature cols for determinism.
+    kept_metadata_cols = [c for c in metadata_cols if c in intersection_cols]
+    reserved_metadata_cols = sorted(
+        c
+        for c in intersection_cols
+        if c not in set(metadata_cols) and is_reserved_metadata_col(c)
+    )
+    kept_metadata_cols = kept_metadata_cols + reserved_metadata_cols
+    kept_feature_cols = sorted(
+        c for c in intersection_cols if c not in set(kept_metadata_cols)
+    )
+
+    threshold_dropped = []
+    if drop_cols_threshold is not None and kept_feature_cols:
+        # Pin to one reference schema so pyarrow casts each file instead of auto-unifying.
+        pool = ds.dataset(
+            paths, format="parquet", schema=pq.read_schema(paths[0])
+        ).to_table(columns=kept_feature_cols)
+        # Compute pool-level NaN proportion per column without materializing full pandas.
+        total_rows = pool.num_rows
+        if total_rows > 0:
+            for col_name in list(kept_feature_cols):
+                nulls = pool.column(col_name).null_count
+                if nulls / total_rows >= drop_cols_threshold:
+                    threshold_dropped.append(col_name)
+        if threshold_dropped:
+            print(
+                f"[pool] dropping {len(threshold_dropped)} column(s) with pool-level "
+                f"NaN proportion >= {drop_cols_threshold * 100:.1f}%: "
+                f"{', '.join(threshold_dropped[:10])}"
+                f"{', ...' if len(threshold_dropped) > 10 else ''}"
+            )
+            kept_feature_cols = [
+                c for c in kept_feature_cols if c not in threshold_dropped
+            ]
+
+    return (
+        kept_metadata_cols,
+        kept_feature_cols,
+        {
+            "schema_mismatch": schema_mismatch,
+            "threshold_dropped": threshold_dropped,
+        },
+    )
 
 
 def query_filter(metadata, features, queries):
@@ -149,42 +265,36 @@ def missing_values_filter(
                 if pd.api.types.is_integer_dtype(features[col]):
                     features[col] = features[col].astype("float64")
 
-            # Identify rows with any NAs in the remaining columns
-            has_na_mask = features[remaining_cols_with_na].isna().any(axis=1)
-            na_rows_idx = features.index[has_na_mask]
-            non_na_rows_idx = features.index[~has_na_mask]
+            # Use positional (iloc) indexing throughout since features.index may have duplicate labels.
+            has_na_mask = features[remaining_cols_with_na].isna().any(axis=1).to_numpy()
+            na_positions = np.flatnonzero(has_na_mask)
+            non_na_positions = np.flatnonzero(~has_na_mask)
+            col_positions = [
+                features.columns.get_loc(c) for c in remaining_cols_with_na
+            ]
 
             np.random.seed(42)
-            # Process NA rows in batches
-            for i in range(0, len(na_rows_idx), batch_size):
-                batch_na_idx = na_rows_idx[i : i + batch_size]
+            for i in range(0, len(na_positions), batch_size):
+                batch_pos = na_positions[i : i + batch_size]
                 print(
-                    f"Imputing for batch {i // batch_size + 1} with {len(batch_na_idx)} NA rows"
+                    f"Imputing for batch {i // batch_size + 1} with {len(batch_pos)} NA rows"
                 )
 
-                # Sample non-NA rows randomly instead of stratified sampling
-                sampled_non_na_idx = np.random.choice(
-                    non_na_rows_idx,
-                    size=min(sample_size, len(non_na_rows_idx)),
+                sampled_non_na_pos = np.random.choice(
+                    non_na_positions,
+                    size=min(sample_size, len(non_na_positions)),
                     replace=False,
                 )
+                combined_pos = np.concatenate([batch_pos, sampled_non_na_pos])
 
-                # Combine sampled non-NA rows with current batch of NA rows
-                batch_idx = np.concatenate([batch_na_idx, sampled_non_na_idx])
-
-                # Perform KNN imputation on this batch
                 imputer = KNNImputer(n_neighbors=5)
                 imputed_values = imputer.fit_transform(
-                    features.loc[batch_idx, remaining_cols_with_na]
+                    features.iloc[combined_pos, col_positions].to_numpy()
                 )
 
-                # Update only the NA rows with imputed values
-                na_rows_in_batch = np.arange(len(batch_na_idx))
-                features.loc[batch_na_idx, remaining_cols_with_na] = pd.DataFrame(
-                    imputed_values[na_rows_in_batch],
-                    index=batch_na_idx,
-                    columns=remaining_cols_with_na,
-                )
+                features.iloc[batch_pos, col_positions] = imputed_values[
+                    : len(batch_pos)
+                ]
 
     return metadata, features
 

--- a/workflow/lib/aggregate/perturbation_score.py
+++ b/workflow/lib/aggregate/perturbation_score.py
@@ -16,7 +16,11 @@ from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.metrics import roc_auc_score
 
 from lib.aggregate.align import prepare_alignment_data, centerscale_on_controls
-from lib.aggregate.cell_data_utils import split_cell_data, control_mask
+from lib.aggregate.cell_data_utils import (
+    split_cell_data,
+    control_mask,
+    is_reserved_metadata_col,
+)
 
 
 def perturbation_score(
@@ -24,6 +28,9 @@ def perturbation_score(
     metadata_cols: list[str],
     perturbation_name_col: str,
     control_key: str | list,
+    perturbation_id_col: str | None = None,
+    control_name_col: str | None = None,
+    batch_cols: list[str] | None = None,
     minimum_cell_count: int = 100,
     n_jobs: int = -1,
 ) -> None:
@@ -36,19 +43,31 @@ def perturbation_score(
     Args:
         cell_data (pd.DataFrame): DataFrame containing cell data that will be modified in-place.
         metadata_cols (list[str]): List of metadata column names that will be updated to include 'perturbation_score'.
-        perturbation_name_col (str): Column name containing perturbation identifiers.
-        control_key (str | list): Prefix identifying control perturbations (e.g., 'nontargeting').
+        perturbation_name_col (str): Column name containing perturbation identifiers (what `gene` is drawn from; e.g. "gene_symbol_0" or "cell_barcode_0").
+        control_key (str | list): Prefix identifying control perturbations (e.g., 'nontargeting'), or a list of exact control names.
+        perturbation_id_col (str, optional): Column name for unique perturbation IDs
+            used by prepare_alignment_data. Defaults to perturbation_name_col.
+        control_name_col (str, optional): Column used to identify controls via
+            control_key. Defaults to perturbation_name_col.
+        batch_cols (list[str], optional): Columns defining the batch grouping.
+            Defaults to ["plate", "well"].
         minimum_cell_count (int, optional): Minimum number of cells required to process a perturbation. Defaults to 100.
         n_jobs (int, optional): Number of parallel jobs. -1 uses all available CPUs. Defaults to -1.
     """
+    if perturbation_id_col is None:
+        perturbation_id_col = perturbation_name_col
+    if control_name_col is None:
+        control_name_col = perturbation_name_col
+    if batch_cols is None:
+        batch_cols = ["plate", "well"]
+
     perturbation_col = cell_data[perturbation_name_col]
-    unique_perts = perturbation_col.drop_duplicates()
-    perturbed_genes = unique_perts[
-        ~control_mask(unique_perts, control_key, match="startswith")
-    ].tolist()
-    nt_idx = perturbation_col.index[
-        control_mask(perturbation_col, control_key, match="startswith")
-    ].to_numpy()
+    # Controls are identified on control_name_col; control_mask ignores any group suffix on a composite key.
+    is_control = control_mask(
+        cell_data[control_name_col], control_key, match="startswith"
+    )
+    perturbed_genes = perturbation_col[~is_control].dropna().unique().tolist()
+    nt_idx = perturbation_col.index[is_control].to_numpy()
 
     print(f"Processing {len(perturbed_genes)} genes with {n_jobs} parallel jobs...")
 
@@ -82,8 +101,8 @@ def perturbation_score(
             )
             keep_idx = np.union1d(gene_idx, nt_keep)
 
-            # Extract subset
-            gene_subset_df = cell_data.iloc[keep_idx].copy()
+            # Extract subset via .loc since keep_idx holds pandas index labels.
+            gene_subset_df = cell_data.loc[keep_idx].copy()
             original_idx = gene_subset_df.index.copy()
             gene_subset_df = gene_subset_df.reset_index(drop=True)
 
@@ -97,6 +116,11 @@ def perturbation_score(
                 gene_subset_df,
                 original_idx,
                 metadata_cols,
+                perturbation_name_col,
+                control_key,
+                perturbation_id_col,
+                control_name_col,
+                batch_cols,
                 minimum_cell_count,
                 perturbation_name_col,
                 control_key,
@@ -123,7 +147,7 @@ def calculate_perturbation_scores(
     cell_data: pd.DataFrame,
     gene: str,
     feature_cols: list[str],
-    perturbation_col: str = "gene_symbol_0",
+    perturbation_col: str,
     n_differential_features: int = 200,
     minimum_cell_count: int = 100,
 ) -> tuple[pd.Series, float]:
@@ -139,7 +163,7 @@ def calculate_perturbation_scores(
         cell_data (pd.DataFrame): DataFrame containing cell data with features and metadata.
         gene (str): The target gene perturbation to score against.
         feature_cols (list[str]): List of feature column names to use for scoring.
-        perturbation_col (str, optional): Column name containing perturbation labels. Defaults to "gene_symbol_0".
+        perturbation_col (str): Column name containing perturbation labels used to build the binary target.
         n_differential_features (int, optional): Number of top differential features to select. Defaults to 200.
         minimum_cell_count (int, optional): Minimum number of cells required for scoring. Defaults to 200.
 
@@ -150,7 +174,15 @@ def calculate_perturbation_scores(
     if cell_data.shape[0] < minimum_cell_count:
         return pd.Series(np.nan, index=cell_data.index), np.nan
 
-    y = (cell_data[perturbation_col] == gene).astype(int).to_numpy()
+    # NaN-safe binary target: fillna(False) so astype(int) yields strictly {0, 1}.
+    y = (
+        cell_data[perturbation_col]
+        .eq(gene)
+        .fillna(False)
+        .astype(bool)
+        .astype(int)
+        .to_numpy()
+    )
     X_all = cell_data[feature_cols].to_numpy()
 
     # select top-k differential features (ANOVA F-test)
@@ -179,21 +211,27 @@ def _process_gene_subset(
     gene_subset_df: pd.DataFrame,
     original_idx: pd.Index,
     metadata_cols: list[str],
-    minimum_cell_count: int,
     perturbation_name_col: str,
     control_key: str | list,
+    perturbation_id_col: str,
+    control_name_col: str,
+    batch_cols: list[str],
+    minimum_cell_count: int,
 ) -> tuple[str, np.ndarray, pd.Series, float] | None:
     """Process a pre-sliced gene subset and return perturbation scores.
 
     Args:
-        gene: Gene symbol being processed.
-        gene_idx: Original indices of gene cells in the full dataset.
-        gene_subset_df: Pre-sliced DataFrame with gene + control cells (reset index).
+        gene: Perturbation identifier being scored (drawn from perturbation_name_col).
+        gene_idx: Original indices of perturbation cells in the full dataset.
+        gene_subset_df: Pre-sliced DataFrame with perturbation + control cells (reset index).
         original_idx: Original indices before reset (for mapping scores back).
         metadata_cols: Metadata column names.
+        perturbation_name_col: Column naming each perturbation unit (what `gene` is drawn from).
+        control_key: Prefix identifying control rows in control_name_col, or a list of exact control names.
+        perturbation_id_col: Column used as the unique perturbation ID in prepare_alignment_data.
+        control_name_col: Column used by centerscale to detect controls via control_key.
+        batch_cols: Columns defining the batch grouping.
         minimum_cell_count: Minimum cells required.
-        perturbation_name_col: Column name containing perturbation labels.
-        control_key: Control identifier, or a list of exact control names.
 
     Returns:
         Tuple of (gene, gene_idx, perturbation_scores, auc) or None if skipped.
@@ -204,14 +242,15 @@ def _process_gene_subset(
 
     # SCALE PERTURBATION GENE AND CONTROL FEATURES
     feature_cols = gene_subset_df.columns.difference(metadata_cols, sort=False)
+    feature_cols = feature_cols[[not is_reserved_metadata_col(c) for c in feature_cols]]
     metadata, features = split_cell_data(gene_subset_df, metadata_cols)
     metadata, features = prepare_alignment_data(
         metadata,
         features,
-        ["plate", "well"],
+        batch_cols,
         perturbation_name_col,
         control_key,
-        "cell_barcode_0",
+        perturbation_id_col,
     )
 
     features = features.astype(np.float32)
@@ -221,6 +260,7 @@ def _process_gene_subset(
         perturbation_name_col,
         control_key,
         "batch_values",
+        control_col=control_name_col,
     )
     features = pd.DataFrame(features, columns=feature_cols)
     gene_subset_df = pd.concat([metadata, features], axis=1)

--- a/workflow/lib/aggregate/second_obj_utils.py
+++ b/workflow/lib/aggregate/second_obj_utils.py
@@ -1,0 +1,236 @@
+"""Utilities for aggregating secondary object data into cell-level features.
+
+This module provides functions to merge cell-level data with per-object secondary
+object data using configurable aggregation strategies.
+"""
+
+import numpy as np
+import pandas as pd
+from typing import Literal, List
+
+
+def aggregate_second_obj_data(
+    cells_df: pd.DataFrame,
+    second_objs_df: pd.DataFrame,
+    agg_strategy: Literal["none", "single", "all", "average"],
+) -> pd.DataFrame:
+    """Aggregate secondary object data according to specified strategy.
+
+    Merges cell-level data with secondary-object-level data using different
+    strategies to handle the one-to-many relationship between cells and
+    secondary objects.
+
+    Args:
+        cells_df (pd.DataFrame): Cell-level data from final_merge. Must contain
+            merge keys: 'plate', 'well', 'tile', 'cell_0'.
+        second_objs_df (pd.DataFrame): Per-object secondary object data from
+            merge_phenotype_second_objs. Must contain merge keys: 'plate', 'well',
+            'tile', 'cell_id'.
+        agg_strategy ({"none", "single", "all", "average"}): Aggregation strategy:
+            - "none": Return cells_df unchanged
+            - "single": Add features only for cells with exactly 1 secondary object;
+              NaN for cells with 0 or 2+ objects (no rows are dropped)
+            - "all": Create numbered columns per object (feature_1, feature_2, etc.)
+            - "average": Mean of numeric features across all secondary objects per cell
+
+    Returns:
+        pd.DataFrame: Cell-level data with secondary object features merged according
+            to strategy. All cells from cells_df are always preserved. A well with no
+            secondary objects still gets the full set of feature columns, NaN-filled,
+            so per-well outputs keep a consistent schema — pooling intersects columns
+            across wells, so dropping them for one well would drop them for all.
+
+    Raises:
+        ValueError: If required merge keys are missing or strategy is invalid.
+    """
+    valid_strategies = ["none", "single", "all", "average"]
+    if agg_strategy not in valid_strategies:
+        raise ValueError(
+            f"Unknown strategy: {agg_strategy}. Must be one of {valid_strategies}"
+        )
+
+    if agg_strategy == "none":
+        return cells_df.copy()
+
+    cells_merge_keys = ["plate", "well", "tile", "cell_0"]
+    second_objs_merge_keys = ["plate", "well", "tile", "cell_id"]
+
+    _validate_merge_keys(cells_df, cells_merge_keys, "cells")
+    _validate_merge_keys(second_objs_df, second_objs_merge_keys, "second_objs")
+    second_objs_df = _align_merge_key_dtypes(
+        cells_df, second_objs_df, cells_merge_keys, second_objs_merge_keys
+    )
+
+    strategy_functions = {
+        "single": _aggregate_single,
+        "all": _aggregate_all,
+        "average": _aggregate_average,
+    }
+
+    return strategy_functions[agg_strategy](
+        cells_df.copy(), second_objs_df, cells_merge_keys, second_objs_merge_keys
+    )
+
+
+def _validate_merge_keys(
+    df: pd.DataFrame, required_keys: List[str], df_name: str
+) -> None:
+    """Validate that required merge keys exist in dataframe."""
+    missing_keys = [key for key in required_keys if key not in df.columns]
+    if missing_keys:
+        raise ValueError(f"Missing merge keys {missing_keys} in {df_name} dataframe")
+
+
+def _align_merge_key_dtypes(
+    cells_df: pd.DataFrame,
+    second_objs_df: pd.DataFrame,
+    cells_keys: List[str],
+    second_objs_keys: List[str],
+) -> pd.DataFrame:
+    """Cast second-object merge keys to the cells' dtypes so the left-merge matches."""
+    df = second_objs_df.copy()
+    for ck, sk in zip(cells_keys, second_objs_keys):
+        if (
+            ck in cells_df.columns
+            and sk in df.columns
+            and df[sk].dtype != cells_df[ck].dtype
+        ):
+            df[sk] = df[sk].astype(cells_df[ck].dtype)
+    return df
+
+
+def _get_feature_cols(second_objs_df: pd.DataFrame, merge_keys: List[str]) -> List[str]:
+    """Get secondary object feature columns (everything except merge keys and second_obj_id)."""
+    exclude = set(merge_keys) | {"second_obj_id"}
+    return [col for col in second_objs_df.columns if col not in exclude]
+
+
+def _prepare_second_objs(
+    second_objs_df: pd.DataFrame,
+    second_objs_merge_keys: List[str],
+    cells_merge_keys: List[str],
+) -> pd.DataFrame:
+    """Rename cell_id to cell_0 for merging with cells dataframe."""
+    df = second_objs_df.copy()
+    df = df.rename(columns={"cell_id": "cell_0"})
+    return df
+
+
+def _aggregate_single(
+    cells_df: pd.DataFrame,
+    second_objs_df: pd.DataFrame,
+    cells_merge_keys: List[str],
+    second_objs_merge_keys: List[str],
+) -> pd.DataFrame:
+    """Single strategy: populate features only for cells with exactly 1 secondary object.
+
+    All cells are preserved. Cells with 0 or 2+ secondary objects get NaN for
+    all secondary object feature columns.
+    """
+    second_objs = _prepare_second_objs(
+        second_objs_df, second_objs_merge_keys, cells_merge_keys
+    )
+    feature_cols = _get_feature_cols(second_objs_df, second_objs_merge_keys)
+
+    # Count secondary objects per cell
+    obj_counts = (
+        second_objs.groupby(cells_merge_keys).size().reset_index(name="_obj_count")
+    )
+
+    # Tag cells with their object count, keeping a stable key so the split/concat below preserves input order
+    cells_with_count = cells_df.merge(obj_counts, on=cells_merge_keys, how="left")
+    cells_with_count["_obj_count"] = cells_with_count["_obj_count"].fillna(0)
+    cells_with_count = cells_with_count.reset_index(drop=True)
+    cells_with_count["_orig_order"] = np.arange(len(cells_with_count))
+
+    # Split into single-object and other cells
+    single_mask = cells_with_count["_obj_count"] == 1
+    single_cells = cells_with_count[single_mask].drop(columns=["_obj_count"])
+    other_cells = cells_with_count[~single_mask].drop(columns=["_obj_count"])
+
+    # Merge features for single-object cells
+    merged_single = single_cells.merge(
+        second_objs[cells_merge_keys + feature_cols],
+        on=cells_merge_keys,
+        how="left",
+    )
+
+    # Add NaN columns for other cells
+    if feature_cols:
+        nan_df = pd.DataFrame(np.nan, index=other_cells.index, columns=feature_cols)
+        other_cells = pd.concat([other_cells, nan_df], axis=1)
+
+    combined = pd.concat([merged_single, other_cells], ignore_index=True)
+    combined = combined.sort_values("_orig_order").reset_index(drop=True)
+    return combined.drop(columns=["_orig_order"])
+
+
+def _aggregate_all(
+    cells_df: pd.DataFrame,
+    second_objs_df: pd.DataFrame,
+    cells_merge_keys: List[str],
+    second_objs_merge_keys: List[str],
+) -> pd.DataFrame:
+    """All strategy: create numbered columns for each secondary object.
+
+    Creates feature_1, feature_2, etc. columns. Cells with fewer objects than
+    the maximum get NaN for the missing object columns.
+    """
+    second_objs = _prepare_second_objs(
+        second_objs_df, second_objs_merge_keys, cells_merge_keys
+    )
+    feature_cols = _get_feature_cols(second_objs_df, second_objs_merge_keys)
+
+    # Number secondary objects within each cell
+    second_objs["_obj_num"] = second_objs.groupby(cells_merge_keys).cumcount() + 1
+
+    max_objs = second_objs["_obj_num"].max() if len(second_objs) > 0 else 0
+
+    result_df = cells_df.copy()
+
+    for obj_num in range(1, max_objs + 1):
+        current = second_objs[second_objs["_obj_num"] == obj_num].copy()
+        col_mapping = {col: f"{col}_{obj_num}" for col in feature_cols}
+        current = current.rename(columns=col_mapping)
+
+        merge_cols = cells_merge_keys + list(col_mapping.values())
+        result_df = result_df.merge(
+            current[merge_cols], on=cells_merge_keys, how="left"
+        )
+
+    return result_df
+
+
+def _aggregate_average(
+    cells_df: pd.DataFrame,
+    second_objs_df: pd.DataFrame,
+    cells_merge_keys: List[str],
+    second_objs_merge_keys: List[str],
+) -> pd.DataFrame:
+    """Average strategy: mean of numeric features across all secondary objects per cell.
+
+    Non-numeric columns use the first value. Cells with no secondary objects get NaN.
+    """
+    second_objs = _prepare_second_objs(
+        second_objs_df, second_objs_merge_keys, cells_merge_keys
+    )
+    feature_cols = _get_feature_cols(second_objs_df, second_objs_merge_keys)
+
+    if not feature_cols:
+        return cells_df.copy()
+
+    # Identify numeric vs non-numeric feature columns
+    numeric_cols = (
+        second_objs[feature_cols].select_dtypes(include=[np.number]).columns.tolist()
+    )
+    non_numeric_cols = [col for col in feature_cols if col not in numeric_cols]
+
+    agg_dict = {}
+    for col in numeric_cols:
+        agg_dict[col] = "mean"
+    for col in non_numeric_cols:
+        agg_dict[col] = "first"
+
+    averaged = second_objs.groupby(cells_merge_keys).agg(agg_dict).reset_index()
+
+    return cells_df.merge(averaged, on=cells_merge_keys, how="left")

--- a/workflow/lib/cluster/cluster_eval.py
+++ b/workflow/lib/cluster/cluster_eval.py
@@ -8,12 +8,11 @@ cluster size visualization, bootstrap filtering, and optimal resolution finding.
 import json
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
 import seaborn as sns
 
-from lib.shared.file_utils import parse_filename, get_filename
+from lib.shared.file_utils import get_filename
 from lib.shared.parquet_io import read_parquet
 
 
@@ -26,6 +25,7 @@ def find_optimal_resolution(
     resolutions=None,
     ideal_size_range=(15, 25),
     size_metric="mean",
+    compartment_combo=None,
 ):
     """Find the optimal Leiden resolution by reading benchmark outputs.
 
@@ -53,6 +53,8 @@ def find_optimal_resolution(
         size_metric (str): Which cluster size metric to optimize. Options:
             - "mean": Mean genes per cluster (default, better for skewed distributions)
             - "median": Median genes per cluster (less sensitive to outliers)
+        compartment_combo (str, optional): Compartment combination name. When omitted,
+            resolves the legacy path without a compartment directory.
 
     Returns:
         dict: Dictionary with:
@@ -64,11 +66,16 @@ def find_optimal_resolution(
     """
     root_fp = Path(root_fp)
 
+    base_path = add_compartment_path(
+        root_fp / "cluster" / channel_combo,
+        compartment_combo or "",
+        compartment_combo is not None,
+    )
+    base_path = base_path / cell_class
+
     # Build base cluster path
     if use_filtered:
-        base_path = root_fp / "cluster" / channel_combo / cell_class / "filtered"
-    else:
-        base_path = root_fp / "cluster" / channel_combo / cell_class
+        base_path = base_path / "filtered"
 
     # Auto-discover resolutions if not provided
     if resolutions is None:
@@ -438,8 +445,9 @@ def analyze_all_resolutions(
     show_plots=True,
     top_n_table=10,
     verbose=True,
+    compartment_combos=None,
 ):
-    """Analyze optimal resolutions for all cell class/channel combinations.
+    """Analyze optimal resolutions for all cell class/channel/compartment combinations.
 
     Convenience wrapper that finds optimal resolutions, displays results,
     and returns a summary for all combinations.
@@ -456,68 +464,81 @@ def analyze_all_resolutions(
         show_plots (bool): Whether to display comparison plots (default True).
         top_n_table (int): Number of top resolutions to show in table (default 10).
         verbose (bool): Whether to print detailed output (default True).
+        compartment_combos (list, optional): Compartment combinations to analyze.
+            When omitted, resolves legacy paths without a compartment directory.
 
     Returns:
-        dict: Dictionary mapping "cellclass_channel" to result dict from find_optimal_resolution.
-            Also includes "summary_df" key with pandas DataFrame of all optimal resolutions.
+        dict: Dictionary mapping a cell-class/channel key (plus compartment when
+            supplied) to results from ``find_optimal_resolution``. Also includes
+            ``summary_df`` with all optimal resolutions.
     """
     import matplotlib.pyplot as plt
     from IPython.display import display
 
     optimal_resolutions = {}
+    resolved_compartment_combos = (
+        compartment_combos if compartment_combos is not None else [None]
+    )
 
     for cell_class in cell_classes:
         for channel_combo in channel_combos:
-            try:
-                result = find_optimal_resolution(
-                    root_fp=root_fp,
-                    channel_combo=channel_combo,
-                    cell_class=cell_class,
-                    use_filtered=use_filtered,
-                    metric=metric,
-                    ideal_size_range=ideal_size_range,
-                    size_metric=size_metric,
-                )
-                key = f"{cell_class}_{channel_combo}"
-                optimal_resolutions[key] = result
+            for compartment_combo in resolved_compartment_combos:
+                try:
+                    result = find_optimal_resolution(
+                        root_fp=root_fp,
+                        channel_combo=channel_combo,
+                        compartment_combo=compartment_combo,
+                        cell_class=cell_class,
+                        use_filtered=use_filtered,
+                        metric=metric,
+                        ideal_size_range=ideal_size_range,
+                        size_metric=size_metric,
+                    )
+                    key = f"{cell_class}_{channel_combo}"
+                    combo_label = f"{cell_class} / {channel_combo}"
+                    if compartment_combo is not None:
+                        key = f"{key}_{compartment_combo}"
+                        combo_label = f"{combo_label} / {compartment_combo}"
+                    optimal_resolutions[key] = result
 
-                if verbose:
-                    print(f"\n{'=' * 80}")
-                    print(f"{cell_class} / {channel_combo}")
-                    print(f"{'=' * 80}")
-                    print(f"  Optimal resolution: {result['optimal_resolution']}")
-                    print(f"  Optimization metric: {result['metric_used']}")
-                    print(f"  Size metric used: {result['size_metric_used']}")
-                    print(f"  Target size range: {result['ideal_size_range']}")
+                    if verbose:
+                        print(f"\n{'=' * 80}")
+                        print(combo_label)
+                        print(f"{'=' * 80}")
+                        print(f"  Optimal resolution: {result['optimal_resolution']}")
+                        print(f"  Optimization metric: {result['metric_used']}")
+                        print(f"  Size metric used: {result['size_metric_used']}")
+                        print(f"  Target size range: {result['ideal_size_range']}")
 
-                    # Show formatted decision table
-                    print(
-                        f"\nTop {top_n_table} resolutions (sorted by {metric} score):"
-                    )
-                    table = format_resolution_table(
-                        result["all_results"], top_n=top_n_table
-                    )
-                    display(table)
+                        # Show formatted decision table
+                        print(
+                            f"\nTop {top_n_table} resolutions (sorted by {metric} score):"
+                        )
+                        table = format_resolution_table(
+                            result["all_results"], top_n=top_n_table
+                        )
+                        display(table)
 
-                if show_plots:
-                    # Show metrics comparison plot
-                    fig = plot_resolution_comparison(
-                        result["all_results"], metric=metric
-                    )
-                    plt.suptitle(
-                        f"{cell_class} / {channel_combo}",
-                        fontsize=14,
-                        fontweight="bold",
-                    )
-                    plt.tight_layout()
-                    plt.show()
+                    if show_plots:
+                        # Show metrics comparison plot
+                        fig = plot_resolution_comparison(
+                            result["all_results"], metric=metric
+                        )
+                        plt.suptitle(
+                            combo_label,
+                            fontsize=14,
+                            fontweight="bold",
+                        )
+                        plt.tight_layout()
+                        plt.show()
 
-            except Exception as e:
-                if verbose:
-                    print(
-                        f"\n{cell_class} / {channel_combo}: No benchmark results found"
-                    )
-                    print(f"  Error: {e}")
+                except Exception as e:
+                    if verbose:
+                        combo_label = f"{cell_class} / {channel_combo}"
+                        if compartment_combo is not None:
+                            combo_label = f"{combo_label} / {compartment_combo}"
+                        print(f"\n{combo_label}: No benchmark results found")
+                        print(f"  Error: {e}")
 
     # Generate summary table
     if verbose:

--- a/workflow/lib/phenotype/align_channels.py
+++ b/workflow/lib/phenotype/align_channels.py
@@ -1,13 +1,15 @@
 """Module for aligning channels in phenotype.
 
-Uses NumPy and scikit-image to provide image
-alignment between sequencing cycles, apply percentile-based filtering, fill masked
-areas with noise, and perform various transformations to enhance image data quality.
+Uses NumPy and scikit-image to provide image alignment between sequencing cycles.
 """
 
 import numpy as np
 from lib.shared.image_utils import remove_channels
-from lib.shared.align import apply_window, calculate_offsets, apply_offsets
+from lib.shared.align import (
+    apply_window,
+    calculate_offsets,
+    apply_offsets,
+)
 
 
 def align_phenotype_channels(
@@ -19,6 +21,7 @@ def align_phenotype_channels(
     window=2,
     remove_channel=False,
     verbose=False,
+    return_metrics=False,
 ):
     """Rigid alignment of phenotype channels based on target and source channels.
 
@@ -38,9 +41,14 @@ def align_phenotype_channels(
         verbose (bool, optional): If True, print detailed alignment information including
             calculated offsets for source and rider channels. Useful for debugging alignment issues.
             Defaults to False.
+        return_metrics (bool, optional): If True, return alignment quality metrics in addition
+            to aligned data. Defaults to False.
 
     Returns:
         np.ndarray: Phenotype data aligned across specified channels.
+            If return_metrics=True, returns tuple of (aligned_data, metrics_dict) where
+            metrics_dict contains:
+            - 'offset': list, the [y, x] offset that was applied
     """
     # Handle stacked vs unstacked data
     if image_data.ndim == 4:
@@ -50,24 +58,28 @@ def align_phenotype_channels(
         data_ = image_data.copy()
         stack = False
 
-    # Calculate alignment offsets
+    # Calculate alignment offsets using phase cross-correlation
     windowed = apply_window(data_[[target, source]], window)
-    offsets = calculate_offsets(windowed, upsample_factor=upsample_factor)
+    offsets, _ = calculate_offsets(windowed, upsample_factor=upsample_factor)
+
+    final_offset = offsets[1]
 
     # Handle riders and create full offsets array
     if not isinstance(riders, list):
         riders = [riders]
     full_offsets = np.zeros((data_.shape[0], 2))
-    full_offsets[[source] + riders] = offsets[1]
+    full_offsets[[source] + riders] = final_offset
 
     if verbose:
         print("\n=== Phenotype Channel Alignment Offsets ===")
         print(f"  Target channel (index {target}): no shift (reference)")
-        print(f"  Source channel (index {source}): shift = {offsets[1]} pixels (y, x)")
+        print(
+            f"  Source channel (index {source}): shift = {final_offset} pixels (y, x)"
+        )
         if riders:
             for rider_idx in riders:
                 print(
-                    f"  Rider channel (index {rider_idx}): shift = {offsets[1]} pixels (y, x)"
+                    f"  Rider channel (index {rider_idx}): shift = {final_offset} pixels (y, x)"
                 )
 
     # Apply alignment
@@ -106,6 +118,15 @@ def align_phenotype_channels(
         aligned = remove_channels(aligned, target)
     elif remove_channel == "source":
         aligned = remove_channels(aligned, source)
+
+    # Return with metrics if requested
+    if return_metrics:
+        metrics_dict = {
+            "offset": final_offset.tolist()
+            if hasattr(final_offset, "tolist")
+            else list(final_offset),
+        }
+        return aligned, metrics_dict
 
     return aligned
 

--- a/workflow/lib/phenotype/align_channels.py
+++ b/workflow/lib/phenotype/align_channels.py
@@ -96,7 +96,7 @@ def align_phenotype_channels(
         check_data = aligned.max(axis=0)
     else:
         check_data = aligned
-    residual = calculate_offsets(
+    residual, _ = calculate_offsets(
         apply_window(check_data[to_check], window),
         upsample_factor=upsample_factor,
     )

--- a/workflow/lib/phenotype/extract_phenotype_second_objs.py
+++ b/workflow/lib/phenotype/extract_phenotype_second_objs.py
@@ -1,0 +1,383 @@
+"""Helper function to extract phenotype features from CellProfiler-like data for secondary objects."""
+
+from itertools import combinations, permutations, product
+
+import numpy as np
+import pandas as pd
+import skimage.measure
+import skimage.morphology
+import skimage.filters
+import skimage.feature
+import skimage.segmentation
+from scipy import ndimage as ndi
+
+from lib.external.cp_emulator import (
+    grayscale_features_multichannel,
+    correlation_features_multichannel,
+    shape_features,
+    grayscale_columns_multichannel,
+    correlation_columns_multichannel,
+    shape_columns,
+    neighbor_measurements,
+)
+from lib.shared.feature_extraction import extract_features, extract_features_bare
+from lib.shared.log_filter import log_ndi
+from lib.phenotype.constants import DEFAULT_METADATA_COLS
+
+
+def extract_phenotype_second_objs(
+    data_phenotype,
+    second_objs,
+    wildcards,
+    second_obj_cell_mapping_df=None,
+    second_obj_channels="all",
+    foci_channel=None,
+    channel_names=["dapi", "tubulin", "gh2ax", "phalloidin"],
+):
+    """Extract phenotype features for secondary objects with multi-channel functionality.
+
+    Updated version with proper column ordering matching cp_multichannel.
+
+    Args:
+        data_phenotype (numpy.ndarray): Phenotype data array of shape (..., CHANNELS, I, J).
+        second_objs (numpy.ndarray): Secondary object segmentation mask with unique integers for each object.
+        second_obj_cell_mapping_df (pandas.DataFrame): DataFrame containing the mapping between secondary objects and cells.
+        wildcards (dict): Dictionary containing wildcards.
+        second_obj_channels (str or list): List of channel indices to consider for secondary object analysis or 'all'.
+        foci_channel (int, optional): Index of the channel containing foci information.
+        channel_names (list): List of channel names.
+
+    Returns:
+        pandas.DataFrame: DataFrame containing extracted phenotype features for each secondary object.
+    """
+    # If secondary objects are empty, return an empty DataFrame
+    if np.sum(second_objs) == 0:
+        print("No secondary objects found for feature extraction.")
+        return pd.DataFrame(columns=["second_obj_id", "cell_id"])
+
+    # Check if all channels should be used
+    if second_obj_channels == "all":
+        try:
+            second_obj_channels = list(range(data_phenotype.shape[-3]))
+        except IndexError:
+            second_obj_channels = [0]
+
+    dfs = []
+
+    # Define features
+    features = grayscale_features_multichannel.copy()
+    features.update(correlation_features_multichannel)
+    features.update(shape_features)
+
+    # Define function to create column map
+    def make_column_map(channels):
+        columns = {}
+        # Create columns for grayscale features
+        for feat, out in grayscale_columns_multichannel.items():
+            columns.update(
+                {
+                    f"{feat}_{n}": f"{channel_names[ch]}_{renamed}"
+                    for n, (renamed, ch) in enumerate(product(out, channels))
+                }
+            )
+        # Create columns for correlation features
+        for feat, out in correlation_columns_multichannel.items():
+            if feat == "lstsq_slope":
+                iterator = permutations
+            else:
+                iterator = combinations
+            columns.update(
+                {
+                    f"{feat}_{n}": renamed.format(
+                        first=channel_names[first], second=channel_names[second]
+                    )
+                    for n, (renamed, (first, second)) in enumerate(
+                        product(out, iterator(channels, 2))
+                    )
+                }
+            )
+        # Add shape columns
+        columns.update(shape_columns)
+        return columns
+
+    # Create column map for secondary objects
+    second_obj_columns = make_column_map(second_obj_channels)
+
+    # Extract secondary object features for all channels
+    dfs.append(
+        extract_features(
+            data_phenotype[..., second_obj_channels, :, :],
+            second_objs,
+            dict(),  # Pass empty dict instead of wildcards here
+            features,
+            multichannel=True,
+        )
+        .rename(columns=second_obj_columns)
+        .set_index("label")
+        .add_prefix("second_obj_")
+    )
+
+    # Extract foci features within secondary objects if foci channel is provided
+    if foci_channel is not None:
+        foci = find_foci_in_second_objs(
+            data_phenotype[..., foci_channel, :, :],
+            second_objs,
+            remove_border_foci=True,
+        )
+
+        if foci is not None:
+            dfs.append(
+                extract_features_bare(foci, second_objs, features=foci_features)
+                .set_index("label")
+                .add_prefix(f"second_obj_{channel_names[foci_channel]}_")
+            )
+
+    # Extract secondary object neighbor measurements
+    dfs.append(
+        neighbor_measurements(second_objs, distances=[1])
+        .set_index("label")
+        .add_prefix("second_obj_")
+    )
+
+    # Concatenate secondary object features
+    second_obj_features = pd.concat(dfs, axis=1, join="outer", sort=False).reset_index()
+
+    # Combine with second_obj_cell_mapping_df
+    if second_obj_cell_mapping_df is not None:
+        second_obj_df = pd.merge(
+            second_obj_cell_mapping_df,
+            second_obj_features.rename(columns={"label": "second_obj_id"}),
+            on="second_obj_id",
+            how="left",
+            suffixes=("_map", "_feat"),  # left, right
+        )
+
+        # If both exist, coalesce into a single second_obj_area column (prefer features).
+        if {"second_obj_area_map", "second_obj_area_feat"} <= set(
+            second_obj_df.columns
+        ):
+            second_obj_df["second_obj_area"] = second_obj_df[
+                "second_obj_area_feat"
+            ].combine_first(second_obj_df["second_obj_area_map"])
+            second_obj_df = second_obj_df.drop(
+                columns=["second_obj_area_map", "second_obj_area_feat"]
+            )
+    else:
+        second_obj_df = second_obj_features.rename(columns={"label": "second_obj_id"})
+
+    # Add wildcards metadata at the END (they'll be reordered later)
+    for k, v in sorted(wildcards.items()):
+        second_obj_df[k] = v
+
+    # Apply column ordering
+    second_obj_df = order_dataframe_columns_second_objs(second_obj_df)
+
+    return second_obj_df
+
+
+def order_dataframe_columns_second_objs(
+    df, metadata_cols=None, label_cols=["second_obj_id", "cell_id"]
+):
+    """Reorder DataFrame columns to put metadata first, then features for secondary objects.
+
+    Args:
+        df (pandas.DataFrame): DataFrame to reorder
+        metadata_cols (list): List of metadata column names to put first
+        label_cols (list): Names of the label columns (second_obj_id, cell_id)
+
+    Returns:
+        pandas.DataFrame: DataFrame with reordered columns
+    """
+    if metadata_cols is None:
+        metadata_cols = DEFAULT_METADATA_COLS
+
+    # Start with label columns
+    ordered_cols = []
+    for col in label_cols:
+        if col in df.columns:
+            ordered_cols.append(col)
+
+    # Add metadata columns that exist in the DataFrame
+    for col in metadata_cols:
+        if col in df.columns and col not in ordered_cols:
+            ordered_cols.append(col)
+
+    # Categorize remaining feature columns
+    remaining_cols = [col for col in df.columns if col not in ordered_cols]
+
+    # Group features by type
+    second_obj_features = [
+        col for col in remaining_cols if col.startswith("second_obj_")
+    ]
+
+    # Add any other columns that don't fit the above patterns
+    other_features = [
+        col for col in remaining_cols if not col.startswith("second_obj_")
+    ]
+
+    # Combine in desired order
+    ordered_cols.extend(other_features)  # Any additional metadata/wildcards
+    ordered_cols.extend(second_obj_features)
+
+    return df[ordered_cols]
+
+
+def find_foci_in_second_objs(
+    data, second_objs, radius=3, threshold=10, remove_border_foci=False
+):
+    """Detect foci within secondary objects using a white tophat filter and other processing steps.
+
+    Args:
+        data (numpy.ndarray): Input image data.
+        second_objs (numpy.ndarray): Secondary object segmentation mask.
+        radius (int, optional): Radius of the disk used in the white tophat filter. Default is 3.
+        threshold (float, optional): Threshold value for identifying foci in the processed image. Default is 10.
+        remove_border_foci (bool, optional): Flag to remove foci touching the secondary object border. Default is False.
+
+    Returns:
+        labeled (numpy.ndarray): Labeled segmentation mask of foci within secondary objects.
+    """
+    # If no secondary objects, return None
+    if np.sum(second_objs) == 0:
+        return None
+
+    # Create a binary mask for all secondary objects
+    second_obj_mask = second_objs > 0
+
+    # Mask the input data to only consider pixels within secondary objects
+    masked_data = np.zeros_like(data)
+    masked_data[second_obj_mask] = data[second_obj_mask]
+
+    # Apply white tophat filter to highlight foci
+    tophat = skimage.morphology.white_tophat(
+        masked_data, footprint=skimage.morphology.disk(radius)
+    )
+
+    # Apply Laplacian of Gaussian to the filtered image
+    tophat_log = log_ndi(tophat, sigma=radius)
+
+    # Threshold the image to create a binary mask
+    mask = tophat_log > threshold
+
+    # Remove small objects from the mask
+    mask = skimage.morphology.remove_small_objects(mask, min_size=(radius**2))
+
+    # Ensure we only keep foci within secondary objects
+    mask = mask & second_obj_mask
+
+    # Label connected components in the mask
+    labeled = skimage.measure.label(mask)
+
+    # Apply watershed algorithm to refine segmentation
+    labeled = apply_watershed(labeled, smooth=1)
+
+    if remove_border_foci:
+        # Create a border mask for secondary objects
+        second_obj_border = skimage.segmentation.find_boundaries(second_obj_mask)
+        # Remove foci touching the secondary object border
+        labeled = remove_border(labeled, second_obj_border)
+
+    return labeled
+
+
+def apply_watershed(img, smooth=4):
+    """Apply the watershed algorithm to the given image to refine segmentation.
+
+    Args:
+        img (numpy.ndarray): Input binary image.
+        smooth (float, optional): Size of Gaussian kernel used to smooth the distance map. Default is 4.
+
+    Returns:
+        result (numpy.ndarray): Labeled image after watershed segmentation.
+    """
+    # If empty image, return as is
+    if np.sum(img) == 0:
+        return img
+
+    # Compute the distance transform of the image
+    distance = ndi.distance_transform_edt(img)
+
+    if smooth > 0:
+        # Apply Gaussian smoothing to the distance transform
+        distance = skimage.filters.gaussian(distance, sigma=smooth)
+
+    # Identify local maxima in the distance transform
+    local_max_coords = skimage.feature.peak_local_max(
+        distance, footprint=np.ones((3, 3)), exclude_border=False
+    )
+
+    # Create a boolean mask for peaks
+    local_max = np.zeros_like(distance, dtype=bool)
+    if len(local_max_coords) > 0:  # Check if any peaks were found
+        local_max[tuple(local_max_coords.T)] = (
+            True  # Convert coordinates to a boolean mask
+        )
+
+        # Label the local maxima
+        markers = ndi.label(local_max)[0]
+
+        # Apply watershed algorithm to the distance transform
+        result = skimage.segmentation.watershed(-distance, markers, mask=img)
+    else:
+        # If no peaks found, return the original image
+        result = img
+
+    return result.astype(np.uint16)
+
+
+def remove_border(labels, mask, dilate=2):
+    """Remove labeled regions that touch the border of the given mask.
+
+    Args:
+        labels (numpy.ndarray): Labeled image.
+        mask (numpy.ndarray): Mask indicating the border regions.
+        dilate (int, optional): Number of dilation iterations to apply to the mask. Default is 2.
+
+    Returns:
+        labels (numpy.ndarray): Labeled image with border regions removed.
+    """
+    # Dilate the mask to ensure regions touching the border are included
+    if dilate > 0:
+        mask = skimage.morphology.binary_dilation(mask, np.ones((dilate, dilate)))
+
+    # Identify labels that need to be removed
+    remove = np.unique(labels[mask])
+
+    # Remove the identified labels from the labeled image
+    labels = labels.copy()
+    labels.flat[np.in1d(labels, remove)] = 0
+
+    return labels
+
+
+# Define foci features specific to secondary objects
+foci_features = {
+    "foci_count": lambda r: count_labels(r.intensity_image),
+    "foci_area": lambda r: (r.intensity_image > 0).sum(),
+    "foci_area_ratio": lambda r: (r.intensity_image > 0).sum() / r.area
+    if r.area > 0
+    else 0,
+}
+
+
+def count_labels(labels, return_list=False):
+    """Count the unique non-zero labels in a labeled segmentation mask.
+
+    Args:
+        labels (numpy array): Labeled segmentation mask.
+        return_list (bool): Flag indicating whether to return the list of unique labels along with the count.
+
+    Returns:
+        int or tuple: Number of unique non-zero labels. If return_list is True, returns a tuple containing the count
+      and the list of unique labels.
+    """
+    # Get unique labels in the segmentation mask
+    uniques = np.unique(labels)
+    # Remove the background label (0)
+    ls = np.delete(uniques, np.where(uniques == 0))
+    # Count the unique non-zero labels
+    num_labels = len(ls)
+    # Return the count or both count and list of unique labels based on return_list flag
+    if return_list:
+        return num_labels, ls
+    return num_labels

--- a/workflow/lib/phenotype/segment_secondary_object.py
+++ b/workflow/lib/phenotype/segment_secondary_object.py
@@ -1,0 +1,1718 @@
+"""Segment secondary objects using thresholding or ML methods and visualize results.
+
+This module provides functions for segmenting and visualizing secondary objects in microscopy images.
+Both traditional threshold-based and machine learning (ML) segmentation methods are supported,
+with a shared post-processing pipeline that ensures consistent output formats.
+
+Architecture:
+    - segment_second_objs(): Basic segmentation (thresholding + declumping)
+    - segment_second_objs_ml(): ML-based segmentation template (Cellpose, StarDist, etc.)
+    - _postprocess_secondary_objects(): Shared post-processing for both methods
+        * Size filtering (Feret diameter or area)
+        * Cell association (spatial overlap)
+        * Cell summary statistics
+        * Cytoplasm mask updates
+
+Implementing Custom ML Segmentation:
+    Users implementing segment_second_objs_ml() only need to:
+    1. Extract the target channel from the image
+    2. Run their ML model to get a labeled mask (e.g., Cellpose, StarDist)
+    3. Return the labeled mask to the shared post-processing pipeline
+
+Key Functions:
+    - segment_second_objs(): Basic segmentation
+    - segment_second_objs_ml(): ML-based segmentation template (user implements)
+    - _postprocess_secondary_objects(): Shared post-processing pipeline
+    - create_second_obj_boundary_visualization(): Visualize segmentation results
+    - create_second_obj_standard_visualization(): Standard visualization panel
+
+Helper Functions:
+    - apply_threshold_method(): Thresholding methods (Otsu, Li)
+    - apply_declumping(): CellProfiler-compatible declumping
+    - get_feret_diameters(): Compute Feret diameters
+    - create_empty_results(): Generate empty result structures
+    - get_spatial_overlap_candidates(): Spatial indexing for cell-object association
+
+"""
+
+import numpy as np
+import pandas as pd
+from scipy import ndimage
+from skimage import filters, morphology, measure, segmentation, feature, exposure
+from skimage.segmentation import mark_boundaries
+from microfilm.microplot import Microimage
+from lib.shared.configuration_utils import create_micropanel
+from lib.shared.segment_cellpose import (
+    prepare_cellpose,
+    create_cellpose_model,
+    CELLPOSE_4X,
+)
+import cv2
+
+# Check if Cellpose is available (for error messaging)
+try:
+    import cellpose
+
+    CELLPOSE_AVAILABLE = True
+except ImportError:
+    CELLPOSE_AVAILABLE = False
+
+
+def segment_second_objs_ml(
+    image,
+    second_obj_channel_index,
+    cell_masks=None,
+    cytoplasm_masks=None,
+    # Post-processing parameters (shared)
+    second_obj_min_size=10,
+    second_obj_max_size=200,
+    size_filter_method="feret",
+    max_objects_per_cell=120,
+    overlap_threshold=0.1,
+    nuclei_centroids=None,
+    max_total_objects=1000,
+    # Preprocessing parameters
+    logscale=True,
+    # ML-specific parameters - users add more as needed
+    **ml_params,
+):
+    """Segment secondary objects using ML models (Cellpose, StarDist, etc.).
+
+    This function implements ML-based segmentation for secondary objects with support
+    for both Cellpose and StarDist models. Users can choose the appropriate model
+    based on their object morphology:
+    - Cellpose: Better for irregular shapes (vacuoles, organelles with varying morphology)
+    - StarDist: Better for round/star-convex objects (nuclei-like structures)
+
+    The shared post-processing pipeline (_postprocess_secondary_objects) will handle:
+    - Size filtering (Feret diameter or area)
+    - Cell association (spatial overlap)
+    - Cell summary statistics
+    - Cytoplasm mask updates
+
+    Args:
+        image (ndarray): Multichannel image data with shape [channels, height, width].
+        second_obj_channel_index (int): Index of the channel used for secondary object
+            detection.
+        cell_masks (ndarray): Cell segmentation masks with unique integers for each cell.
+        cytoplasm_masks (ndarray, optional): Cytoplasm segmentation masks. If provided,
+            secondary object regions will be removed from cytoplasm masks.
+        second_obj_min_size (float): Minimum size for valid secondary objects.
+        second_obj_max_size (float): Maximum size for valid secondary objects.
+        size_filter_method (str): Size filtering method ("feret" or "area").
+        max_objects_per_cell (int): Maximum secondary objects allowed per cell.
+        overlap_threshold (float): Minimum overlap ratio to associate object with cell
+            (0.0-1.0).
+        nuclei_centroids (dict, DataFrame, or None): Cell nuclei centroids for distance
+            calculations.
+        max_total_objects (int or None): Failsafe limit on detected objects.
+        logscale (bool): Apply log scaling and normalization preprocessing to the target
+            channel before segmentation. Matches the preprocessing used in
+            segment_cellpose and improves segmentation performance. Default is True.
+        **ml_params: Additional ML model parameters. Required and optional parameters
+            depend on ml_method:
+
+            Common parameters:
+
+            - second_obj_method (str, required): ML model to use, "cellpose" or
+              "stardist".
+            - gpu (bool, default False): Whether to use GPU acceleration.
+
+            For second_obj_method="cellpose":
+
+            - second_obj_cellpose_model (str, default 'cyto3'): Cellpose model type
+              ('cyto3', 'cyto2', 'cyto', 'nuclei', etc.).
+            - second_obj_diameter (float or None, default None): Expected diameter of
+              objects in pixels. If None, estimated automatically.
+            - second_obj_flow_threshold (float, default 0.4): Flow error threshold for
+              Cellpose segmentation.
+            - second_obj_cellprob_threshold (float, default 0.0): Cell probability
+              threshold for Cellpose.
+
+            For second_obj_method="stardist":
+
+            - second_obj_stardist_model (str, default '2D_versatile_fluo'): StarDist
+              pretrained model name.
+            - second_obj_prob_threshold (float, default 0.5): Probability threshold for
+              object detection.
+            - second_obj_nms_threshold (float, default 0.4): Non-maximum suppression
+              threshold.
+
+    Returns:
+        tuple:
+            - second_obj_masks: Labeled mask of secondary objects [height, width]
+            - cell_second_obj_table: Dict with 'cell_summary' and
+              'second_obj_cell_mapping' DataFrames
+            - updated_cytoplasm_masks: Cytoplasm masks with secondary objects removed
+              (None if cytoplasm_masks was not provided)
+
+    Raises:
+        ValueError: If ml_method is not 'cellpose' or 'stardist', or if required
+            packages are not installed.
+
+    Note:
+        All post-processing is handled by _postprocess_secondary_objects(), so the
+        output format is guaranteed to match segment_second_objs(). Requires the
+        cellpose or stardist package to be installed.
+    """
+    # Extract and preprocess target channel
+    if logscale:
+        # Use prepare_cellpose for preprocessing (ensures consistency with training)
+        rgb = prepare_cellpose(
+            image,
+            dapi_index=second_obj_channel_index,  # Dummy - will use cyto channel
+            cyto_index=second_obj_channel_index,  # Target channel
+            helper_index=None,
+            logscale=True,
+        )
+        target_channel = rgb[1]  # Extract green (log scaled + normalized)
+    else:
+        target_channel = image[second_obj_channel_index].copy()
+
+    # Get ML method
+    ml_method = ml_params.get("second_obj_method", None)
+    if ml_method is None:
+        raise ValueError(
+            "second_obj_method must be specified in ml_params. "
+            "Valid options: 'cellpose' or 'stardist'"
+        )
+
+    gpu = ml_params.get("gpu", False)
+
+    # Route to appropriate ML model
+    if ml_method == "cellpose":
+        # Cellpose parameters
+        model_type = ml_params.get("second_obj_cellpose_model", "cyto3")
+        diameter = ml_params.get("second_obj_diameter", None)
+        flow_threshold = ml_params.get("second_obj_flow_threshold", 0.4)
+        cellprob_threshold = ml_params.get("second_obj_cellprob_threshold", 0.0)
+
+        print(
+            f"Running Cellpose {model_type} model for secondary object segmentation..."
+        )
+        if diameter is not None:
+            print(f"  Using diameter: {diameter:.1f} pixels")
+        else:
+            print(f"  Diameter will be estimated automatically")
+        print(f"  Flow threshold: {flow_threshold}")
+        print(f"  Cell probability threshold: {cellprob_threshold}")
+        print(f"  GPU: {gpu}")
+
+        # Check Cellpose availability
+        if not CELLPOSE_AVAILABLE:
+            raise ImportError(
+                "Cellpose is required for ML-based secondary object segmentation. "
+                "Install it with: pip install cellpose"
+            )
+
+        # Initialize Cellpose model (handles version detection and validation)
+        model = create_cellpose_model(model_type, gpu=gpu)
+
+        # eval() returns (masks, flows, styles); diameter must be explicit for Cellpose 4.x
+        labeled_mask, flows, styles = model.eval(
+            target_channel,
+            diameter=diameter,
+            flow_threshold=flow_threshold,
+            cellprob_threshold=cellprob_threshold,
+        )
+
+        print(f"Cellpose detected {len(np.unique(labeled_mask)) - 1} secondary objects")
+        if diameter is not None:
+            print(f"Using diameter: {diameter:.1f} pixels")
+
+    elif ml_method == "stardist":
+        # StarDist parameters
+        model_type = ml_params.get("second_obj_stardist_model", "2D_versatile_fluo")
+        prob_thresh = ml_params.get("second_obj_prob_threshold", 0.5)
+        nms_thresh = ml_params.get("second_obj_nms_threshold", 0.4)
+
+        print(
+            f"Running StarDist {model_type} model for secondary object segmentation..."
+        )
+        print(f"  Probability threshold: {prob_thresh}")
+        print(f"  NMS threshold: {nms_thresh}")
+        print(f"  GPU: {gpu}")
+
+        # Import StarDist
+        try:
+            from stardist.models import StarDist2D
+        except ImportError:
+            raise ImportError(
+                "StarDist is required for ML-based secondary object segmentation. "
+                "Install it with: pip install stardist"
+            )
+
+        # Initialize StarDist model
+        model = StarDist2D.from_pretrained(model_type)
+
+        # Run StarDist segmentation
+        labeled_mask, details = model.predict_instances(
+            target_channel, prob_thresh=prob_thresh, nms_thresh=nms_thresh
+        )
+
+        print(f"StarDist detected {len(np.unique(labeled_mask)) - 1} secondary objects")
+
+    else:
+        raise ValueError(
+            f"Unknown ml_method: {ml_method}. Valid options: 'cellpose' or 'stardist'"
+        )
+
+    # Shared post-processing pipeline
+    return _postprocess_secondary_objects(
+        second_obj_masks=labeled_mask,  # ML model output
+        cell_masks=cell_masks,
+        cytoplasm_masks=cytoplasm_masks,
+        second_obj_min_size=second_obj_min_size,
+        second_obj_max_size=second_obj_max_size,
+        size_filter_method=size_filter_method,
+        max_objects_per_cell=max_objects_per_cell,
+        overlap_threshold=overlap_threshold,
+        nuclei_centroids=nuclei_centroids,
+        max_total_objects=max_total_objects,
+        image=image,
+        second_obj_channel_index=second_obj_channel_index,
+    )
+
+
+def segment_second_objs(
+    image,
+    second_obj_channel_index,
+    cell_masks=None,
+    cytoplasm_masks=None,
+    # Size filtering
+    second_obj_min_size=10,
+    second_obj_max_size=200,
+    size_filter_method="feret",
+    # Pre-processing
+    threshold_smoothing_scale=1.3488,
+    threshold_method="otsu_two_peak",
+    use_morphological_opening=True,
+    opening_disk_radius=1,
+    fill_holes="both",
+    # Declumping method (CellProfiler standard)
+    declump_method="shape",
+    declump_mode="watershed",
+    # Seed detection (CellProfiler naming)
+    suppress_local_maxima=20,
+    maxima_reduction_factor=None,
+    # Shape-based refinement (independent from declump_method)
+    use_shape_refinement=False,
+    proportion_threshold=0.4,
+    # Cell association
+    max_objects_per_cell=120,
+    overlap_threshold=0.1,
+    nuclei_centroids=None,
+    # Failsafe
+    max_total_objects=1000,
+    # Debugging
+    return_threshold_output=False,
+):
+    """Segment secondary objects within cells using CellProfiler-compatible thresholding and declumping.
+
+    Args:
+        image (numpy.ndarray): Multichannel image data with shape [channels, height, width].
+        second_obj_channel_index (int): Index of the channel used for secondary object detection.
+        cell_masks (numpy.ndarray): Cell segmentation masks with unique integers for each cell.
+        cytoplasm_masks (numpy.ndarray, optional): Cytoplasm segmentation masks with unique integers.
+            If provided, secondary object regions will be removed from cytoplasm masks.
+
+        second_obj_min_size (float, optional): Minimum size for valid secondary objects (default: 10).
+            Interpreted as Feret diameter or area depending on size_filter_method.
+        second_obj_max_size (float, optional): Maximum size for valid secondary objects (default: 200).
+        size_filter_method (str, optional): Size filtering method (default: "feret").
+            - "feret": Use Feret diameters (min and max widths of rotated bounding box)
+            - "area": Use pixel area (CellProfiler standard)
+
+        threshold_smoothing_scale (float, optional): Sigma for Gaussian smoothing before thresholding. Default is 1.3488.
+        threshold_method (str, optional): Thresholding method to use (default: "otsu_two_peak").
+            Options:
+            - "otsu_two_peak": Standard 2-class Otsu thresholding
+            - "otsu_three_peak_mid_bg": 3-class Otsu, keeps only highest intensity class
+            - "otsu_three_peak_mid_fg": 3-class Otsu, keeps middle and high intensity classes
+            - "min_cross_entropy": Minimum cross entropy (Li) thresholding
+        use_morphological_opening (bool, optional): Apply opening to separate weakly connected objects (default: True).
+        opening_disk_radius (int, optional): Radius of disk structuring element for opening (default: 1).
+        fill_holes (str, optional): When to fill holes in segmented objects (default: "both").
+            Options:
+            - "threshold": Fill holes only after thresholding (before declumping)
+            - "declump": Fill holes only after declumping (per-label filling)
+            - "both": Fill holes after both thresholding and declumping
+            - "none": Do not fill holes at any stage
+
+        declump_method (str, optional): Method for separating clumped objects (default: "shape").
+            CellProfiler standard methods:
+            - "none": No declumping (connected components only)
+            - "shape": Distance transform peaks (radial distance)
+            - "intensity": Local intensity maxima
+            - "shape_intensity": Combined distance + intensity peaks
+
+        declump_mode (str, optional): Watershed segmentation mode (default: "watershed").
+            - "watershed": Standard watershed from markers
+            - "propagate": Distance propagation variant
+            - "none": Use markers only without watershed
+
+        suppress_local_maxima (int, optional): Minimum spacing between seed points in pixels (default: 20).
+            CellProfiler parameter. Controls spatial separation of detected peaks.
+
+        maxima_reduction_factor (float or None, optional): H-maxima threshold for suppressing weak peaks (default: None).
+            Range: 0.0-1.0. Higher values = more aggressive suppression.
+            If None, no h-maxima filtering applied.
+            Formula: h = maxima_reduction_factor * (peak_map_max - peak_map_min)
+            This is applied DURING seed detection (before watershed).
+
+        use_shape_refinement (bool, optional): Apply boundary/perimeter quality control after declumping (default: False).
+            Custom feature not in CellProfiler. When enabled, evaluates watershed splits
+            and rejects splits where the dividing boundary is long relative to perimeter.
+            This is applied AFTER watershed declumping as a refinement step.
+
+        proportion_threshold (float, optional): Boundary/perimeter ratio threshold for shape refinement (default: 0.4).
+            Only used when use_shape_refinement=True.
+            Splits accepted if boundary_length / perimeter < proportion_threshold.
+
+        max_objects_per_cell (int, optional): Maximum secondary objects allowed per cell (default: 120).
+        overlap_threshold (float, optional): Minimum overlap ratio to associate object with cell (default: 0.1).
+        nuclei_centroids (dict or DataFrame, optional): Cell nuclei centroids for distance calculations.
+            Format: {nuclei_id: (i, j)} or DataFrame with columns 'i', 'j'.
+
+        max_total_objects (int or None, optional): Failsafe limit on detected objects (default: 1000).
+            Returns empty results if exceeded to avoid processing over-segmented images.
+
+        return_threshold_output (bool, optional): If True, returns intermediate thresholding results
+            for debugging and visualization (default: False). When enabled, the threshold_output
+            dictionary contains:
+            - 'binary_mask': Binary mask after thresholding, hole filling, and opening (before declumping)
+            - 'threshold_value': Computed threshold value from apply_threshold_method()
+            - 'preprocessed_channel': Log-transformed and Gaussian-smoothed channel used for thresholding
+
+    Returns:
+        tuple: Returns depend on return_threshold_output flag:
+
+        If return_threshold_output=False (default):
+            - second_obj_masks (numpy.ndarray): Labeled mask of secondary objects
+            - cell_second_obj_table (dict): Dictionary with DataFrames containing associations
+            - updated_cytoplasm_masks (numpy.ndarray | None): Updated cytoplasm masks,
+              None if cytoplasm_masks was not provided
+
+        If return_threshold_output=True:
+            - second_obj_masks (numpy.ndarray): Labeled mask of secondary objects
+            - cell_second_obj_table (dict): Dictionary with DataFrames containing associations
+            - updated_cytoplasm_masks (numpy.ndarray | None): Updated cytoplasm masks,
+              None if cytoplasm_masks was not provided
+            - threshold_output (dict): Intermediate thresholding results with keys:
+                - 'binary_mask': Binary mask before declumping
+                - 'threshold_value': Threshold value used
+                - 'preprocessed_channel': Preprocessed channel image
+    """
+    # Extract the secondary object channel
+    second_obj_img = image[second_obj_channel_index]
+    second_obj_img = np.clip(second_obj_img, a_min=0, a_max=None)
+
+    # Apply log transform and smoothing
+    second_obj_log = exposure.adjust_log(second_obj_img + 1)
+    second_obj_smooth = filters.gaussian(
+        second_obj_log, sigma=threshold_smoothing_scale
+    )
+
+    # Apply selected threshold method
+    thresh, binary_mask = apply_threshold_method(
+        second_obj_smooth, method=threshold_method
+    )
+
+    # Fill holes after thresholding (if enabled)
+    if fill_holes in ["threshold", "both"]:
+        binary_mask = ndimage.binary_fill_holes(binary_mask)
+
+    # Early exit if no objects found
+    if not np.any(binary_mask):
+        print("No objects detected after thresholding")
+        empty_results = create_empty_results(
+            cell_masks, cytoplasm_masks, nuclei_centroids
+        )
+
+        # Handle return_threshold_output for empty case
+        if return_threshold_output:
+            threshold_output = {
+                "binary_mask": binary_mask,
+                "threshold_value": thresh,
+                "preprocessed_channel": second_obj_smooth,
+            }
+            # Add threshold_output to the tuple
+            return (*empty_results, threshold_output)
+        else:
+            return empty_results
+
+    # Failsafe: Check for excessive objects early
+    if max_total_objects is not None:
+        temp_labeled, num_components = ndimage.label(binary_mask)
+        if num_components > max_total_objects:
+            print(
+                f"Failsafe triggered: Detected {num_components} objects (limit: {max_total_objects})"
+            )
+            print("Returning empty results to avoid processing over-segmented image")
+            empty_results = create_empty_results(
+                cell_masks, cytoplasm_masks, nuclei_centroids
+            )
+
+            # Handle return_threshold_output for failsafe case
+            if return_threshold_output:
+                threshold_output = {
+                    "binary_mask": binary_mask,
+                    "threshold_value": thresh,
+                    "preprocessed_channel": second_obj_smooth,
+                }
+                return (*empty_results, threshold_output)
+            else:
+                return empty_results
+
+    # Morphological opening
+    if use_morphological_opening:
+        binary_mask = apply_morphological_opening(
+            binary_mask, opening_disk_radius=opening_disk_radius
+        )
+
+    # Capture intermediate state for visualization
+    if return_threshold_output:
+        threshold_binary_mask = binary_mask.copy()
+        threshold_value_stored = thresh
+        threshold_preprocessed_channel = second_obj_smooth.copy()
+
+    # Declumping
+    declumped = apply_declumping(
+        binary_mask,
+        second_obj_smooth,
+        declump_method=declump_method,
+        declump_mode=declump_mode,
+        suppress_local_maxima=suppress_local_maxima,
+        maxima_reduction_factor=maxima_reduction_factor,
+    )
+
+    print(
+        f"After declumping ({declump_method}): {len(np.unique(declumped)) - 1} objects"
+    )
+
+    # Optionally apply shape-based refinement (independent from declump_method)
+    if use_shape_refinement:
+        print("Applying shape-based boundary/perimeter refinement...")
+        declumped = shape_based_declumping(
+            declumped > 0,
+            second_obj_img=second_obj_img,
+            min_distance=suppress_local_maxima,
+            proportion_threshold=proportion_threshold,
+        )
+        print(f"After shape refinement: {len(np.unique(declumped)) - 1} objects")
+
+    # Fill holes after declumping, claiming only background pixels so a fill can't overwrite a neighboring object
+    if fill_holes in ["declump", "both"]:
+        unique_labels = np.unique(declumped[declumped > 0])
+        for label in unique_labels:
+            mask = declumped == label
+            filled = ndimage.binary_fill_holes(mask)
+            declumped[filled & (declumped == 0)] = label
+
+    # Apply shared post-processing pipeline: size filtering, cell association, statistics, cytoplasm updates
+    post_results = _postprocess_secondary_objects(
+        second_obj_masks=declumped,
+        cell_masks=cell_masks,
+        cytoplasm_masks=cytoplasm_masks,
+        second_obj_min_size=second_obj_min_size,
+        second_obj_max_size=second_obj_max_size,
+        size_filter_method=size_filter_method,
+        max_objects_per_cell=max_objects_per_cell,
+        overlap_threshold=overlap_threshold,
+        nuclei_centroids=nuclei_centroids,
+        max_total_objects=max_total_objects,
+        image=image,
+        second_obj_channel_index=second_obj_channel_index,
+    )
+
+    # Handle return_threshold_output flag for debugging
+    if return_threshold_output:
+        # Create threshold output dictionary
+        threshold_output = {
+            "binary_mask": threshold_binary_mask,
+            "threshold_value": threshold_value_stored,
+            "preprocessed_channel": threshold_preprocessed_channel,
+        }
+        # Append threshold_output to results tuple
+        return (*post_results, threshold_output)
+    else:
+        # Standard return (backward compatible)
+        return post_results
+
+
+def segment_second_objs_from_config(
+    image,
+    cell_masks,
+    cytoplasm_masks,
+    second_obj_params,
+    nuclei_centroids=None,
+):
+    """Dispatch secondary-object segmentation (ML or classical) from a config param dict.
+
+    Routes the phenotype config's second-object parameters to segment_second_objs_ml or
+    segment_second_objs, passing only ML-specific params to the ML path.
+
+    Args:
+        image (numpy.ndarray): Phenotype image (CHANNELS, I, J).
+        cell_masks (numpy.ndarray): Cell segmentation masks.
+        cytoplasm_masks (numpy.ndarray): Cytoplasm segmentation masks.
+        second_obj_params (dict): Second-object parameters from config["phenotype"].
+        nuclei_centroids (dict, optional): Cell nuclei centroids for distance calculations.
+
+    Returns:
+        tuple: (second_obj_masks, cell_second_obj_table, updated_cytoplasm_masks).
+    """
+    common_params = {
+        "image": image,
+        "second_obj_channel_index": second_obj_params["second_obj_channel_index"],
+        "cell_masks": cell_masks,
+        "cytoplasm_masks": cytoplasm_masks,
+        "second_obj_min_size": second_obj_params.get("second_obj_min_size", 10),
+        "second_obj_max_size": second_obj_params.get("second_obj_max_size", 200),
+        "size_filter_method": second_obj_params.get("size_filter_method", "feret"),
+        "max_objects_per_cell": second_obj_params.get("max_objects_per_cell", 120),
+        "overlap_threshold": second_obj_params.get("overlap_threshold", 0.1),
+        "nuclei_centroids": nuclei_centroids,
+        "max_total_objects": second_obj_params.get("max_total_objects", 1000),
+    }
+
+    if second_obj_params.get("use_ml_segmentation", False):
+        # ML path takes only ML-specific params (drop shared, classical-only, and config-level keys).
+        shared_keys = set(common_params)
+        cv_only_keys = {
+            "threshold_smoothing_scale",
+            "threshold_method",
+            "use_morphological_opening",
+            "opening_disk_radius",
+            "fill_holes",
+            "declump_method",
+            "declump_mode",
+            "suppress_local_maxima",
+            "maxima_reduction_factor",
+            "use_shape_refinement",
+            "proportion_threshold",
+        }
+        config_level_keys = {
+            "use_ml_segmentation",
+            "second_obj_detection",
+            "foci_channel_index",
+            "channel_names",
+            "dapi_index",
+            "cyto_index",
+            "align",
+            "segmentation_method",
+            "reconcile",
+            "cp_method",
+            "nuclei_diameter",
+            "cell_diameter",
+            "target",
+            "source",
+            "riders",
+            "remove_channel",
+            "upsample_factor",
+            "window",
+        }
+        ml_params = {
+            k: v
+            for k, v in second_obj_params.items()
+            if k not in shared_keys | cv_only_keys | config_level_keys
+        }
+        return segment_second_objs_ml(**common_params, **ml_params)
+
+    cv_params = {
+        "threshold_smoothing_scale": second_obj_params.get(
+            "threshold_smoothing_scale", 1.3488
+        ),
+        "threshold_method": second_obj_params.get("threshold_method", "otsu_two_peak"),
+        "use_morphological_opening": second_obj_params.get(
+            "use_morphological_opening", True
+        ),
+        "opening_disk_radius": second_obj_params.get("opening_disk_radius", 1),
+        "fill_holes": second_obj_params.get("fill_holes", "both"),
+        "declump_method": second_obj_params.get("declump_method", "shape"),
+        "declump_mode": second_obj_params.get("declump_mode", "watershed"),
+        "suppress_local_maxima": second_obj_params.get("suppress_local_maxima", 20),
+        "maxima_reduction_factor": second_obj_params.get(
+            "maxima_reduction_factor", None
+        ),
+        "use_shape_refinement": second_obj_params.get("use_shape_refinement", False),
+        "proportion_threshold": second_obj_params.get("proportion_threshold", 0.4),
+    }
+    return segment_second_objs(**common_params, **cv_params)
+
+
+def estimate_second_obj_diameter(
+    image, second_obj_channel_index, method="cellpose", **kwargs
+):
+    """Estimate the diameter of secondary objects in an image channel.
+
+    This is a convenience function to help users estimate appropriate diameter
+    parameters for ML-based secondary object segmentation.
+
+    Args:
+        image (ndarray): Multichannel image data with shape [channels, height, width].
+        second_obj_channel_index (int): Index of the channel containing secondary
+            objects.
+        method (str): Method to use for diameter estimation:
+
+            - "cellpose": Use Cellpose's built-in diameter estimation (default).
+            - "manual": Manually measure from image statistics.
+        **kwargs: Additional parameters for the estimation method. For
+            method="cellpose": model_type (str, default 'cyto3') and gpu (bool,
+            default False).
+
+    Returns:
+        float: Estimated diameter in pixels.
+
+    Examples:
+        >>> diameter = estimate_second_obj_diameter(
+        ...     aligned_image,
+        ...     second_obj_channel_index=7,
+        ...     method="cellpose",
+        ...     model_type="cyto3"
+        ... )
+        >>> print(f"Estimated diameter: {diameter:.1f} pixels")
+    """
+    target_channel = image[second_obj_channel_index]
+
+    if method == "cellpose":
+        # Check Cellpose availability
+        if not CELLPOSE_AVAILABLE:
+            raise ImportError(
+                "Cellpose is required for diameter estimation. "
+                "Install it with: pip install cellpose"
+            )
+
+        # Cellpose 4.x does not support automatic diameter estimation
+        if CELLPOSE_4X:
+            raise NotImplementedError(
+                "Automatic diameter estimation is not supported with Cellpose 4.x. "
+                "Please specify second_obj_diameter explicitly in your config, "
+                "or use method='manual' for threshold-based estimation, "
+                "or downgrade to Cellpose 3.x: pip install cellpose==3.1.0"
+            )
+
+        model_type = kwargs.get("model_type", "cyto3")
+        gpu = kwargs.get("gpu", False)
+
+        print(f"Estimating secondary object diameter using Cellpose {model_type}...")
+
+        # Cellpose 3.x: Use the old API which supports diameter estimation
+        from cellpose import models as cellpose_models
+
+        model = cellpose_models.Cellpose(gpu=gpu, model_type=model_type)
+
+        # Run segmentation with automatic diameter estimation
+        _, _, _, diameter = model.eval(
+            target_channel,
+            diameter=None,  # Auto-estimate
+            channels=[0, 0],
+        )
+
+        print(f"Estimated diameter: {diameter:.1f} pixels")
+        return float(diameter)
+
+    elif method == "manual":
+        # Estimate diameter by thresholding and measuring typical object sizes.
+        from skimage import filters, measure
+        from scipy import ndimage
+
+        # Apply Otsu threshold
+        thresh = filters.threshold_otsu(target_channel)
+        binary = target_channel > thresh
+
+        # Label objects
+        labeled, _ = ndimage.label(binary)
+        regions = measure.regionprops(labeled)
+
+        if len(regions) == 0:
+            print("No objects detected for diameter estimation")
+            return None
+
+        # Calculate median equivalent diameter
+        diameters = [r.equivalent_diameter for r in regions]
+        diameter = np.median(diameters)
+
+        print(
+            f"Estimated diameter (median of {len(regions)} objects): {diameter:.1f} pixels"
+        )
+        return float(diameter)
+
+    else:
+        raise ValueError(f"Unknown method: {method}. Use 'cellpose' or 'manual'")
+
+
+def apply_threshold_method(image, method="otsu_two_peak"):
+    """Apply specified thresholding method to an image.
+
+    Args:
+        image (ndarray): Input image, should be preprocessed with log transform and
+            smoothing.
+        method (str): Thresholding method to use. Options:
+
+            - 'otsu_two_peak': Standard Otsu thresholding (2-class).
+            - 'otsu_three_peak_mid_bg': 3-class Otsu, middle class as background.
+            - 'otsu_three_peak_mid_fg': 3-class Otsu, middle class as foreground.
+            - 'min_cross_entropy': Minimum cross entropy (Li) thresholding.
+
+    Returns:
+        tuple:
+            - threshold (float): Computed threshold value.
+            - binary_mask (ndarray): Binary mask after thresholding.
+    """
+    if method == "otsu_two_peak":
+        # Standard two-class Otsu
+        threshold = filters.threshold_otsu(image)
+        binary_mask = image > threshold
+
+    elif method == "otsu_three_peak_mid_bg":
+        # Three-class Otsu, treat middle intensity class as background
+        threshold = filters.threshold_multiotsu(image, classes=3)
+        # Keep only the highest intensity class (threshold[1] separates mid from high)
+        binary_mask = image > threshold[1]
+
+    elif method == "otsu_three_peak_mid_fg":
+        # Three-class Otsu, treat middle intensity class as foreground
+        threshold = filters.threshold_multiotsu(image, classes=3)
+        # Keep both middle and high intensity classes (threshold[0] separates low from mid)
+        binary_mask = image > threshold[0]
+
+    elif method == "min_cross_entropy":
+        # Minimum cross entropy (Li) method
+        threshold = filters.threshold_li(image)
+        binary_mask = image > threshold
+
+    else:
+        raise ValueError(
+            f"Unknown threshold method: {method}. "
+            f"Valid options: 'otsu_two_peak', 'otsu_three_peak_mid_bg', "
+            f"'otsu_three_peak_mid_fg', 'min_cross_entropy'"
+        )
+
+    return threshold, binary_mask
+
+
+def create_second_obj_boundary_visualization(
+    image,
+    second_obj_channel_index,
+    cell_masks,
+    second_obj_masks,
+    channel_names=None,
+    channel_cmaps=None,
+):
+    """Create enhanced visualization showing cells and secondary objects.
+
+    Args:
+        image (numpy.ndarray): Multichannel image data with shape [channels, height, width].
+        second_obj_channel_index (int): Index of the channel used for secondary object detection.
+        cell_masks (numpy.ndarray): Cell segmentation masks with unique integers for each cell.
+        second_obj_masks (numpy.ndarray): Secondary object segmentation masks with original secondary object IDs.
+        channel_names (list of str, optional): Names for each channel in the image.
+        channel_cmaps (list of str, optional): Color maps for each channel in the image.
+
+    Returns:
+        matplotlib.figure.Figure: The created micropanel figure showing the cell boundaries (green)
+            and secondary object boundaries (magenta) overlaid on the image.
+    """
+    if channel_names is None or len(channel_names) <= second_obj_channel_index:
+        channel_name = f"Channel {second_obj_channel_index}"
+    else:
+        channel_name = channel_names[second_obj_channel_index]
+
+    # Get secondary object channel
+    second_obj_img = image[second_obj_channel_index].copy()
+
+    # Create a copy of the original image for the merged view with boundaries
+    merged_img = image.copy()
+
+    # Function to add boundaries to an image
+    def add_boundaries(base_image, base_is_multichannel=True):
+        # Determine the shape based on whether base_image is multichannel or single channel
+        if base_is_multichannel:
+            # For multichannel image, keep as is
+            enhanced_img = base_image.copy()
+            height, width = base_image.shape[1], base_image.shape[2]
+            num_channels = base_image.shape[0]
+        else:
+            # For single channel image, expand to 3 channels
+            height, width = base_image.shape
+            num_channels = 3
+            # Create 3-channel image with the base image in all channels
+            enhanced_img = np.zeros((num_channels, height, width), dtype=np.float32)
+            base_norm = base_image / (base_image.max() if base_image.max() > 0 else 1.0)
+            for c in range(num_channels):
+                enhanced_img[c] = base_norm
+
+        # Add cell boundaries (green)
+        if base_is_multichannel:
+            # Build a temporary RGB image for mark_boundaries, then extract the green channel.
+            temp_img = np.zeros((height, width, 3), dtype=np.float32)
+            for c in range(min(3, num_channels)):
+                temp_img[:, :, c] = enhanced_img[c] / (
+                    enhanced_img[c].max() if enhanced_img[c].max() > 0 else 1.0
+                )
+
+            cell_boundary_img = mark_boundaries(
+                temp_img,
+                cell_masks,
+                color=(0, 1, 0),  # Green for cells
+                mode="thick",
+            )
+
+            # Update the green channel with cell boundaries - make them more prominent
+            cell_boundary_intensity = (
+                1.2 * enhanced_img[1].max()
+            )  # Increase intensity by 20%
+            enhanced_img[1] = np.maximum(
+                enhanced_img[1], cell_boundary_img[:, :, 1] * cell_boundary_intensity
+            )
+            # Cap values at 1.0 if normalized
+            if enhanced_img.dtype == np.float32 or enhanced_img.dtype == np.float64:
+                enhanced_img[1] = np.minimum(
+                    enhanced_img[1],
+                    1.0 if enhanced_img[1].max() <= 1.0 else enhanced_img[1].max(),
+                )
+        else:
+            # For single channel image, directly add boundaries to green channel
+            cell_boundary = mark_boundaries(
+                base_image,
+                cell_masks,
+                color=(0, 1, 0),  # Green for cells
+                mode="thick",
+            )
+            enhanced_img[1] = np.maximum(enhanced_img[1], cell_boundary[:, :, 1])
+
+        # Add secondary object boundaries (magenta: red + blue)
+        if base_is_multichannel:
+            # For multichannel image, create temporary RGB again
+            second_obj_boundary_img = mark_boundaries(
+                temp_img,
+                second_obj_masks > 0,  # Binary mask
+                color=(1, 0, 1),  # Magenta for secondary objects
+                mode="thick",
+            )
+
+            # Update red and blue channels with secondary object boundaries
+            enhanced_img[0] = np.maximum(
+                enhanced_img[0],
+                second_obj_boundary_img[:, :, 0] * enhanced_img[0].max(),
+            )
+            if num_channels > 2:  # Make sure we have a blue channel
+                enhanced_img[2] = np.maximum(
+                    enhanced_img[2],
+                    second_obj_boundary_img[:, :, 2] * enhanced_img[2].max(),
+                )
+        else:
+            # For single channel, add boundaries to red and blue channels
+            second_obj_boundary = mark_boundaries(
+                base_image,
+                second_obj_masks > 0,  # Binary mask
+                color=(1, 0, 1),  # Magenta for secondary objects
+                mode="thick",
+            )
+            enhanced_img[0] = np.maximum(enhanced_img[0], second_obj_boundary[:, :, 0])
+            enhanced_img[2] = np.maximum(enhanced_img[2], second_obj_boundary[:, :, 2])
+
+        return enhanced_img
+
+    # Create merged microimage with boundaries
+    merged_with_boundaries = add_boundaries(merged_img)
+    merged_microimage = Microimage(
+        merged_with_boundaries, channel_names="Merged", cmaps=channel_cmaps
+    )
+
+    # Create secondary object channel microimage with boundaries (single channel to 3D).
+    second_obj_3d = add_boundaries(second_obj_img, base_is_multichannel=False)
+    boundaries_microimage = Microimage(
+        second_obj_3d,
+        channel_names=f"{channel_name}",
+        cmaps=["pure_red", "pure_green", "pure_blue"],
+    )
+
+    # Create the micropanel
+    microimages = [merged_microimage, boundaries_microimage]
+    panel = create_micropanel(microimages, add_channel_label=True)
+
+    return panel
+
+
+def create_second_obj_standard_visualization(
+    aligned_image,
+    second_obj_channel_index,
+    second_obj_channel_name,
+    second_obj_masks,
+    threshold_output=None,
+    label_color="magenta",
+):
+    """Create standard visualization panel for secondary object segmentation.
+
+    Args:
+        aligned_image (ndarray): Multichannel aligned image [channels, height, width].
+        second_obj_channel_index (int): Index of the channel used for secondary object
+            detection.
+        second_obj_channel_name (str): Name of the secondary object channel
+            (e.g. "CDPK1").
+        second_obj_masks (ndarray): Labeled mask of segmented secondary objects.
+        threshold_output (dict, optional): Threshold debugging output with keys
+            'preprocessed_channel' (log-transformed, Gaussian-smoothed channel) and
+            'binary_mask' (binary mask after thresholding). If None, creates a simple
+            1x2 panel; if provided, creates a 2x2 panel.
+        label_color (str, optional): Color for channel labels. Defaults to 'magenta'.
+
+    Returns:
+        Micropanel: Micropanel object with visualizations.
+    """
+    from lib.shared.configuration_utils import random_cmap
+
+    # Build secondary object colormap
+    second_obj_cmap = random_cmap(num_colors=len(np.unique(second_obj_masks)))
+
+    if threshold_output:
+        # 2x2 grid when threshold_output is provided
+        micro_images = [
+            Microimage(
+                threshold_output["preprocessed_channel"],
+                channel_names="Preprocessed",
+                cmaps="gray",
+            ),
+            Microimage(
+                threshold_output["binary_mask"],
+                channel_names="Threshold Binary",
+                cmaps="gray",
+            ),
+            Microimage(
+                aligned_image[second_obj_channel_index],
+                channel_names=f"{second_obj_channel_name} (Raw)",
+                cmaps="gray",
+            ),
+            Microimage(
+                second_obj_masks,
+                cmaps=second_obj_cmap,
+                channel_names="Secondary Objects",
+            ),
+        ]
+        num_cols = 2
+    else:
+        # 1x2 grid when threshold_output is None
+        micro_images = [
+            Microimage(
+                aligned_image[second_obj_channel_index],
+                channel_names=f"{second_obj_channel_name} (Raw)",
+                cmaps="gray",
+            ),
+            Microimage(
+                second_obj_masks,
+                cmaps=second_obj_cmap,
+                channel_names="Secondary Objects",
+            ),
+        ]
+        num_cols = 2
+
+    panel = create_micropanel(
+        micro_images,
+        add_channel_label=True,
+        num_cols=num_cols,
+    )
+
+    # Set all channel labels to specified color
+    for ax in panel.fig.axes:
+        for text in ax.texts:
+            text.set_color(label_color)
+
+    return panel
+
+
+def get_feret_diameters(coords):
+    """Compute the minimum and maximum Feret diameters of a 2D shape.
+
+    The Feret diameters are calculated using OpenCV's minAreaRect, which finds
+    the smallest-area rotated bounding rectangle that encloses the input coordinates.
+
+    Args:
+        coords (ndarray): Array of shape (N, 2) of (x, y) coordinates representing the
+            pixels or contour of a region.
+
+    Returns:
+        tuple:
+            - feret_min (float): The shortest distance between two parallel lines
+              tangent to the object (the minimum Feret diameter).
+            - feret_max (float): The longest distance between two parallel lines
+              tangent to the object (the maximum Feret diameter).
+
+    Note:
+        Assumes the input coordinates define a planar shape (e.g. from a binary mask or
+        regionprops). Returned values are in the same units as the input coordinates,
+        typically pixels. Internally uses OpenCV's cv2.minAreaRect.
+    """
+    cnt = coords.astype(np.int32)
+    rect = cv2.minAreaRect(cnt)
+    w, h = rect[1]
+    return min(w, h), max(w, h)
+
+
+def apply_morphological_opening(binary_mask, opening_disk_radius=1):
+    """Apply morphological opening to separate weakly connected secondary objects.
+
+    Args:
+        binary_mask (ndarray): Binary mask of secondary objects.
+        opening_disk_radius (int): Radius of the disk structuring element; larger is
+            more aggressive.
+
+    Returns:
+        ndarray: Morphologically opened mask.
+    """
+    footprint = morphology.disk(max(1, opening_disk_radius))
+    opened = morphology.binary_opening(binary_mask, footprint=footprint)
+
+    # Recover small objects that were removed by opening
+    removed = binary_mask & ~opened
+    small_objects, num = ndimage.label(removed)
+
+    # Only recover objects at least as large as the structuring element
+    min_recoverable_size = np.pi * opening_disk_radius**2
+    for i in range(1, num + 1):
+        obj_mask = small_objects == i
+        if np.sum(obj_mask) >= min_recoverable_size:
+            opened |= obj_mask
+
+    return opened
+
+
+def apply_h_maxima_suppression(peak_map, h_factor):
+    """Apply h-maxima transform to suppress weak local maxima.
+
+    This complements spatial suppression (min_distance) by filtering peaks
+    based on their prominence/height in the distance or intensity map.
+
+    Args:
+        peak_map (ndarray): Distance transform or intensity image.
+        h_factor (float): Height threshold factor (0.0-1.0), where
+            h = h_factor * (peak_map.max() - peak_map.min()). Higher values suppress
+            more aggressively.
+
+    Returns:
+        ndarray: Map with weak maxima suppressed.
+    """
+    if h_factor <= 0 or h_factor > 1:
+        raise ValueError(f"h_factor must be in (0, 1], got {h_factor}")
+
+    # Calculate absolute height threshold
+    h = h_factor * (peak_map.max() - peak_map.min())
+
+    # h-maxima transform: flatten maxima shallower than h, keep the map grayscale
+    filtered_map = morphology.reconstruction(peak_map - h, peak_map, method="dilation")
+
+    return filtered_map
+
+
+def apply_declumping(
+    binary_mask,
+    second_obj_smooth,
+    declump_method,
+    declump_mode,
+    suppress_local_maxima,
+    maxima_reduction_factor,
+):
+    """Apply declumping based on CellProfiler-compatible method selection.
+
+    Args:
+        binary_mask (ndarray): Binary mask of secondary objects.
+        second_obj_smooth (ndarray): Smoothed intensity image (log + Gaussian filtered).
+        declump_method (str): One of "none", "shape", "intensity", "shape_intensity",
+            "distance".
+        declump_mode (str): One of "watershed", "propagate", "none".
+        suppress_local_maxima (int): Minimum distance between peaks (spatial
+            constraint).
+        maxima_reduction_factor (float or None): H-maxima threshold (0.0-1.0). None
+            disables it.
+
+    Returns:
+        ndarray: Labeled mask after declumping.
+
+    Note:
+        Shape refinement is NOT handled here — it is applied as optional refinement
+        after this function in the main pipeline.
+    """
+    # Method 1: No declumping
+    if declump_method == "none":
+        declumped, _ = ndimage.label(binary_mask)
+        return declumped
+
+    # Method 2: Shape-based (distance transform)
+    if declump_method in ["shape", "distance"]:
+        peak_map = ndimage.distance_transform_edt(binary_mask)
+
+    # Method 3: Intensity-based
+    elif declump_method == "intensity":
+        # Use smoothed intensity within mask
+        peak_map = second_obj_smooth.copy()
+        peak_map[~binary_mask] = 0
+
+    # Method 4: Combined shape + intensity
+    elif declump_method == "shape_intensity":
+        # Normalize both maps to [0, 1] and average
+        distance_map = ndimage.distance_transform_edt(binary_mask)
+        distance_norm = distance_map / (distance_map.max() + 1e-10)
+
+        intensity_map = second_obj_smooth.copy()
+        intensity_map[~binary_mask] = 0
+        intensity_norm = intensity_map / (intensity_map.max() + 1e-10)
+
+        peak_map = (distance_norm + intensity_norm) / 2
+
+    else:
+        raise ValueError(f"Unknown declump_method: {declump_method}")
+
+    # Apply h-maxima suppression if requested
+    if maxima_reduction_factor is not None:
+        peak_map = apply_h_maxima_suppression(peak_map, maxima_reduction_factor)
+
+    # Detect local maxima
+    local_max = feature.peak_local_max(
+        peak_map,
+        min_distance=suppress_local_maxima,
+        labels=binary_mask,
+        exclude_border=False,
+    )
+
+    # Create markers
+    markers = np.zeros_like(binary_mask, dtype=int)
+    if len(local_max) == 0:
+        # No peaks found, return connected components
+        declumped, _ = ndimage.label(binary_mask)
+        return declumped
+
+    markers[tuple(local_max.T)] = np.arange(1, len(local_max) + 1)
+
+    # Apply declump_mode
+    if declump_mode == "none":
+        # Use markers only (no watershed)
+        declumped = markers.copy()
+
+    elif declump_mode == "watershed":
+        # Standard watershed with negative distance
+        if declump_method in ["shape", "shape_intensity"]:
+            # Use distance transform for watershed
+            distance = ndimage.distance_transform_edt(binary_mask)
+            declumped = segmentation.watershed(-distance, markers, mask=binary_mask)
+        else:
+            # For pure intensity, watershed on negative intensity
+            intensity = second_obj_smooth.copy()
+            intensity[~binary_mask] = intensity.max()
+            declumped = segmentation.watershed(intensity, markers, mask=binary_mask)
+
+    elif declump_mode == "propagate":
+        # Propagate from seeds using positive distance
+        distance = ndimage.distance_transform_edt(binary_mask)
+        declumped = segmentation.watershed(distance, markers, mask=binary_mask)
+
+    else:
+        raise ValueError(f"Unknown declump_mode: {declump_mode}")
+
+    # Recover unassigned regions
+    missing = (declumped == 0) & binary_mask
+    if np.any(missing):
+        labeled_missing, _ = ndimage.label(missing)
+        if declumped.max() > 0:
+            labeled_missing[labeled_missing > 0] += declumped.max()
+        declumped += labeled_missing
+
+    return declumped
+
+
+def shape_based_declumping(
+    binary_mask, second_obj_img=None, min_distance=20, proportion_threshold=0.4
+):
+    """Split connected components only when the separating boundary is short relative to the region perimeter.
+
+    Args:
+        binary_mask (ndarray): Input binary secondary object mask.
+        second_obj_img (ndarray, optional): Intensity image. Currently unused, kept for
+            API compatibility.
+        min_distance (int): Minimum distance between peaks for watershed markers.
+        proportion_threshold (float): Accept the split if
+            boundary_length / perimeter < proportion_threshold. For example, 0.12 means
+            the cut must be under 12% of the perimeter.
+
+    Returns:
+        ndarray: Labeled mask after shape-based declumping.
+    """
+    labeled_out = np.zeros_like(binary_mask, dtype=int)
+    next_label = 1
+
+    # Label connected regions
+    regions_lab, n = ndimage.label(binary_mask)
+
+    for region_label in range(1, n + 1):
+        region_mask = regions_lab == region_label
+        if region_mask.sum() == 0:
+            continue
+
+        # Distance transform and find peaks
+        dist = ndimage.distance_transform_edt(region_mask)
+        peaks = feature.peak_local_max(
+            dist, min_distance=min_distance, labels=region_mask, exclude_border=False
+        )
+
+        # If only one peak, keep as single object
+        if len(peaks) <= 1:
+            labeled_out[region_mask] = next_label
+            next_label += 1
+            continue
+
+        # Create markers and apply watershed
+        markers = np.zeros_like(region_mask, dtype=int)
+        markers[tuple(peaks.T)] = np.arange(1, len(peaks) + 1)
+        local_watershed = segmentation.watershed(-dist, markers, mask=region_mask)
+
+        # Vectorized boundary detection
+        lab = local_watershed
+
+        # Vertical boundaries (compare rows)
+        vertical_boundary = (
+            (lab[:-1, :] != lab[1:, :]) & (lab[:-1, :] > 0) & (lab[1:, :] > 0)
+        )
+
+        # Horizontal boundaries (compare columns)
+        horizontal_boundary = (
+            (lab[:, :-1] != lab[:, 1:]) & (lab[:, :-1] > 0) & (lab[:, 1:] > 0)
+        )
+
+        # Count total boundary pixels
+        boundary_length = np.sum(vertical_boundary) + np.sum(horizontal_boundary)
+
+        prop = measure.regionprops(region_mask.astype(np.uint8))[0]
+        perimeter = prop.perimeter if prop.perimeter > 0 else 1.0
+
+        # Accept split if boundary is short relative to perimeter
+        if (boundary_length / perimeter) < proportion_threshold:
+            sublabels = np.unique(local_watershed[local_watershed > 0])
+            for s in sublabels:
+                labeled_out[local_watershed == s] = next_label
+                next_label += 1
+        else:
+            # Reject split, keep as single object
+            labeled_out[region_mask] = next_label
+            next_label += 1
+
+    return labeled_out
+
+
+def create_empty_results(cell_masks, cytoplasm_masks, nuclei_centroids=None):
+    """Helper function to create empty results when no secondary objects are found.
+
+    Args:
+        cell_masks (ndarray): Cell segmentation masks.
+        cytoplasm_masks (ndarray, optional): Cytoplasm segmentation masks.
+        nuclei_centroids (dict or DataFrame, optional): Nuclei centroids information.
+
+    Returns:
+        tuple: Empty secondary object masks, cell_second_obj_table dict, and
+            cytoplasm_masks (None if cytoplasm_masks was not provided).
+    """
+    cell_ids = np.unique(cell_masks[cell_masks > 0])
+    empty_second_obj_masks = np.zeros_like(cell_masks)
+
+    cell_summary = []
+    for cell_id in cell_ids:
+        cell_area = np.sum(cell_masks == cell_id)
+        summary_entry = {
+            "cell_id": cell_id,
+            "has_second_obj": False,
+            "num_second_objs": 0,
+            "second_obj_ids": [],
+            "cell_area": cell_area,
+            "total_second_obj_area": 0,
+            "second_obj_area_ratio": 0,
+            "mean_second_obj_diameter": None,
+        }
+
+        # Add cell nucleus distance fields if nuclei_centroids was provided
+        if nuclei_centroids is not None:
+            summary_entry["mean_distance_to_nucleus"] = None
+
+        cell_summary.append(summary_entry)
+
+    cell_second_obj_table = {
+        "cell_summary": pd.DataFrame(cell_summary),
+        "second_obj_cell_mapping": pd.DataFrame(),
+    }
+
+    # cytoplasm_masks is None when no cytoplasm masks were given (no objects to remove)
+    return empty_second_obj_masks, cell_second_obj_table, cytoplasm_masks
+
+
+def get_spatial_overlap_candidates(second_obj_regions, cell_masks):
+    """Use bounding boxes to pre-filter which cells could overlap with each secondary object.
+
+    Args:
+        second_obj_regions (dict): Mapping of second_obj_id to regionprops.
+        cell_masks (ndarray): Cell segmentation masks.
+
+    Returns:
+        dict: Mapping of second_obj_id to a list of candidate cell_ids.
+    """
+    # Get all cell regions with their bounding boxes
+    cell_regions = measure.regionprops(cell_masks)
+    cell_bboxes = {
+        r.label: r.bbox for r in cell_regions
+    }  # (min_row, min_col, max_row, max_col)
+
+    candidates = {}
+
+    for second_obj_id, vac_region in second_obj_regions.items():
+        vac_bbox = vac_region.bbox  # (min_row, min_col, max_row, max_col)
+
+        # Find cells whose bounding boxes intersect with this secondary object's bbox
+        overlapping_cells = []
+        for cell_id, cell_bbox in cell_bboxes.items():
+            # Check if bounding boxes overlap
+            if not (
+                vac_bbox[2] < cell_bbox[0]  # second_obj above cell
+                or vac_bbox[0] > cell_bbox[2]  # second_obj below cell
+                or vac_bbox[3] < cell_bbox[1]  # second_obj left of cell
+                or vac_bbox[1] > cell_bbox[3]
+            ):  # second_obj right of cell
+                overlapping_cells.append(cell_id)
+
+        candidates[second_obj_id] = overlapping_cells
+
+    return candidates
+
+
+def _postprocess_secondary_objects(
+    second_obj_masks,
+    cell_masks,
+    cytoplasm_masks,
+    second_obj_min_size,
+    second_obj_max_size,
+    size_filter_method,
+    max_objects_per_cell,
+    overlap_threshold,
+    nuclei_centroids,
+    max_total_objects,
+    image=None,
+    second_obj_channel_index=None,
+):
+    """Apply post-processing pipeline to secondary object masks.
+
+    This function performs the shared post-processing steps for both
+    basic thresholding and ML-based secondary object segmentation:
+    1. Size filtering (Feret diameter or area)
+    2. Cell association (spatial overlap)
+    3. Cell summary statistics
+    4. Cytoplasm mask updates
+
+    Args:
+        second_obj_masks (ndarray): Labeled mask of secondary objects (integer labels,
+            background=0).
+        cell_masks (ndarray): Cell segmentation masks with unique integers for each
+            cell.
+        cytoplasm_masks (ndarray or None): Cytoplasm segmentation masks. If provided,
+            secondary object regions will be removed from cytoplasm masks.
+        second_obj_min_size (float): Minimum size for valid secondary objects.
+        second_obj_max_size (float): Maximum size for valid secondary objects.
+        size_filter_method (str): Size filtering method ("feret" or "area").
+        max_objects_per_cell (int): Maximum secondary objects allowed per cell.
+        overlap_threshold (float): Minimum overlap ratio to associate object with cell
+            (0.0-1.0).
+        nuclei_centroids (dict, DataFrame, or None): Cell nuclei centroids for distance
+            calculations, as {nuclei_id: (i, j)} or a DataFrame with 'i' and 'j'
+            columns.
+        max_total_objects (int or None): Failsafe limit on detected objects. Returns
+            empty results if exceeded.
+        image (ndarray, optional): Multichannel image [channels, height, width]. Only
+            needed if nuclei_centroids is provided, for distance calculations.
+        second_obj_channel_index (int, optional): Index of the secondary object channel.
+            Only needed if nuclei_centroids is provided, for distance calculations.
+
+    Returns:
+        tuple:
+            - second_obj_masks: Filtered and renumbered secondary object masks
+            - cell_second_obj_table: Dict with 'cell_summary' and
+              'second_obj_cell_mapping' DataFrames
+            - updated_cytoplasm_masks: Cytoplasm masks with secondary objects removed
+              (or None)
+
+    Note:
+        Shared by both segment_second_objs() and segment_second_objs_ml(). Input masks
+        should already be labeled (not binary). Empty input masks are handled
+        gracefully.
+    """
+    # Handle empty input
+    if not np.any(second_obj_masks):
+        print("No objects detected in input masks")
+        return create_empty_results(cell_masks, cytoplasm_masks, nuclei_centroids)
+
+    # Failsafe: Check for excessive objects early
+    num_input_objects = len(np.unique(second_obj_masks)) - 1  # Exclude background
+    if max_total_objects is not None and num_input_objects > max_total_objects:
+        print(
+            f"Failsafe triggered: Detected {num_input_objects} objects (limit: {max_total_objects})"
+        )
+        print("Returning empty results to avoid processing over-segmented image")
+        return create_empty_results(cell_masks, cytoplasm_masks, nuclei_centroids)
+
+    # Filter by size
+    print(f"Filtering by {size_filter_method}...")
+    regions = measure.regionprops(second_obj_masks)
+    valid_labels = []
+
+    if size_filter_method == "feret":
+        # Feret diameter filtering
+        for region in regions:
+            coords = region.coords[:, [1, 0]]  # (x, y) format
+            if len(coords) < 3:
+                continue
+
+            feret_min, feret_max = get_feret_diameters(coords)
+            if second_obj_min_size <= feret_min and feret_max <= second_obj_max_size:
+                valid_labels.append(region.label)
+
+    elif size_filter_method == "area":
+        # Area-based filtering (CellProfiler standard)
+        for region in regions:
+            if second_obj_min_size <= region.area <= second_obj_max_size:
+                valid_labels.append(region.label)
+
+    else:
+        raise ValueError(f"Unknown size_filter_method: {size_filter_method}")
+
+    if not valid_labels:
+        print(f"No valid secondary objects found after {size_filter_method} filtering")
+        return create_empty_results(cell_masks, cytoplasm_masks, nuclei_centroids)
+
+    print(
+        f"After {size_filter_method} filtering: {len(valid_labels)} valid secondary objects"
+    )
+
+    # Create valid secondary objects mask with renumbered labels
+    labeled_second_objs = np.zeros_like(second_obj_masks)
+    for i, lbl in enumerate(valid_labels, start=1):
+        labeled_second_objs[second_obj_masks == lbl] = i
+
+    num_second_objs = len(valid_labels)
+
+    # Get cell IDs
+    cell_ids = np.unique(cell_masks[cell_masks > 0])
+
+    # Prepare nuclei centroids - this is for cell nuclei distance calculations
+    nuclei_centroids_dict = None
+    if nuclei_centroids is not None:
+        if isinstance(nuclei_centroids, pd.DataFrame):
+            nuclei_centroids_dict = {
+                row.get("nuclei_id", idx): (row["i"], row["j"])
+                for idx, row in nuclei_centroids.iterrows()
+            }
+        else:
+            nuclei_centroids_dict = nuclei_centroids
+
+    # Pre-compute region properties for all secondary objects
+    second_obj_regions = {
+        region.label: region for region in measure.regionprops(labeled_second_objs)
+    }
+
+    # Pre-compute which cells could overlap with each secondary object
+    print("Computing spatial overlap candidates...")
+    overlap_candidates = get_spatial_overlap_candidates(second_obj_regions, cell_masks)
+
+    # Initialize tracking variables
+    second_obj_cell_mapping = []
+    second_objs_per_cell = {cell_id: 0 for cell_id in cell_ids}
+
+    # Process each secondary object
+    print("Processing secondary object-cell associations...")
+    for second_obj_id in range(1, num_second_objs + 1):
+        if second_obj_id not in second_obj_regions:
+            continue
+
+        region = second_obj_regions[second_obj_id]
+        second_obj_mask = labeled_second_objs == second_obj_id
+        second_obj_area = region.area
+        second_obj_centroid = region.centroid
+
+        # Calculate equivalent diameter for this secondary object
+        second_obj_diameter = 2 * np.sqrt(second_obj_area / np.pi)
+
+        # Initialize mapping entry with basic info
+        mapping_entry = {
+            "second_obj_id": second_obj_id,
+            "second_obj_area": second_obj_area,
+            "second_obj_diameter": second_obj_diameter,
+        }
+
+        # Calculate distance to nearest cell nucleus
+        if nuclei_centroids_dict is not None:
+            min_dist = np.inf
+            nearest_nucleus_id = None
+            for nuc_id, nuc_centroid in nuclei_centroids_dict.items():
+                dist = np.sqrt(
+                    (second_obj_centroid[0] - nuc_centroid[0]) ** 2
+                    + (second_obj_centroid[1] - nuc_centroid[1]) ** 2
+                )
+                if dist < min_dist:
+                    min_dist = dist
+                    nearest_nucleus_id = nuc_id
+
+            mapping_entry["distance_to_nucleus"] = (
+                min_dist if min_dist != np.inf else None
+            )
+            mapping_entry["nearest_nucleus_id"] = nearest_nucleus_id
+
+        # Find best overlapping cell
+        best_cell_id = None
+        best_overlap = 0
+
+        # Check spatial overlap candidates
+        candidate_cells = overlap_candidates.get(second_obj_id, [])
+
+        for cell_id in candidate_cells:
+            if second_objs_per_cell[cell_id] >= max_objects_per_cell:
+                continue
+
+            # Calculate overlap efficiently
+            cell_mask = cell_masks == cell_id
+            overlap = np.sum(second_obj_mask & cell_mask)
+
+            if overlap > 0:
+                overlap_ratio = overlap / second_obj_area
+                if overlap_ratio >= overlap_threshold and overlap_ratio > best_overlap:
+                    best_overlap = overlap_ratio
+                    best_cell_id = cell_id
+
+        # Add successful associations
+        if best_cell_id is not None:
+            mapping_entry["cell_id"] = best_cell_id
+            mapping_entry["overlap_ratio"] = best_overlap
+
+            second_obj_cell_mapping.append(mapping_entry)
+            second_objs_per_cell[best_cell_id] += 1
+
+    # Create secondary object-cell mapping DataFrame
+    second_obj_cell_df = pd.DataFrame(second_obj_cell_mapping)
+
+    # Create cell summary
+    if second_obj_cell_mapping:
+        # Group by cell_id once for efficiency
+        grouped = second_obj_cell_df.groupby("cell_id")
+        cell_summary = []
+
+        for cell_id in cell_ids:
+            cell_area = np.sum(cell_masks == cell_id)
+
+            # Initialize basic cell summary
+            summary_entry = {
+                "cell_id": cell_id,
+                "cell_area": cell_area,
+            }
+
+            # Check if cell_id has associated secondary objects
+            if cell_id in grouped.groups:
+                cell_second_objs = grouped.get_group(cell_id)
+
+                # Calculate cell-level statistics
+                total_second_obj_area = cell_second_objs["second_obj_area"].sum()
+                mean_diameter = cell_second_objs["second_obj_diameter"].mean()
+
+                summary_entry.update(
+                    {
+                        "has_second_obj": True,
+                        "num_second_objs": len(cell_second_objs),
+                        "second_obj_ids": list(cell_second_objs["second_obj_id"]),
+                        "total_second_obj_area": total_second_obj_area,
+                        "second_obj_area_ratio": total_second_obj_area / cell_area
+                        if cell_area > 0
+                        else 0,
+                        "mean_second_obj_diameter": mean_diameter,
+                    }
+                )
+
+                # Add cell nucleus distance fields if nuclei_centroids was provided
+                if nuclei_centroids_dict is not None:
+                    mean_distance = (
+                        cell_second_objs["distance_to_nucleus"].dropna().mean()
+                        if not cell_second_objs["distance_to_nucleus"].dropna().empty
+                        else None
+                    )
+                    summary_entry["mean_distance_to_nucleus"] = mean_distance
+
+            else:  # Cell without secondary objects
+                summary_entry.update(
+                    {
+                        "has_second_obj": False,
+                        "num_second_objs": 0,
+                        "second_obj_ids": [],
+                        "total_second_obj_area": 0,
+                        "second_obj_area_ratio": 0,
+                        "mean_second_obj_diameter": None,
+                    }
+                )
+
+                # Add cell nucleus distance fields if nuclei_centroids was provided
+                if nuclei_centroids_dict is not None:
+                    summary_entry["mean_distance_to_nucleus"] = None
+
+            cell_summary.append(summary_entry)
+
+    else:
+        # Handle case with no secondary objects
+        cell_summary = []
+        for cell_id in cell_ids:
+            cell_area = np.sum(cell_masks == cell_id)
+            summary_entry = {
+                "cell_id": cell_id,
+                "has_second_obj": False,
+                "num_second_objs": 0,
+                "second_obj_ids": [],
+                "cell_area": cell_area,
+                "total_second_obj_area": 0,
+                "second_obj_area_ratio": 0,
+                "mean_second_obj_diameter": None,
+            }
+
+            # Add cell nucleus distance fields if nuclei_centroids was provided
+            if nuclei_centroids_dict is not None:
+                summary_entry["mean_distance_to_nucleus"] = None
+
+            cell_summary.append(summary_entry)
+
+    # Create final results
+    cell_summary_df = pd.DataFrame(cell_summary)
+    cell_second_obj_table = {
+        "cell_summary": cell_summary_df,
+        "second_obj_cell_mapping": second_obj_cell_df,
+    }
+
+    # Create associated secondary object masks
+    associated_second_objs = np.zeros_like(labeled_second_objs)
+    for mapping in second_obj_cell_mapping:
+        second_obj_id = mapping["second_obj_id"]
+        second_obj_mask = labeled_second_objs == second_obj_id
+        associated_second_objs[second_obj_mask] = second_obj_id
+
+    # Print statistics
+    total_kept = len(second_obj_cell_mapping)
+    print(
+        f"Kept {total_kept} out of {num_second_objs} detected secondary objects "
+        f"({total_kept / num_second_objs * 100:.1f}%)"
+    )
+    print(
+        f"Discarded {num_second_objs - total_kept} secondary objects that didn't meet diameter criteria or cell overlap"
+    )
+
+    # Process cytoplasm masks if provided
+    updated_cytoplasm_masks = None
+    if cytoplasm_masks is not None:
+        updated_cytoplasm_masks = cytoplasm_masks.copy()
+        for mapping in second_obj_cell_mapping:
+            second_obj_id = mapping["second_obj_id"]
+            cell_id = mapping["cell_id"]
+            second_obj_mask = associated_second_objs == second_obj_id
+            cytoplasm_mask = updated_cytoplasm_masks == cell_id
+            updated_cytoplasm_masks[cytoplasm_mask & second_obj_mask] = 0
+        print(
+            f"Updated cytoplasm masks by removing {len(second_obj_cell_mapping)} secondary object regions"
+        )
+
+    # Return results (updated_cytoplasm_masks is None when no cytoplasm masks were given)
+    return associated_second_objs, cell_second_obj_table, updated_cytoplasm_masks

--- a/workflow/lib/sbs/align_cycles.py
+++ b/workflow/lib/sbs/align_cycles.py
@@ -13,6 +13,7 @@ from lib.shared.align import (
     calculate_offsets,
     apply_offsets,
     filter_percentiles,
+    offsets_to_metrics,
 )
 
 
@@ -29,6 +30,7 @@ def align_cycles(
     manual_background_cycle=None,
     manual_channel_mapping=None,
     verbose=False,
+    return_metrics=False,
 ):
     """Rigid alignment of sequencing cycles and channels.
 
@@ -66,9 +68,12 @@ def align_cycles(
         verbose (bool, optional): If True, print detailed alignment information including
             calculated offsets for each cycle. Useful for debugging alignment issues.
             Defaults to False.
+        return_metrics (bool, optional): If True, also return a dict of per-cycle alignment
+            offset metrics keyed offset_y_cycle{i}/offset_x_cycle{i}. Defaults to False.
 
     Returns:
         np.ndarray: SBS image aligned across cycles.
+        dict, optional: Per-cycle alignment offset metrics if return_metrics is True.
     """
     skip_cycles = skip_cycles or []
 
@@ -247,6 +252,9 @@ def align_cycles(
             [align_it(x) for x in aligned[:, base_slices]]
         )
 
+    # Track per-cycle offsets from whichever alignment branch runs
+    cycle_offsets = None
+
     # Align between cycles
     if method == "DAPI":
         # Only attempt DAPI alignment if DAPI channel exists
@@ -262,6 +270,7 @@ def align_cycles(
                 upsample_factor=upsample_factor,
                 return_offsets=True,
             )
+            cycle_offsets = offsets
 
             if verbose:
                 print("\n=== Cycle Alignment Offsets (DAPI method) ===")
@@ -286,7 +295,8 @@ def align_cycles(
         target = apply_window(aligned[:, sbs_channels], window=window).max(axis=1)
         normed = normalize_by_percentile(target, q_norm=q_norm)
         normed[normed > cutoff] = cutoff
-        offsets = calculate_offsets(normed, upsample_factor=upsample_factor)
+        offsets, _ = calculate_offsets(normed, upsample_factor=upsample_factor)
+        cycle_offsets = offsets
 
         if verbose:
             print("\n=== Cycle Alignment Offsets (sbs_mean method) ===")
@@ -343,6 +353,12 @@ def align_cycles(
     print(
         f"  intra_cycle_channel_shift_residual_max_px:  {intra_cycle_channel_shift_residual_max_px:.4f}  (pass < 1.0)"
     )
+    if return_metrics:
+        return aligned, (
+            offsets_to_metrics(cycle_offsets, "cycle")
+            if cycle_offsets is not None
+            else {}
+        )
 
     return aligned
 
@@ -363,7 +379,7 @@ def align_within_cycle(data_, upsample_factor=4, window=1, q1=0, q2=90):
     # Filter the input data based on percentiles
     filtered = filter_percentiles(apply_window(data_, window), q1=q1, q2=q2)
     # Calculate offsets using the filtered data
-    offsets = calculate_offsets(filtered, upsample_factor=upsample_factor)
+    offsets, _ = calculate_offsets(filtered, upsample_factor=upsample_factor)
     # Apply the calculated offsets to the original data and return the result
     return apply_offsets(data_, offsets)
 
@@ -386,7 +402,7 @@ def align_between_cycles(
     """
     # Calculate offsets from the target channel
     target = apply_window(data[:, channel_index], window)
-    offsets = calculate_offsets(target, upsample_factor=upsample_factor)
+    offsets, _ = calculate_offsets(target, upsample_factor=upsample_factor)
 
     # Apply the calculated offsets to all channels
     warped = []

--- a/workflow/lib/sbs/align_cycles.py
+++ b/workflow/lib/sbs/align_cycles.py
@@ -326,7 +326,7 @@ def align_cycles(
 
     # Alignment QC — residual on aligned cycles and base channels
     if aligned.shape[1] > 0 and (channel_order is None or channel_order[0] == "DAPI"):
-        dapi_residual = calculate_offsets(
+        dapi_residual, _ = calculate_offsets(
             aligned[:, 0], upsample_factor=upsample_factor
         )
         cycle_dapi_shift_residual_max_px = float(np.max(np.abs(dapi_residual)))
@@ -336,7 +336,7 @@ def align_cycles(
     if base_indices and len(base_indices) > 1:
         per_cycle_residuals = []
         for c in range(aligned.shape[0]):
-            intra = calculate_offsets(
+            intra, _ = calculate_offsets(
                 aligned[c, base_indices], upsample_factor=upsample_factor
             )
             per_cycle_residuals.append(float(np.max(np.abs(intra))))

--- a/workflow/lib/shared/align.py
+++ b/workflow/lib/shared/align.py
@@ -1,14 +1,12 @@
 """Shared functions for aligning images.
 
-Uses NumPy and scikit-image to provide image
-alignment between sequencing cycles, apply percentile-based filtering, fill masked
-areas with noise, and perform various transformations to enhance image data quality.
+Uses NumPy and scikit-image to provide image alignment between sequencing cycles.
 """
 
 import numpy as np
 import skimage
 
-from lib.shared.image_utils import applyIJ, remove_channels
+from lib.shared.image_utils import applyIJ
 
 
 def apply_window(data, window):
@@ -65,26 +63,40 @@ def calculate_offsets(data_, upsample_factor):
         upsample_factor (int): Upsampling factor for cross-correlation.
 
     Returns:
-        np.ndarray: Offset values between images.
+        tuple: (offsets, errors) where offsets is np.ndarray of offset values
+            and errors is np.ndarray of correlation errors (0 = perfect correlation).
     """
     # Set the target frame as the first frame in the data
     target = data_[0]
-    # Initialize an empty list to store offsets
+
+    # Initialize empty lists to store offsets and errors
     offsets = []
+    errors = []
     # Iterate through each frame in the data
     for i, src in enumerate(data_):
-        # If it's the first frame, add a zero offset
+        # If it's the first frame, add a zero offset and zero error
         if i == 0:
             offsets += [(0, 0)]
+            errors += [0.0]
         else:
             # Calculate the offset between the current frame and the target frame
-            offset, _, _ = skimage.registration.phase_cross_correlation(
+            offset, error, _ = skimage.registration.phase_cross_correlation(
                 src, target, upsample_factor=upsample_factor, normalization=None
             )
-            # Add the offset to the list
+            # Add the offset and error to the lists
             offsets += [offset]
-    # Convert the list of offsets to a numpy array and return
-    return np.array(offsets)
+            errors += [error]
+    # Convert the lists to numpy arrays and return
+    return np.array(offsets), np.array(errors)
+
+
+def offsets_to_metrics(offsets, unit):
+    """Flatten per-step (dy, dx) offsets into an {offset_y_{unit}{i}, offset_x_{unit}{i}} metrics dict (i from 1)."""
+    metrics = {}
+    for i, (dy, dx) in enumerate(offsets, 1):
+        metrics[f"offset_y_{unit}{i}"] = dy
+        metrics[f"offset_x_{unit}{i}"] = dx
+    return metrics
 
 
 @applyIJ

--- a/workflow/lib/shared/cellpose_training.py
+++ b/workflow/lib/shared/cellpose_training.py
@@ -1,0 +1,696 @@
+"""Cellpose Fine-Tuning Utilities.
+
+Functions for loading training data, augmentation, training, evaluation,
+and visualization of Cellpose models for secondary object segmentation.
+"""
+
+from pathlib import Path
+from typing import List, Tuple, Optional, Union, Dict
+import numpy as np
+
+from tifffile import imread
+from cellpose import models, train, io
+import matplotlib.pyplot as plt
+from matplotlib.colors import ListedColormap
+
+# Reuse utilities from segment_cellpose (single source of truth)
+from lib.shared.segment_cellpose import prepare_cellpose, create_cellpose_model
+
+
+def load_training_data(
+    image_paths: List[Union[str, Path]],
+    mask_paths: List[Union[str, Path]],
+    mode: str = "secondary_obj",
+    channel_index: Optional[int] = None,
+    dapi_index: Optional[int] = None,
+    cyto_index: Optional[int] = None,
+    helper_index: Optional[int] = None,
+    logscale: bool = True,
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Load paired images and masks for Cellpose training.
+
+    Supports different preprocessing modes to match deployment functions:
+    - "secondary_obj": For segment_second_objs_ml (single channel, log scaling)
+    - "cells": For segment_cellpose with cells=True (3-channel RGB)
+    - "nuclei": For segment_cellpose with cells=False (DAPI only)
+
+    Args:
+        image_paths (List[str | Path]): Paths to image files (TIFF format, can be
+            multi-channel).
+        mask_paths (List[str | Path]): Paths to mask files (NPY format, labeled
+            masks where each object has a unique integer ID and background is 0).
+        mode (str): Preprocessing mode. Options:
+            - "secondary_obj": For segment_second_objs_ml (requires channel_index)
+            - "cells": For segment_cellpose cells (requires dapi_index, cyto_index)
+            - "nuclei": For segment_cellpose nuclei only (requires dapi_index)
+        channel_index (int, optional): Channel index for secondary_obj mode.
+        dapi_index (int, optional): DAPI channel index for cells/nuclei modes.
+        cyto_index (int, optional): Cytoplasm channel index for cells mode.
+        helper_index (int, optional): Helper channel index for cells mode (optional).
+        logscale (bool): Apply log scaling preprocessing. Default True.
+
+    Returns:
+        images (List[np.ndarray]): List of preprocessed image arrays (uint8).
+            - secondary_obj/nuclei: 2D arrays [height, width]
+            - cells: 3D arrays [3, height, width]
+        masks (List[np.ndarray]): List of 2D labeled mask arrays (int32).
+
+    Raises:
+        ValueError: If number of images and masks don't match, required indices not
+            provided, or if dimensions mismatch.
+    """
+    if len(image_paths) != len(mask_paths):
+        raise ValueError(
+            f"Number of images ({len(image_paths)}) must match "
+            f"number of masks ({len(mask_paths)})"
+        )
+
+    # Validate mode and required parameters
+    if mode == "secondary_obj":
+        if channel_index is None:
+            raise ValueError("channel_index is required for mode='secondary_obj'")
+    elif mode == "cells":
+        if dapi_index is None or cyto_index is None:
+            raise ValueError("dapi_index and cyto_index are required for mode='cells'")
+    elif mode == "nuclei":
+        if dapi_index is None:
+            raise ValueError("dapi_index is required for mode='nuclei'")
+    else:
+        raise ValueError(
+            f"Unknown mode: {mode}. Valid options: 'secondary_obj', 'cells', 'nuclei'"
+        )
+
+    images = []
+    masks = []
+
+    for img_path, mask_path in zip(image_paths, mask_paths):
+        # Load image
+        img = imread(str(img_path))
+
+        # Apply mode-specific preprocessing using prepare_cellpose (single source of truth)
+        if mode == "secondary_obj":
+            # Use prepare_cellpose with target channel as cyto; green channel (1) has log scaling + max norm.
+            rgb = prepare_cellpose(
+                img,
+                dapi_index=channel_index,  # Dummy - will use cyto
+                cyto_index=channel_index,  # Target channel
+                helper_index=None,
+                logscale=logscale,
+            )
+            processed_img = rgb[1]  # Extract green (log scaled + normalized)
+
+        elif mode == "cells":
+            # Full RGB output from prepare_cellpose
+            processed_img = prepare_cellpose(
+                img,
+                dapi_index=dapi_index,
+                cyto_index=cyto_index,
+                helper_index=helper_index,
+                logscale=logscale,
+            )
+
+        elif mode == "nuclei":
+            # Use prepare_cellpose and extract DAPI (blue) channel
+            rgb = prepare_cellpose(
+                img,
+                dapi_index=dapi_index,
+                cyto_index=dapi_index,  # Dummy
+                helper_index=None,
+                logscale=False,  # DAPI uses percentile norm, not log scale
+            )
+            processed_img = rgb[2]  # Extract blue (DAPI with percentile norm)
+
+        # Load mask (support both .npy and .tif/.tiff formats)
+        mask_path_str = str(mask_path)
+        if mask_path_str.endswith(".npy"):
+            mask = np.load(mask_path_str)
+        else:
+            mask = imread(mask_path_str)
+        if mask.ndim > 2:
+            raise ValueError(f"Mask at {mask_path} should be 2D, got {mask.ndim}D")
+
+        # Validate dimensions match (compare 2D shapes)
+        img_shape_2d = (
+            processed_img.shape[-2:] if processed_img.ndim > 2 else processed_img.shape
+        )
+        if img_shape_2d != mask.shape:
+            raise ValueError(
+                f"Image shape {img_shape_2d} doesn't match mask shape {mask.shape} "
+                f"for {img_path}"
+            )
+
+        images.append(processed_img)
+        masks.append(mask.astype(np.int32))
+
+    print(f"Loaded {len(images)} image-mask pairs (mode={mode})")
+    return images, masks
+
+
+def augment_training_data(
+    images: List[np.ndarray],
+    masks: List[np.ndarray],
+    rotations: bool = True,
+    flips: bool = True,
+    intensity_scaling: bool = True,
+    intensity_range: Tuple[float, float] = (0.8, 1.2),
+    noise: bool = False,
+    noise_std: float = 0.02,
+    seed: Optional[int] = None,
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Apply data augmentation to expand small training datasets.
+
+    For a dataset of N images, this can produce up to 8N augmented samples
+    (4 rotations x 2 flip states).
+
+    Args:
+        images (List[np.ndarray]): List of 2D image arrays.
+        masks (List[np.ndarray]): List of 2D labeled mask arrays.
+        rotations (bool): Apply 90, 180, 270 degree rotations.
+        flips (bool): Apply horizontal and vertical flips.
+        intensity_scaling (bool): Apply random intensity scaling.
+        intensity_range (Tuple[float, float]): Range for intensity scaling factor.
+        noise (bool): Add Gaussian noise.
+        noise_std (float): Standard deviation of Gaussian noise.
+        seed (int, optional): Seed for reproducible intensity/noise augmentation.
+
+    Returns:
+        aug_images (List[np.ndarray]): Augmented images (includes originals).
+        aug_masks (List[np.ndarray]): Augmented masks (includes originals).
+    """
+    aug_images = []
+    aug_masks = []
+    rng = np.random.default_rng(seed)
+
+    for img, mask in zip(images, masks):
+        # Start with original
+        variants = [(img.copy(), mask.copy())]
+
+        # Rotations (90, 180, 270 degrees)
+        if rotations:
+            for k in [1, 2, 3]:  # k*90 degrees
+                rot_img = np.rot90(img, k)
+                rot_mask = np.rot90(mask, k)
+                variants.append((rot_img.copy(), rot_mask.copy()))
+
+        # Flips
+        if flips:
+            current_variants = variants.copy()
+            for v_img, v_mask in current_variants:
+                # Horizontal flip
+                flip_img = np.fliplr(v_img)
+                flip_mask = np.fliplr(v_mask)
+                variants.append((flip_img.copy(), flip_mask.copy()))
+
+        # Intensity modifications (applied to each variant)
+        final_variants = []
+        for v_img, v_mask in variants:
+            # Original intensity
+            final_variants.append((v_img.copy(), v_mask.copy()))
+
+            # Intensity scaling; clip to the image's own range (inputs are uint8 0-255)
+            if intensity_scaling:
+                hi = (
+                    np.iinfo(v_img.dtype).max
+                    if np.issubdtype(v_img.dtype, np.integer)
+                    else 1.0
+                )
+                scale = rng.uniform(intensity_range[0], intensity_range[1])
+                scaled_img = np.clip(v_img * scale, 0, hi).astype(v_img.dtype)
+                final_variants.append((scaled_img, v_mask.copy()))
+
+            # Noise; std scaled to the image's value range
+            if noise:
+                hi = (
+                    np.iinfo(v_img.dtype).max
+                    if np.issubdtype(v_img.dtype, np.integer)
+                    else 1.0
+                )
+                noisy_img = v_img + rng.normal(0, noise_std * hi, v_img.shape)
+                noisy_img = np.clip(noisy_img, 0, hi).astype(v_img.dtype)
+                final_variants.append((noisy_img, v_mask.copy()))
+
+        for v_img, v_mask in final_variants:
+            aug_images.append(v_img)
+            aug_masks.append(v_mask)
+
+    print(
+        f"Augmentation: {len(images)} original → {len(aug_images)} samples "
+        f"({len(aug_images) / len(images):.1f}x expansion)"
+    )
+    return aug_images, aug_masks
+
+
+def prepare_cellpose_training(
+    images: List[np.ndarray],
+    masks: List[np.ndarray],
+    test_fraction: float = 0.1,
+    seed: int = 42,
+) -> Tuple[List[np.ndarray], List[np.ndarray], List[np.ndarray], List[np.ndarray]]:
+    """Split data into training and test sets for Cellpose.
+
+    Args:
+        images (List[np.ndarray]): List of 2D image arrays.
+        masks (List[np.ndarray]): List of 2D labeled mask arrays.
+        test_fraction (float): Fraction of data to use for testing (0.0 to 1.0).
+        seed (int): Random seed for reproducibility.
+
+    Returns:
+        train_images (List[np.ndarray]): Training images.
+        train_masks (List[np.ndarray]): Training masks.
+        test_images (List[np.ndarray]): Test images.
+        test_masks (List[np.ndarray]): Test masks.
+    """
+    n_samples = len(images)
+    n_test = max(1, int(n_samples * test_fraction))
+    # Keep at least one training sample (n_test=0 when only one sample exists)
+    n_test = min(n_test, n_samples - 1) if n_samples > 1 else 0
+
+    # Shuffle indices with a local generator (no global RNG side effects)
+    rng = np.random.default_rng(seed)
+    indices = rng.permutation(n_samples)
+
+    test_indices = indices[:n_test]
+    train_indices = indices[n_test:]
+
+    train_images = [images[i] for i in train_indices]
+    train_masks = [masks[i] for i in train_indices]
+    test_images = [images[i] for i in test_indices]
+    test_masks = [masks[i] for i in test_indices]
+
+    print(f"Split: {len(train_images)} training, {len(test_images)} test samples")
+    return train_images, train_masks, test_images, test_masks
+
+
+def train_cellpose(
+    train_images: List[np.ndarray],
+    train_masks: List[np.ndarray],
+    test_images: Optional[List[np.ndarray]] = None,
+    test_masks: Optional[List[np.ndarray]] = None,
+    base_model: str = "cpsam",
+    n_epochs: int = 500,
+    learning_rate: float = 0.1,
+    weight_decay: float = 1e-5,
+    batch_size: int = 8,
+    save_path: Union[str, Path] = "models",
+    model_name: str = "cpsam_secondary_obj",
+    gpu: bool = True,
+    channels: List[int] = None,
+) -> models.CellposeModel:
+    """Fine-tune a Cellpose model on custom training data.
+
+    Args:
+        train_images (List[np.ndarray]): Training images (2D arrays).
+        train_masks (List[np.ndarray]): Training masks (labeled 2D arrays).
+        test_images (List[np.ndarray], optional): Test images for validation during
+            training.
+        test_masks (List[np.ndarray], optional): Test masks for validation.
+        base_model (str): Base model to fine-tune from. Options: "cpsam", "cyto3",
+            "cyto2", "nuclei".
+        n_epochs (int): Number of training epochs.
+        learning_rate (float): Initial learning rate.
+        weight_decay (float): L2 regularization weight.
+        batch_size (int): Training batch size.
+        save_path (str | Path): Directory to save trained model.
+        model_name (str): Name for the saved model.
+        gpu (bool): Use GPU acceleration if available.
+        channels (List[int], optional): Channel configuration for Cellpose.
+            Default [0, 0] for grayscale.
+
+    Returns:
+        model (CellposeModel): Trained Cellpose model.
+    """
+    save_path = Path(save_path)
+    save_path.mkdir(parents=True, exist_ok=True)
+
+    if channels is None:
+        channels = [0, 0]  # Grayscale
+
+    # Set up logging to see training progress
+    io.logger_setup()
+
+    print(f"Initializing model from base: {base_model}")
+    print(
+        f"Training parameters: epochs={n_epochs}, lr={learning_rate}, batch={batch_size}"
+    )
+
+    # Initialize model with version-aware helper (validates model compatibility)
+    model = create_cellpose_model(base_model, gpu=gpu)
+
+    print(f"Starting training with {len(train_images)} samples...")
+
+    # Cellpose 3.0+ uses train.train_seg() with pre-formatted images (no channels param).
+    model_path, train_losses, test_losses = train.train_seg(
+        model.net,
+        train_data=train_images,
+        train_labels=train_masks,
+        test_data=test_images,
+        test_labels=test_masks,
+        save_path=str(save_path),
+        n_epochs=n_epochs,
+        learning_rate=learning_rate,
+        weight_decay=weight_decay,
+        batch_size=batch_size,
+        model_name=model_name,
+    )
+
+    print(f"Training complete. Model saved to: {model_path}")
+
+    # Load and return the trained model
+    trained_model = models.CellposeModel(gpu=gpu, pretrained_model=model_path)
+    return trained_model
+
+
+def load_trained_model(
+    model_path: Union[str, Path],
+    gpu: bool = True,
+) -> models.CellposeModel:
+    """Load a fine-tuned Cellpose model.
+
+    Args:
+        model_path (str | Path): Path to saved model file.
+        gpu (bool): Use GPU acceleration.
+
+    Returns:
+        model (CellposeModel): Loaded Cellpose model ready for inference.
+    """
+    model = models.CellposeModel(gpu=gpu, pretrained_model=str(model_path))
+    print(f"Loaded model from: {model_path}")
+    return model
+
+
+def predict_masks(
+    model: models.CellposeModel,
+    images: List[np.ndarray],
+    diameter: Optional[float] = None,
+    flow_threshold: float = 0.4,
+    cellprob_threshold: float = 0.0,
+    channels: List[int] = None,
+) -> List[np.ndarray]:
+    """Run inference on images using a Cellpose model.
+
+    Args:
+        model (CellposeModel): Cellpose model (base or fine-tuned).
+        images (List[np.ndarray]): List of 2D images to segment.
+        diameter (float, optional): Expected object diameter. None for auto-estimation.
+        flow_threshold (float): Flow error threshold.
+        cellprob_threshold (float): Cell probability threshold.
+        channels (List[int], optional): Channel configuration. Default [0, 0] for
+            grayscale.
+
+    Returns:
+        masks (List[np.ndarray]): Predicted segmentation masks.
+    """
+    if channels is None:
+        channels = [0, 0]
+
+    masks, flows, styles = model.eval(
+        images,
+        diameter=diameter,
+        channels=channels,
+        flow_threshold=flow_threshold,
+        cellprob_threshold=cellprob_threshold,
+    )
+
+    return masks
+
+
+def calculate_iou(pred_mask: np.ndarray, gt_mask: np.ndarray) -> float:
+    """Calculate Intersection over Union between predicted and ground truth masks.
+
+    This computes the average IoU across all objects.
+
+    Args:
+        pred_mask (np.ndarray): Predicted labeled mask.
+        gt_mask (np.ndarray): Ground truth labeled mask.
+
+    Returns:
+        iou (float): Mean IoU score (0 to 1).
+    """
+    pred_binary = pred_mask > 0
+    gt_binary = gt_mask > 0
+
+    intersection = np.logical_and(pred_binary, gt_binary).sum()
+    union = np.logical_or(pred_binary, gt_binary).sum()
+
+    if union == 0:
+        return 1.0 if intersection == 0 else 0.0
+
+    return intersection / union
+
+
+def calculate_object_metrics(
+    pred_mask: np.ndarray,
+    gt_mask: np.ndarray,
+    iou_threshold: float = 0.5,
+) -> Dict[str, float]:
+    """Calculate object-level metrics (precision, recall, F1).
+
+    An object is considered a true positive if it overlaps with a ground truth
+    object with IoU >= threshold.
+
+    Args:
+        pred_mask (np.ndarray): Predicted labeled mask.
+        gt_mask (np.ndarray): Ground truth labeled mask.
+        iou_threshold (float): IoU threshold for matching objects.
+
+    Returns:
+        metrics (dict): Dictionary with 'precision', 'recall', 'f1', 'n_pred',
+            'n_gt', 'n_tp'.
+    """
+    pred_labels = np.unique(pred_mask[pred_mask > 0])
+    gt_labels = np.unique(gt_mask[gt_mask > 0])
+
+    n_pred = len(pred_labels)
+    n_gt = len(gt_labels)
+
+    if n_pred == 0 and n_gt == 0:
+        return {
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0,
+            "n_pred": 0,
+            "n_gt": 0,
+            "n_tp": 0,
+        }
+
+    if n_pred == 0:
+        return {
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": 0.0,
+            "n_pred": 0,
+            "n_gt": n_gt,
+            "n_tp": 0,
+        }
+
+    if n_gt == 0:
+        return {
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": 0.0,
+            "n_pred": n_pred,
+            "n_gt": 0,
+            "n_tp": 0,
+        }
+
+    # Match predictions to ground truth
+    matched_gt = set()
+    tp = 0
+
+    for pred_label in pred_labels:
+        pred_region = pred_mask == pred_label
+        best_iou = 0
+        best_gt = None
+
+        for gt_label in gt_labels:
+            if gt_label in matched_gt:
+                continue
+            gt_region = gt_mask == gt_label
+
+            intersection = np.logical_and(pred_region, gt_region).sum()
+            union = np.logical_or(pred_region, gt_region).sum()
+            iou = intersection / union if union > 0 else 0
+
+            if iou > best_iou:
+                best_iou = iou
+                best_gt = gt_label
+
+        if best_iou >= iou_threshold and best_gt is not None:
+            tp += 1
+            matched_gt.add(best_gt)
+
+    precision = tp / n_pred if n_pred > 0 else 0
+    recall = tp / n_gt if n_gt > 0 else 0
+    f1 = (
+        2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0
+    )
+
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "n_pred": n_pred,
+        "n_gt": n_gt,
+        "n_tp": tp,
+    }
+
+
+def evaluate_segmentation(
+    model: models.CellposeModel,
+    images: List[np.ndarray],
+    gt_masks: List[np.ndarray],
+    diameter: Optional[float] = None,
+    flow_threshold: float = 0.4,
+    cellprob_threshold: float = 0.0,
+    iou_threshold: float = 0.5,
+) -> Dict[str, float]:
+    """Evaluate model performance on a test set.
+
+    Args:
+        model (CellposeModel): Cellpose model to evaluate.
+        images (List[np.ndarray]): Test images.
+        gt_masks (List[np.ndarray]): Ground truth masks.
+        diameter (float, optional): Object diameter for inference.
+        flow_threshold (float): Flow threshold for inference.
+        cellprob_threshold (float): Cell probability threshold.
+        iou_threshold (float): IoU threshold for object matching.
+
+    Returns:
+        metrics (dict): Aggregated metrics: mean_iou, mean_precision, mean_recall,
+            mean_f1.
+    """
+    pred_masks = predict_masks(
+        model,
+        images,
+        diameter=diameter,
+        flow_threshold=flow_threshold,
+        cellprob_threshold=cellprob_threshold,
+    )
+
+    ious = []
+    precisions = []
+    recalls = []
+    f1s = []
+
+    for pred, gt in zip(pred_masks, gt_masks):
+        iou = calculate_iou(pred, gt)
+        metrics = calculate_object_metrics(pred, gt, iou_threshold)
+
+        ious.append(iou)
+        precisions.append(metrics["precision"])
+        recalls.append(metrics["recall"])
+        f1s.append(metrics["f1"])
+
+    return {
+        "mean_iou": np.mean(ious),
+        "mean_precision": np.mean(precisions),
+        "mean_recall": np.mean(recalls),
+        "mean_f1": np.mean(f1s),
+        "per_image_iou": ious,
+        "per_image_precision": precisions,
+        "per_image_recall": recalls,
+        "per_image_f1": f1s,
+    }
+
+
+def random_label_cmap(n_labels: int = 256, seed: int = 42) -> ListedColormap:
+    """Create a random colormap for labeled masks."""
+    rng = np.random.default_rng(seed)
+    colors = rng.random((n_labels, 3))
+    colors[0] = [0, 0, 0]  # Background is black
+    return ListedColormap(colors)
+
+
+def visualize_comparison(
+    image: np.ndarray,
+    pred_mask: np.ndarray,
+    gt_mask: np.ndarray,
+    title: str = "",
+    figsize: Tuple[int, int] = (15, 5),
+) -> plt.Figure:
+    """Visualize side-by-side comparison of prediction vs ground truth.
+
+    Args:
+        image (np.ndarray): Original image.
+        pred_mask (np.ndarray): Predicted segmentation mask.
+        gt_mask (np.ndarray): Ground truth mask.
+        title (str): Figure title.
+        figsize (Tuple[int, int]): Figure size.
+
+    Returns:
+        fig (plt.Figure): Matplotlib figure.
+    """
+    fig, axes = plt.subplots(1, 4, figsize=figsize)
+
+    # Original image
+    axes[0].imshow(image, cmap="gray")
+    axes[0].set_title("Original Image")
+    axes[0].axis("off")
+
+    # Ground truth
+    cmap = random_label_cmap(max(gt_mask.max(), pred_mask.max()) + 1)
+    axes[1].imshow(gt_mask, cmap=cmap, interpolation="nearest")
+    axes[1].set_title(f"Ground Truth ({gt_mask.max()} objects)")
+    axes[1].axis("off")
+
+    # Prediction
+    axes[2].imshow(pred_mask, cmap=cmap, interpolation="nearest")
+    axes[2].set_title(f"Prediction ({pred_mask.max()} objects)")
+    axes[2].axis("off")
+
+    # Overlay
+    overlay = np.zeros((*image.shape, 3))
+    overlay[..., 0] = image  # Red channel = image
+    overlay[..., 1] = (gt_mask > 0).astype(float) * 0.5  # Green = GT
+    overlay[..., 2] = (pred_mask > 0).astype(float) * 0.5  # Blue = prediction
+    axes[3].imshow(np.clip(overlay, 0, 1))
+    axes[3].set_title("Overlay (G=GT, B=Pred)")
+    axes[3].axis("off")
+
+    # Calculate metrics
+    iou = calculate_iou(pred_mask, gt_mask)
+    metrics = calculate_object_metrics(pred_mask, gt_mask)
+
+    fig.suptitle(
+        f"{title}\nIoU: {iou:.3f} | Precision: {metrics['precision']:.3f} | "
+        f"Recall: {metrics['recall']:.3f} | F1: {metrics['f1']:.3f}",
+        fontsize=12,
+    )
+
+    plt.tight_layout()
+    return fig
+
+
+def visualize_training_sample(
+    image: np.ndarray,
+    mask: np.ndarray,
+    title: str = "",
+    figsize: Tuple[int, int] = (10, 5),
+) -> plt.Figure:
+    """Visualize a single training sample (image + mask).
+
+    Args:
+        image (np.ndarray): Training image.
+        mask (np.ndarray): Corresponding mask.
+        title (str): Figure title.
+        figsize (Tuple[int, int]): Figure size.
+
+    Returns:
+        fig (plt.Figure): Matplotlib figure.
+    """
+    fig, axes = plt.subplots(1, 2, figsize=figsize)
+
+    axes[0].imshow(image, cmap="gray")
+    axes[0].set_title("Image")
+    axes[0].axis("off")
+
+    cmap = random_label_cmap(mask.max() + 1)
+    axes[1].imshow(mask, cmap=cmap, interpolation="nearest")
+    axes[1].set_title(f"Mask ({mask.max()} objects)")
+    axes[1].axis("off")
+
+    if title:
+        fig.suptitle(title)
+
+    plt.tight_layout()
+    return fig

--- a/workflow/lib/shared/compartment_utils.py
+++ b/workflow/lib/shared/compartment_utils.py
@@ -1,0 +1,183 @@
+"""Helpers for optional compartment-specific pipeline outputs."""
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def get_default_compartment_combo(second_obj_detection: bool) -> str:
+    """Return the all-compartments combo for the configured phenotype run.
+
+    Args:
+        second_obj_detection: Whether secondary-object detection is enabled.
+
+    Returns:
+        The hyphen-delimited all-compartments combo.
+    """
+    compartments = ["cell", "nucleus", "cytoplasm"]
+    if second_obj_detection:
+        compartments.append("second_obj")
+    return "-".join(compartments)
+
+
+def normalize_compartment_combo_table(
+    combos: pd.DataFrame,
+    split_by_compartment: bool,
+    default_compartment_combo: str,
+) -> pd.DataFrame:
+    """Normalize a wildcard-combo table for the configured path mode.
+
+    Args:
+        combos: Aggregate or cluster wildcard combinations.
+        split_by_compartment: Whether compartment-specific paths are enabled.
+        default_compartment_combo: Combo used when paths are not compartment-specific
+            or the input table omits the column.
+
+    Returns:
+        A normalized copy of ``combos`` with a ``compartment_combo`` column.
+    """
+    normalized = combos.copy()
+    if not split_by_compartment or "compartment_combo" not in normalized.columns:
+        normalized["compartment_combo"] = default_compartment_combo
+    return normalized.drop_duplicates().reset_index(drop=True)
+
+
+def normalize_compartment_records(
+    records: list[dict],
+    split_by_compartment: bool,
+    default_compartment_combo: str,
+) -> list[dict]:
+    """Normalize compartment values in config records and remove duplicates.
+
+    Args:
+        records: Configuration records, such as bootstrap combinations.
+        split_by_compartment: Whether compartment-specific paths are enabled.
+        default_compartment_combo: Combo used when paths are not compartment-specific
+            or a record omits the value.
+
+    Returns:
+        Normalized records in their original order.
+    """
+    normalized_records = []
+    for record in records:
+        normalized = dict(record)
+        if not split_by_compartment or not normalized.get("compartment_combo"):
+            normalized["compartment_combo"] = default_compartment_combo
+        if normalized not in normalized_records:
+            normalized_records.append(normalized)
+    return normalized_records
+
+
+def get_compartment_combo(
+    wildcards,
+    split_by_compartment: bool,
+    default_compartment_combo: str,
+) -> str:
+    """Resolve a compartment combo without requiring an off-mode wildcard.
+
+    Args:
+        wildcards: Snakemake wildcards for the current job.
+        split_by_compartment: Whether compartment-specific paths are enabled.
+        default_compartment_combo: Combo to use when splitting is disabled.
+
+    Returns:
+        The wildcard value when splitting is enabled, otherwise the default combo.
+    """
+    if split_by_compartment:
+        return wildcards.compartment_combo
+    return default_compartment_combo
+
+
+def format_rule_output(
+    output,
+    wildcards,
+    split_by_compartment: bool,
+    default_compartment_combo: str,
+    **values,
+):
+    """Format a target-path template with the current rule's wildcards.
+
+    Fills cell_class, channel_combo, and the resolved compartment_combo (plus any extra
+    values), so rule input functions can resolve sibling output paths without defining
+    helpers in the .smk files.
+
+    Args:
+        output: A target-path template (str or Path) containing named fields.
+        wildcards: Snakemake wildcards for the current job.
+        split_by_compartment: Whether compartment-specific paths are enabled.
+        default_compartment_combo: Combo to use when splitting is disabled.
+        **values: Additional template fields to fill (e.g. gene, construct).
+
+    Returns:
+        The formatted path string.
+    """
+    return str(output).format(
+        cell_class=wildcards.cell_class,
+        channel_combo=wildcards.channel_combo,
+        compartment_combo=get_compartment_combo(
+            wildcards, split_by_compartment, default_compartment_combo
+        ),
+        **values,
+    )
+
+
+def add_compartment_metadata(
+    metadata: dict,
+    compartment_combo: str,
+    split_by_compartment: bool,
+) -> dict:
+    """Add filename metadata only for compartment-specific paths.
+
+    Args:
+        metadata: Existing filename metadata.
+        compartment_combo: Compartment value or wildcard template.
+        split_by_compartment: Whether compartment-specific paths are enabled.
+
+    Returns:
+        A copy of ``metadata`` with optional compartment metadata.
+    """
+    resolved = dict(metadata)
+    if split_by_compartment:
+        resolved["compartment_combo"] = compartment_combo
+    return resolved
+
+
+def add_compartment_path(
+    base_path: str | Path,
+    compartment_combo: str,
+    split_by_compartment: bool,
+) -> Path:
+    """Append a compartment directory only when splitting is enabled.
+
+    Args:
+        base_path: Path before the optional compartment segment.
+        compartment_combo: Compartment value or wildcard template.
+        split_by_compartment: Whether compartment-specific paths are enabled.
+
+    Returns:
+        The path with the optional compartment directory.
+    """
+    base_path = Path(base_path)
+    if split_by_compartment:
+        return base_path / compartment_combo
+    return base_path
+
+
+def add_compartment_suffix(
+    stem: str,
+    compartment_combo: str,
+    split_by_compartment: bool,
+) -> str:
+    """Append a delimiter-safe compartment suffix to a bootstrap stem.
+
+    Args:
+        stem: Bootstrap path stem before the optional compartment value.
+        compartment_combo: Compartment value or wildcard template.
+        split_by_compartment: Whether compartment-specific paths are enabled.
+
+    Returns:
+        ``stem`` with ``__{compartment_combo}`` appended only when enabled.
+    """
+    if split_by_compartment:
+        return f"{stem}__{compartment_combo}"
+    return stem

--- a/workflow/lib/shared/file_utils.py
+++ b/workflow/lib/shared/file_utils.py
@@ -20,6 +20,7 @@ FILENAME_METADATA_MAPPING = {
     "round": ["R-", str],
     "cell_class": ["CeCl-", str],
     "channel_combo": ["ChCo-", str],
+    "compartment_combo": ["CmCo-", str],
     "gene": ["G-", str],
     "sgrna": ["SG-", str],
     "channel": ["CH-", str],
@@ -523,3 +524,26 @@ def validate_data_type(data_type):
     if data_type not in valid_types:
         raise ValueError(f"data_type must be one of {valid_types}, got '{data_type}'")
     return data_type
+
+
+def read_tsv_safe(filepath, return_empty_on_error=True):
+    """Read a TSV file safely with error handling.
+
+    Args:
+        filepath (str or Path): Path to the TSV file to read.
+        return_empty_on_error (bool, optional): If True, return empty DataFrame on
+            EmptyDataError. If False, return None on EmptyDataError. Default: True.
+
+    Returns:
+        pd.DataFrame or None: DataFrame if file read successfully or is empty (when
+            return_empty_on_error=True). None if file is empty and
+            return_empty_on_error=False.
+
+    Examples:
+        >>> df = read_tsv_safe('data.tsv')
+        >>> df = read_tsv_safe('data.tsv', return_empty_on_error=False)
+    """
+    try:
+        return pd.read_csv(filepath, sep="\t")
+    except pd.errors.EmptyDataError:
+        return pd.DataFrame() if return_empty_on_error else None

--- a/workflow/lib/shared/metrics.py
+++ b/workflow/lib/shared/metrics.py
@@ -6,10 +6,16 @@ import numpy as np
 import json
 import sys
 import io
-from scipy import stats
 import pyarrow.parquet as pq
-import pyarrow.dataset as ds
 import warnings
+
+from lib.shared.compartment_utils import (
+    add_compartment_metadata,
+    add_compartment_path,
+    get_default_compartment_combo,
+    normalize_compartment_combo_table,
+)
+from lib.shared.file_utils import get_filename
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -137,7 +143,7 @@ def get_phenotype_stats(config):
     Returns:
         dict: Statistics including total cells and feature count
     """
-    from lib.aggregate.cell_data_utils import DEFAULT_METADATA_COLS
+    from lib.phenotype.constants import DEFAULT_METADATA_COLS
 
     # Extract paths from config
     root_fp = Path(config["all"]["root_fp"])
@@ -298,17 +304,27 @@ def get_aggregate_stats(config, n_rows=10000, include_batch_effects=False):
         include_batch_effects: Whether to calculate batch effect metrics (slow)
 
     Returns:
-        dict: Dictionary with statistics for each cell_class/channel_combo combination
+        dict: Dictionary with statistics for each cell_class/channel_combo/compartment_combo combination
     """
     root_fp = Path(config["all"]["root_fp"])
     aggregate_dir = root_fp / "aggregate"
 
     # Load the aggregate combo TSV file from config
     aggregate_combo_fp = Path(config["aggregate"]["aggregate_combo_fp"])
-    aggregate_combos = pd.read_csv(aggregate_combo_fp, sep="\t")
+    split_by_compartment = config["aggregate"].get("split_by_compartment", False)
+    default_compartment_combo = get_default_compartment_combo(
+        config.get("phenotype", {}).get("second_obj_detection", False)
+    )
+    aggregate_combos = normalize_compartment_combo_table(
+        pd.read_csv(aggregate_combo_fp, sep="\t"),
+        split_by_compartment,
+        default_compartment_combo,
+    )
 
-    # Get unique cell_class and channel_combo combinations
-    unique_combos = aggregate_combos[["cell_class", "channel_combo"]].drop_duplicates()
+    # Get unique cell_class, channel_combo, and compartment_combo combinations
+    unique_combos = aggregate_combos[
+        ["cell_class", "channel_combo", "compartment_combo"]
+    ].drop_duplicates()
 
     # Get perturbation column name from config
     perturbation_col = config["aggregate"].get("perturbation_name_col", "gene_symbol_0")
@@ -319,23 +335,34 @@ def get_aggregate_stats(config, n_rows=10000, include_batch_effects=False):
     for _, combo in unique_combos.iterrows():
         cell_class = combo["cell_class"]
         channel_combo = combo["channel_combo"]
+        compartment_combo = combo["compartment_combo"]
 
         try:
             result = _get_single_aggregate_stats(
                 config,
                 cell_class,
                 channel_combo,
+                compartment_combo,
                 n_rows,
                 root_fp,
                 aggregate_dir,
                 perturbation_col,
                 control_key,
                 include_batch_effects,
+                split_by_compartment,
             )
-            all_results[f"{cell_class}_{channel_combo}"] = result
+            result_key = f"{cell_class}_{channel_combo}"
+            if split_by_compartment:
+                result_key = f"{result_key}_{compartment_combo}"
+            all_results[result_key] = result
         except Exception as e:
-            print(f"Error processing {cell_class}/{channel_combo}: {str(e)}")
-            all_results[f"{cell_class}_{channel_combo}"] = {"error": str(e)}
+            result_key = f"{cell_class}_{channel_combo}"
+            result_label = f"{cell_class}/{channel_combo}"
+            if split_by_compartment:
+                result_key = f"{result_key}_{compartment_combo}"
+                result_label = f"{result_label}/{compartment_combo}"
+            print(f"Error processing {result_label}: {str(e)}")
+            all_results[result_key] = {"error": str(e)}
 
     return all_results
 
@@ -344,21 +371,24 @@ def _get_single_aggregate_stats(
     config,
     cell_class,
     channel_combo,
+    compartment_combo,
     n_rows,
     root_fp,
     aggregate_dir,
     perturbation_col,
     control_key,
     include_batch_effects,
+    split_by_compartment,
 ):
-    """Helper function to get stats for a single cell_class/channel_combo combination."""
-    from lib.shared.file_utils import load_parquet_subset
-
+    """Helper function to get stats for a single cell_class/channel_combo/compartment_combo combination."""
     # Load the aggregated TSV file
+    data_location = add_compartment_metadata(
+        {"cell_class": cell_class, "channel_combo": channel_combo},
+        compartment_combo,
+        split_by_compartment,
+    )
     aggregated_path = (
-        aggregate_dir
-        / "tsvs"
-        / f"CeCl-{cell_class}_ChCo-{channel_combo}__aggregated.tsv"
+        aggregate_dir / "tsvs" / get_filename(data_location, "aggregated", "tsv")
     )
     aggregated = pd.read_csv(aggregated_path, sep="\t")
 
@@ -376,10 +406,13 @@ def _get_single_aggregate_stats(
     # Count total cells from merge_data parquets (pre-filter)
     # Use direct path instead of recursive glob for speed
     merge_data_dir = aggregate_dir / "parquets"
+    well_data_location = {
+        "plate": "*",
+        "well": "*",
+        **data_location,
+    }
     merge_data_paths = list(
-        merge_data_dir.glob(
-            f"*_CeCl-{cell_class}_ChCo-{channel_combo}__merge_data.parquet"
-        )
+        merge_data_dir.glob(get_filename(well_data_location, "merge_data", "parquet"))
     )
 
     total_pre_filtered_cells = 0
@@ -390,7 +423,7 @@ def _get_single_aggregate_stats(
     # Count filtered cells from parquet metadata (fast)
     filtered_dir = aggregate_dir / "parquets"
     filtered_paths = list(
-        filtered_dir.glob(f"*_CeCl-{cell_class}_ChCo-{channel_combo}__filtered.parquet")
+        filtered_dir.glob(get_filename(well_data_location, "filtered", "parquet"))
     )
 
     total_filtered_cells = 0
@@ -414,10 +447,12 @@ def _get_single_aggregate_stats(
             config,
             cell_class,
             channel_combo,
+            compartment_combo,
             n_rows,
             aggregate_dir,
             perturbation_col,
             control_key,
+            split_by_compartment,
         )
         result.update(batch_stats)
 
@@ -428,20 +463,33 @@ def _calculate_batch_effects(
     config,
     cell_class,
     channel_combo,
+    compartment_combo,
     n_rows,
     aggregate_dir,
     perturbation_col,
     control_key,
+    split_by_compartment,
 ):
     """Calculate batch effect metrics (pre/post alignment)."""
-    from lib.aggregate.cell_data_utils import DEFAULT_METADATA_COLS, control_mask
+    from lib.aggregate.cell_data_utils import control_mask
+    from lib.phenotype.constants import DEFAULT_METADATA_COLS
     from lib.shared.file_utils import load_parquet_subset
     from sklearn.feature_selection import f_classif
 
     filtered_dir = aggregate_dir / "parquets"
     # Use direct path instead of recursive glob for speed
+    data_location = add_compartment_metadata(
+        {
+            "plate": "*",
+            "well": "*",
+            "cell_class": cell_class,
+            "channel_combo": channel_combo,
+        },
+        compartment_combo,
+        split_by_compartment,
+    )
     filtered_paths = list(
-        filtered_dir.glob(f"*_CeCl-{cell_class}_ChCo-{channel_combo}__filtered.parquet")
+        filtered_dir.glob(get_filename(data_location, "filtered", "parquet"))
     )
 
     # Load filtered data - sample from a subset of files to avoid
@@ -503,10 +551,15 @@ def _calculate_batch_effects(
     pre_align_p_median = np.median(valid_p_vals) if len(valid_p_vals) > 0 else np.nan
 
     # Post-alignment batch effects
+    aligned_location = add_compartment_metadata(
+        {"cell_class": cell_class, "channel_combo": channel_combo},
+        compartment_combo,
+        split_by_compartment,
+    )
     aligned_path = (
         aggregate_dir
         / "parquets"
-        / f"CeCl-{cell_class}_ChCo-{channel_combo}__aligned.parquet"
+        / get_filename(aligned_location, "aligned", "parquet")
     )
 
     # Use same sample size as pre-alignment for consistency
@@ -560,17 +613,33 @@ def get_cluster_stats(config):
 
     # Read the cluster_combos.tsv file from config
     cluster_combo_fp = Path(config["cluster"]["cluster_combo_fp"])
-    cluster_combos = pd.read_csv(cluster_combo_fp, sep="\t")
+    split_by_compartment = config.get("aggregate", {}).get(
+        "split_by_compartment", False
+    )
+    default_compartment_combo = get_default_compartment_combo(
+        config.get("phenotype", {}).get("second_obj_detection", False)
+    )
+    cluster_combos = normalize_compartment_combo_table(
+        pd.read_csv(cluster_combo_fp, sep="\t"),
+        split_by_compartment,
+        default_compartment_combo,
+    )
 
     results = []
 
     for _, row in cluster_combos.iterrows():
         cell_class = row["cell_class"]
         channel_combo = row["channel_combo"]
+        compartment_combo = row["compartment_combo"]
         leiden_resolution = row["leiden_resolution"]
 
+        cluster_specific_dir = add_compartment_path(
+            cluster_dir / channel_combo,
+            compartment_combo,
+            split_by_compartment,
+        )
         cluster_specific_dir = (
-            cluster_dir / channel_combo / cell_class / str(leiden_resolution)
+            cluster_specific_dir / cell_class / str(leiden_resolution)
         )
 
         # Path to metrics files
@@ -624,6 +693,8 @@ def get_cluster_stats(config):
                     "true_positives", 0
                 ),
             }
+            if split_by_compartment:
+                result["compartment_combo"] = compartment_combo
 
             # Read shuffled metrics if available
             if shuffled_metrics_path.exists():
@@ -642,9 +713,10 @@ def get_cluster_stats(config):
             results.append(result)
 
         except Exception as e:
-            print(
-                f"Error reading metrics for {cell_class}/{channel_combo}/{leiden_resolution}: {e}"
-            )
+            result_label = f"{cell_class}/{channel_combo}"
+            if split_by_compartment:
+                result_label = f"{result_label}/{compartment_combo}"
+            print(f"Error reading metrics for {result_label}/{leiden_resolution}: {e}")
 
     results_df = pd.DataFrame(results)
 
@@ -814,9 +886,10 @@ def get_all_stats(
 
     if not stats["cluster"]["detailed_results"].empty:
         for _, row in stats["cluster"]["detailed_results"].iterrows():
-            print(
-                f"\n   {row['cell_class']} - {row['channel_combo']} (resolution={row['leiden_resolution']}):"
-            )
+            combo_label = f"{row['cell_class']} - {row['channel_combo']}"
+            if "compartment_combo" in row:
+                combo_label = f"{combo_label} - {row['compartment_combo']}"
+            print(f"\n   {combo_label} (resolution={row['leiden_resolution']}):")
             print(f"      - Clusters: {row['unique_clusters']}")
             print(
                 f"      - CORUM enriched: {row['corum_enriched']} ({row['corum_proportion']:.1%})"

--- a/workflow/lib/shared/rule_utils.py
+++ b/workflow/lib/shared/rule_utils.py
@@ -6,8 +6,6 @@ import glob
 from typing import Dict, List, Any, Union
 import pandas as pd
 
-from lib.shared.file_utils import parse_filename
-
 
 def get_alignment_params(wildcards, config: Dict[str, Any]) -> Dict[str, Any]:
     """Get alignment parameters for a specific plate.
@@ -314,6 +312,8 @@ def get_bootstrap_inputs(
     gene_pvals_pattern: Union[str, Path],
     cell_class: str,
     channel_combo: str,
+    compartment_combo: str,
+    split_by_compartment: bool,
 ) -> List[str]:
     """Get all bootstrap inputs for completion flag.
 
@@ -325,14 +325,20 @@ def get_bootstrap_inputs(
         gene_pvals_pattern (Union[str, Path]): Template string for gene p-value files.
         cell_class (str): Cell class for bootstrap analysis.
         channel_combo (str): Channel combination for bootstrap analysis.
+        compartment_combo (str): Compartment combination for bootstrap analysis.
+        split_by_compartment (bool): Whether compartment-specific paths are enabled.
 
     Returns:
         List[str]: List of all bootstrap output file paths for both constructs and genes.
     """
     # Get all construct data files from checkpoint
-    bootstrap_data_dir = checkpoint.get(
-        cell_class=cell_class, channel_combo=channel_combo
-    ).output[0]
+    checkpoint_wildcards = {
+        "cell_class": cell_class,
+        "channel_combo": channel_combo,
+    }
+    if split_by_compartment:
+        checkpoint_wildcards["compartment_combo"] = compartment_combo
+    bootstrap_data_dir = checkpoint.get(**checkpoint_wildcards).output[0]
 
     construct_files = glob.glob(f"{bootstrap_data_dir}/*__construct_data.tsv")
 
@@ -363,12 +369,14 @@ def get_bootstrap_inputs(
                 str(construct_nulls_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),
                 str(construct_pvals_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),
@@ -381,10 +389,16 @@ def get_bootstrap_inputs(
             outputs.extend(
                 [
                     str(gene_nulls_pattern).format(
-                        cell_class=cell_class, channel_combo=channel_combo, gene=gene
+                        cell_class=cell_class,
+                        channel_combo=channel_combo,
+                        compartment_combo=compartment_combo,
+                        gene=gene,
                     ),
                     str(gene_pvals_pattern).format(
-                        cell_class=cell_class, channel_combo=channel_combo, gene=gene
+                        cell_class=cell_class,
+                        channel_combo=channel_combo,
+                        compartment_combo=compartment_combo,
+                        gene=gene,
                     ),
                 ]
             )
@@ -398,6 +412,8 @@ def get_bootstrap_construct_outputs(
     construct_pvals_pattern: Union[str, Path],
     cell_class: str,
     channel_combo: str,
+    compartment_combo: str,
+    split_by_compartment: bool,
 ) -> List[str]:
     """Get all construct bootstrap outputs for completion flag.
 
@@ -411,6 +427,9 @@ def get_bootstrap_construct_outputs(
         cell_class (str): Cell class identifier for bootstrap analysis (e.g., 'live', 'dead').
         channel_combo (str): Channel combination identifier for bootstrap analysis
             (e.g., 'dapi_tubulin', 'all_channels').
+        compartment_combo (str): Compartment combination identifier for bootstrap analysis
+            (e.g., 'cell-nucleus-cytoplasm', 'nucleus').
+        split_by_compartment (bool): Whether compartment-specific paths are enabled.
 
     Returns:
         List[str]: List of all construct bootstrap output file paths, including both
@@ -418,9 +437,13 @@ def get_bootstrap_construct_outputs(
             the checkpoint directory.
     """
     # Get all construct data files from checkpoint
-    bootstrap_data_dir = checkpoint.get(
-        cell_class=cell_class, channel_combo=channel_combo
-    ).output[0]
+    checkpoint_wildcards = {
+        "cell_class": cell_class,
+        "channel_combo": channel_combo,
+    }
+    if split_by_compartment:
+        checkpoint_wildcards["compartment_combo"] = compartment_combo
+    bootstrap_data_dir = checkpoint.get(**checkpoint_wildcards).output[0]
 
     construct_files = glob.glob(f"{bootstrap_data_dir}/*__construct_data.tsv")
 
@@ -450,12 +473,14 @@ def get_bootstrap_construct_outputs(
                 str(construct_nulls_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),
                 str(construct_pvals_pattern).format(
                     cell_class=cell_class,
                     channel_combo=channel_combo,
+                    compartment_combo=compartment_combo,
                     gene=gene,
                     construct=construct,
                 ),

--- a/workflow/lib/shared/segment_cellpose.py
+++ b/workflow/lib/shared/segment_cellpose.py
@@ -54,8 +54,8 @@ except (AttributeError, ValueError):
 CELLPOSE_4X = CELLPOSE_VERSION >= (4, 0)
 
 
-def initialize_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
-    """Initialize a CellposeModel with version-aware configuration.
+def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
+    r"""Create a CellposeModel with version-aware initialization.
 
     Handles differences between Cellpose 3.x and 4.x APIs and validates
     model compatibility with the installed Cellpose version.
@@ -65,7 +65,7 @@ def initialize_cellpose_model(model_type: str, gpu: bool = False) -> CellposeMod
             or a path to a custom trained model (e.g., 'models/my_custom_model').
             - Cellpose 3.x: Supports 'cyto3', 'nuclei', 'cyto2'
             - Cellpose 4.x: Only supports 'cpsam'
-            - Custom model paths (containing path separators) are supported in both versions
+            - Custom model paths (containing '/' or '\\') are supported in both versions
         gpu (bool, optional): Whether to use GPU for inference. Default is False.
 
     Returns:
@@ -434,8 +434,8 @@ def segment_cellpose_rgb(
     # Create Cellpose models using version-aware helper
     # Nuclei model: "cpsam" for 4.x, "nuclei" for 3.x
     nuclei_model_type = "cpsam" if CELLPOSE_4X else "nuclei"
-    model_dapi = initialize_cellpose_model(nuclei_model_type, gpu=gpu)
-    model_cyto = initialize_cellpose_model(cellpose_model, gpu=gpu)
+    model_dapi = create_cellpose_model(nuclei_model_type, gpu=gpu)
+    model_cyto = create_cellpose_model(cellpose_model, gpu=gpu)
 
     # Set default kwargs if not provided
     if nuclei_kwargs is None:
@@ -533,7 +533,7 @@ def segment_cellpose_nuclei_rgb(
         numpy.ndarray: Labeled segmentation mask of nuclei.
     """
     # Create Cellpose model using version-aware helper
-    model = initialize_cellpose_model(cellpose_model, gpu=gpu)
+    model = create_cellpose_model(cellpose_model, gpu=gpu)
 
     # Segment nuclei using CellposeModel from the RGB image
     # Pass only blue channel (DAPI) for nuclei segmentation

--- a/workflow/lib/shared/target_utils.py
+++ b/workflow/lib/shared/target_utils.py
@@ -240,7 +240,7 @@ def get_merge_targets_by_approach(config):
 def map_wildcard_outputs(wildcard_combos_df, output_template, wildcards_to_map):
     """Map specified wildcards in a template string using values from a DataFrame.
 
-    Given a template path and a list of wildcards to map (e.g. ["cell_class", "channel_combo"]),
+    Given a template path and a list of wildcards to map (e.g. ["cell_class", "channel_combo", "compartment_combo"]),
     replaces only those placeholders with values from the DataFrame, leaving others untouched.
     Useful for creating lists of output paths where we need to fill in some wildcards but not others.
 

--- a/workflow/rules/aggregate.smk
+++ b/workflow/rules/aggregate.smk
@@ -1,18 +1,47 @@
+from lib.shared.compartment_utils import get_compartment_combo, format_rule_output
 from lib.shared.target_utils import output_to_input, map_wildcard_outputs
 from lib.shared.rule_utils import get_montage_inputs, get_bootstrap_inputs, get_bootstrap_construct_outputs
+
+
+# Aggregate secondary object features into cell-level data
+SECOND_OBJ_DETECTION = config.get("phenotype", {}).get("second_obj_detection", False)
+# phenotype well-level paths nest by row/col in zarr mode; aggregate rules are keyed by plate/well
+_agg_well_expand = ["row", "col"] if IMG_FMT == "zarr" else []
+
+
+if SECOND_OBJ_DETECTION:
+    rule aggregate_cells_second_objs:
+        input:
+            ancient(MERGE_OUTPUTS["final_merge"]),
+            ancient(lambda wildcards: output_to_input(
+                PHENOTYPE_OUTPUTS["merge_phenotype_second_objs"][0],
+                wildcards={"plate": wildcards.plate, "well": wildcards.well},
+                expansion_values=_agg_well_expand,
+                metadata_combos=merge_wildcard_combos,
+            )),
+        output:
+            AGGREGATE_OUTPUTS_MAPPED["aggregate_cells_second_objs"],
+        params:
+            agg_strategy=config.get("aggregate", {}).get(
+                "second_obj_agg_strategy", "none"
+            ),
+        script:
+            "../scripts/aggregate/aggregate_cells_second_objs.py"
 
 
 # Create datasets with cell classes and channel combos
 rule split_datasets:
     input:
-        # final merge data
-        ancient(MERGE_OUTPUTS["final_merge"]),
+        # cell data (with or without secondary object features)
+        ancient(AGGREGATE_OUTPUTS["aggregate_cells_second_objs"])
+        if SECOND_OBJ_DETECTION
+        else ancient(MERGE_OUTPUTS["final_merge"]),
     priority: 100
     output:
         map_wildcard_outputs(
             aggregate_wildcard_combos,
             AGGREGATE_OUTPUTS["split_datasets"][0],
-            ["cell_class", "channel_combo"],
+            ["cell_class", "channel_combo", "compartment_combo"],
         ),
     params:
         all_channels=config.get("phenotype", {}).get("channel_names"),
@@ -23,8 +52,8 @@ rule split_datasets:
         class_mapping=config.get("classify", {}).get("class_mapping"),
         well_annotations_fp=config.get("aggregate", {}).get("well_annotations_fp"),
         split_col=config.get("aggregate", {}).get("split_col", "class"),
-        cell_classes=aggregate_wildcard_combos["cell_class"].unique(),
-        channel_combos=aggregate_wildcard_combos["channel_combo"].unique(),
+        aggregate_wildcard_combos=aggregate_wildcard_combos,
+        split_by_compartment=SPLIT_BY_COMPARTMENT,
     script:
         "../scripts/aggregate/split_datasets.py"
 
@@ -61,6 +90,9 @@ rule generate_feature_table:
             wildcards={
                 "cell_class": wildcards.cell_class,
                 "channel_combo": wildcards.channel_combo,
+                "compartment_combo": get_compartment_combo(
+                    wildcards, SPLIT_BY_COMPARTMENT, DEFAULT_COMPARTMENT_COMBO
+                ),
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -75,10 +107,12 @@ rule generate_feature_table:
         perturbation_id_col=config.get("aggregate", {}).get("perturbation_id_col"),
         group_cols=config.get("aggregate", {}).get("group_cols", []),
         control_key=config.get("aggregate", {}).get("control_key"),
+        control_name_col=config.get("aggregate", {}).get("control_name_col"),
         batch_cols=config.get("aggregate", {}).get("batch_cols", ["plate", "well"]),
         num_align_batches=config.get("aggregate", {}).get("num_align_batches", 1),
         feature_normalization=config.get("aggregate", {}).get("feature_normalization", "standard"),
         pseudogene_patterns=config.get("aggregate", {}).get("pseudogene_patterns", None),
+        drop_cols_threshold=config.get("aggregate", {}).get("drop_cols_threshold"),
     script:
         "../scripts/aggregate/generate_feature_table.py"
 
@@ -90,6 +124,9 @@ rule align:
             wildcards={
                 "cell_class": wildcards.cell_class,
                 "channel_combo": wildcards.channel_combo,
+                "compartment_combo": get_compartment_combo(
+                    wildcards, SPLIT_BY_COMPARTMENT, DEFAULT_COMPARTMENT_COMBO
+                ),
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -108,6 +145,7 @@ rule align:
         num_align_batches=config.get("aggregate", {}).get("num_align_batches", 1),
         skip_perturbation_score=config.get("aggregate", {}).get("skip_perturbation_score", True),
         control_name_col=config.get("aggregate", {}).get("control_name_col"),
+        drop_cols_threshold=config.get("aggregate", {}).get("drop_cols_threshold"),
     script:
         "../scripts/aggregate/align.py"
 
@@ -126,6 +164,7 @@ rule aggregate:
         agg_method=config.get("aggregate", {}).get("agg_method", "median"),
         ps_probability_threshold=config.get("aggregate", {}).get("ps_probability_threshold"),
         ps_percentile_threshold=config.get("aggregate", {}).get("ps_percentile_threshold"),
+        control_name_col=config.get("aggregate", {}).get("control_name_col"),
     script:
         "../scripts/aggregate/aggregate.py"
 
@@ -140,6 +179,9 @@ rule eval_aggregate:
             wildcards={
                 "cell_class": wildcards.cell_class,
                 "channel_combo": wildcards.channel_combo,
+                "compartment_combo": get_compartment_combo(
+                    wildcards, SPLIT_BY_COMPARTMENT, DEFAULT_COMPARTMENT_COMBO
+                ),
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -147,6 +189,10 @@ rule eval_aggregate:
     priority: 100
     output:
         AGGREGATE_OUTPUTS_MAPPED["eval_aggregate"],
+    params:
+        compartment_combo=lambda wildcards: get_compartment_combo(
+            wildcards, SPLIT_BY_COMPARTMENT, DEFAULT_COMPARTMENT_COMBO
+        ),
     script:
         "../scripts/aggregate/eval_aggregate.py"
 
@@ -165,9 +211,8 @@ checkpoint prepare_montage_data:
             AGGREGATE_OUTPUTS["filter"],
             wildcards={
                 "cell_class": wildcards.cell_class,
-                "channel_combo": aggregate_wildcard_combos["channel_combo"].unique()[
-                    0
-                ],
+                "channel_combo": aggregate_wildcard_combos["channel_combo"].iloc[0],
+                "compartment_combo": aggregate_wildcard_combos["compartment_combo"].iloc[0],
             },
             expansion_values=["plate", "well"],
             metadata_combos=aggregate_wildcard_combos,
@@ -192,7 +237,7 @@ if IMG_FMT == "zarr":
             touch(MONTAGE_OUTPUTS["montage_crop_flag"]),
         params:
             img_fmt="zarr",
-            channels=config["phenotype"]["channel_names"],
+            channels=config.get("phenotype", {}).get("channel_names"),
             examples_zarr_root=lambda wildcards: str(
                 MONTAGE_OUTPUTS["examples_zarr"]
             ).format(cell_class=wildcards.cell_class),
@@ -226,7 +271,7 @@ else:
                 cell_class="{cell_class}",
                 gene="{gene}",
                 sgrna="{sgrna}",
-                channel=config["phenotype"]["channel_names"],
+                channel=config.get("phenotype", {}).get("channel_names"),
             )
             + [
                 str(MONTAGE_OUTPUTS["montage_overlay"]).format(
@@ -235,7 +280,7 @@ else:
             ],
         params:
             img_fmt="tiff",
-            channels=config["phenotype"]["channel_names"],
+            channels=config.get("phenotype", {}).get("channel_names"),
             montage_cell_size=config["aggregate"].get("montage_cell_size", 40),
             montage_shape=config["aggregate"].get("montage_shape", [3, 10]),
         script:
@@ -247,7 +292,7 @@ else:
                 checkpoints.prepare_montage_data,
                 MONTAGE_OUTPUTS["montage"],
                 MONTAGE_OUTPUTS["montage_overlay"],
-                config["phenotype"]["channel_names"],
+                config.get("phenotype", {}).get("channel_names"),
                 wildcards.cell_class,
             ),
         priority: 50
@@ -266,14 +311,23 @@ else:
 # Prepare bootstrap data and create checkpoint
 checkpoint prepare_bootstrap_data:
     input:
-        features_singlecell=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][0]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+        features_singlecell=lambda wildcards: format_rule_output(
+            AGGREGATE_OUTPUTS["generate_feature_table"][0],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
         ),
-        construct_table=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][1]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+        construct_table=lambda wildcards: format_rule_output(
+            AGGREGATE_OUTPUTS["generate_feature_table"][1],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
         ),
-        gene_table=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][2]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+        gene_table=lambda wildcards: format_rule_output(
+            AGGREGATE_OUTPUTS["generate_feature_table"][2],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
         ),
     output:
         directory(BOOTSTRAP_OUTPUTS["bootstrap_data_dir"]),
@@ -298,14 +352,23 @@ checkpoint prepare_bootstrap_data:
 rule bootstrap_construct:
     input:
         construct_data=BOOTSTRAP_OUTPUTS["construct_data"],
-        controls_arr=lambda wildcards: str(BOOTSTRAP_OUTPUTS["controls_arr"]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+        controls_arr=lambda wildcards: format_rule_output(
+            BOOTSTRAP_OUTPUTS["controls_arr"],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
         ),
-        construct_features_arr=lambda wildcards: str(BOOTSTRAP_OUTPUTS["construct_features_arr"]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+        construct_features_arr=lambda wildcards: format_rule_output(
+            BOOTSTRAP_OUTPUTS["construct_features_arr"],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
         ),
-        sample_sizes=lambda wildcards: str(BOOTSTRAP_OUTPUTS["sample_sizes"]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+        sample_sizes=lambda wildcards: format_rule_output(
+            BOOTSTRAP_OUTPUTS["sample_sizes"],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
         ),
     output:
         BOOTSTRAP_OUTPUTS["bootstrap_construct_nulls"],
@@ -328,17 +391,24 @@ rule construct_bootstrap_complete:
             BOOTSTRAP_OUTPUTS["bootstrap_construct_pvals"],
             wildcards.cell_class,
             wildcards.channel_combo,
+            get_compartment_combo(
+                wildcards, SPLIT_BY_COMPARTMENT, DEFAULT_COMPARTMENT_COMBO
+            ),
+            SPLIT_BY_COMPARTMENT,
         ),
     output:
-        touch(AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__construct_bootstrap_complete.flag"),
+        touch(BOOTSTRAP_OUTPUTS["construct_bootstrap_flag"]),
 
 
 # Aggregate construct results to gene level
 rule bootstrap_gene:
     input:
-        construct_flag=AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__construct_bootstrap_complete.flag",
-        gene_table=lambda wildcards: str(AGGREGATE_OUTPUTS["generate_feature_table"][2]).format(
-            cell_class=wildcards.cell_class, channel_combo=wildcards.channel_combo
+        construct_flag=BOOTSTRAP_OUTPUTS["construct_bootstrap_flag"],
+        gene_table=lambda wildcards: format_rule_output(
+            AGGREGATE_OUTPUTS["generate_feature_table"][2],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
         ),
     output:
         BOOTSTRAP_OUTPUTS["bootstrap_gene_nulls"],
@@ -346,11 +416,13 @@ rule bootstrap_gene:
     params:
         num_sims=config.get("aggregate", {}).get("num_sims", 100000),
         perturbation_name_col=config.get("aggregate", {}).get("perturbation_name_col"),
-        construct_nulls_pattern=lambda wildcards: str(BOOTSTRAP_OUTPUTS["bootstrap_construct_nulls"]).format(
-            cell_class=wildcards.cell_class,
-            channel_combo=wildcards.channel_combo,
+        construct_nulls_pattern=lambda wildcards: format_rule_output(
+            BOOTSTRAP_OUTPUTS["bootstrap_construct_nulls"],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
             gene=wildcards.gene,
-            construct="{construct}"
+            construct="{construct}",
         ),
         bootstrap_features_fp=config.get("aggregate", {}).get("bootstrap_features_fp", None),
         bootstrap_extra_features=config.get("aggregate", {}).get("bootstrap_extra_features", None),
@@ -369,6 +441,10 @@ rule initiate_bootstrap:
             BOOTSTRAP_OUTPUTS["bootstrap_gene_pvals"],
             wildcards.cell_class,
             wildcards.channel_combo,
+            get_compartment_combo(
+                wildcards, SPLIT_BY_COMPARTMENT, DEFAULT_COMPARTMENT_COMBO
+            ),
+            SPLIT_BY_COMPARTMENT,
         ),
     output:
         touch(BOOTSTRAP_OUTPUTS["bootstrap_flag"]),
@@ -382,8 +458,18 @@ rule combine_bootstrap:
         BOOTSTRAP_OUTPUTS["combined_construct_results"],
         BOOTSTRAP_OUTPUTS["combined_gene_results"],
     params:
-        constructs_dir=lambda wildcards: str(AGGREGATE_FP / "bootstrap" / f"{wildcards.cell_class}__{wildcards.channel_combo}__constructs"),
-        genes_dir=lambda wildcards: str(AGGREGATE_FP / "bootstrap" / f"{wildcards.cell_class}__{wildcards.channel_combo}__genes"),
+        constructs_dir=lambda wildcards: format_rule_output(
+            BOOTSTRAP_OUTPUTS["bootstrap_construct_nulls"].parent,
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
+        ),
+        genes_dir=lambda wildcards: format_rule_output(
+            BOOTSTRAP_OUTPUTS["bootstrap_gene_nulls"].parent,
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
+        ),
     script:
         "../scripts/aggregate/combine_bootstrap.py"
 
@@ -394,7 +480,12 @@ rule format_singlecell_anndata:
         # Stage-position + global pixel columns are already attached upstream in final_merge.
         filtered_paths=lambda wildcards: output_to_input(
             AGGREGATE_OUTPUTS_MAPPED["filter"],
-            wildcards={"channel_combo": wildcards.channel_combo},
+            wildcards={
+                "channel_combo": wildcards.channel_combo,
+                "compartment_combo": get_compartment_combo(
+                    wildcards, SPLIT_BY_COMPARTMENT, DEFAULT_COMPARTMENT_COMBO
+                ),
+            },
             expansion_values=["plate", "well", "cell_class"],
             metadata_combos=aggregate_wildcard_combos,
         ),
@@ -405,7 +496,7 @@ rule format_singlecell_anndata:
         use_classifier=config.get("classify", {}).get("classifier_path") is not None,
         control_key=config["aggregate"]["control_key"],
         perturbation_name_col=config["aggregate"]["perturbation_name_col"],
-        channel_names=config["phenotype"]["channel_names"],
+        channel_names=config.get("phenotype", {}).get("channel_names"),
         channel_combo="{channel_combo}",
     script:
         "../scripts/aggregate/format_singlecell_anndata.py"

--- a/workflow/rules/cluster.smk
+++ b/workflow/rules/cluster.smk
@@ -1,3 +1,15 @@
+from lib.shared.compartment_utils import format_rule_output
+
+
+# bootstrap gene results for the current combo, resolved on the same compartment path
+_bootstrap_gene_results = lambda wildcards: format_rule_output(
+    BOOTSTRAP_OUTPUTS["combined_gene_results"],
+    wildcards,
+    SPLIT_BY_COMPARTMENT,
+    DEFAULT_COMPARTMENT_COMBO,
+)
+
+
 # Clean aggregate datasets
 rule clean_aggregate:
     input:
@@ -54,31 +66,32 @@ rule benchmark_clusters:
 # Format cluster results into AnnData h5ad (combines all resolutions)
 rule format_cluster_anndata:
     input:
-        features_genes=AGGREGATE_OUTPUTS["generate_feature_table"][2],
-        clustering=[
-            str(CLUSTER_OUTPUTS["phate_leiden_clustering"][0]).format(
-                channel_combo="{channel_combo}",
-                cell_class="{cell_class}",
+        features_genes=lambda wildcards: format_rule_output(
+            AGGREGATE_OUTPUTS["generate_feature_table"][2],
+            wildcards,
+            SPLIT_BY_COMPARTMENT,
+            DEFAULT_COMPARTMENT_COMBO,
+        ),
+        clustering=lambda wildcards: [
+            format_rule_output(
+                CLUSTER_OUTPUTS["phate_leiden_clustering"][0],
+                wildcards,
+                SPLIT_BY_COMPARTMENT,
+                DEFAULT_COMPARTMENT_COMBO,
                 leiden_resolution=res,
             )
             for res in cluster_wildcard_combos["leiden_resolution"].unique()
         ],
         bootstrap_results=lambda wildcards: (
-            ancient(str(BOOTSTRAP_OUTPUTS["combined_gene_results"]).format(
-                cell_class=wildcards.cell_class,
-                channel_combo=wildcards.channel_combo,
-            ))
-            if Path(str(BOOTSTRAP_OUTPUTS["combined_gene_results"]).format(
-                cell_class=wildcards.cell_class,
-                channel_combo=wildcards.channel_combo,
-            )).exists()
+            ancient(_bootstrap_gene_results(wildcards))
+            if Path(_bootstrap_gene_results(wildcards)).exists()
             else []
         ),
     output:
         CLUSTER_OUTPUTS_MAPPED["format_cluster_anndata"],
     params:
         perturbation_name_col=config.get("aggregate", {}).get("perturbation_name_col"),
-        channel_names=config["phenotype"]["channel_names"],
+        channel_names=config.get("phenotype", {}).get("channel_names"),
         leiden_resolutions=list(cluster_wildcard_combos["leiden_resolution"].unique()),
     script:
         "../scripts/cluster/format_cluster_anndata.py"

--- a/workflow/rules/merge.smk
+++ b/workflow/rules/merge.smk
@@ -131,7 +131,7 @@ if merge_approach == "stitch":
             phenotype_metadata=ancient(PREPROCESS_OUTPUTS["combine_metadata_phenotype"]),
             phenotype_stitch_config=MERGE_OUTPUTS["estimate_stitch_phenotype"][0],
             phenotype_tiles=lambda wildcards: output_to_input(
-                PHENOTYPE_OUTPUTS["align_phenotype"],
+                PHENOTYPE_OUTPUTS["align_phenotype"][0],
                 wildcards=wildcards,
                 expansion_values=["tile"],
                 metadata_combos=phenotype_wildcard_combos,
@@ -279,7 +279,7 @@ rule format_merge:
             metadata_combos=merge_wildcard_combos,
         )),
         ancient(lambda wildcards: output_to_input(
-            PHENOTYPE_OUTPUTS["merge_phenotype"][1],
+            PHENOTYPE_OUTPUTS["merge_phenotype_cp"][1],
             wildcards={"plate": wildcards.plate, "well": wildcards.well},
             expansion_values=_merge_well_expand,
             metadata_combos=merge_wildcard_combos,
@@ -316,7 +316,7 @@ rule deduplicate_merge:
             metadata_combos=merge_wildcard_combos,
         )),
         ancient(lambda wildcards: output_to_input(
-            PHENOTYPE_OUTPUTS["merge_phenotype"][1],
+            PHENOTYPE_OUTPUTS["merge_phenotype_cp"][1],
             wildcards={"plate": wildcards.plate, "well": wildcards.well},
             expansion_values=_merge_well_expand,
             metadata_combos=merge_wildcard_combos,
@@ -338,7 +338,7 @@ rule final_merge:
     input:
         MERGE_OUTPUTS["deduplicate_merge"][1],
         ancient(lambda wildcards: output_to_input(
-            PHENOTYPE_OUTPUTS["merge_phenotype"][0],
+            PHENOTYPE_OUTPUTS["merge_phenotype_cp"][0],
             wildcards={"plate": wildcards.plate, "well": wildcards.well},
             expansion_values=_merge_well_expand,
             metadata_combos=merge_wildcard_combos,
@@ -367,7 +367,7 @@ rule eval_merge:
             ancient_output=True,
         ),
         min_phenotype_cp_paths=lambda wildcards: output_to_input(
-            PHENOTYPE_OUTPUTS["merge_phenotype"][1],
+            PHENOTYPE_OUTPUTS["merge_phenotype_cp"][1],
             wildcards=wildcards,
             expansion_values=_merge_well_expand_all,
             metadata_combos=phenotype_wildcard_combos,

--- a/workflow/rules/phenotype.smk
+++ b/workflow/rules/phenotype.smk
@@ -18,7 +18,8 @@ rule align_phenotype:
     input:
         PHENOTYPE_OUTPUTS["apply_ic_field_phenotype"],
     output:
-        PHENOTYPE_OUTPUTS_MAPPED["align_phenotype"],
+        PHENOTYPE_OUTPUTS_MAPPED["align_phenotype"][0],  # aligned image
+        PHENOTYPE_OUTPUTS_MAPPED["align_phenotype"][1],  # alignment metrics TSV
     params:
         config=lambda wildcards: get_alignment_params(wildcards, config),
     script:
@@ -28,7 +29,7 @@ rule align_phenotype:
 # Segments cells and nuclei using pre-defined methods
 rule segment_phenotype:
     input:
-        PHENOTYPE_OUTPUTS["align_phenotype"],
+        PHENOTYPE_OUTPUTS["align_phenotype"][0],
     output:
         PHENOTYPE_OUTPUTS_MAPPED["segment_phenotype"],
     params:
@@ -57,6 +58,8 @@ rule extract_phenotype_info:
     input:
         # nuclei segmentation map
         PHENOTYPE_OUTPUTS["segment_phenotype"][0],
+        # alignment metrics TSV
+        PHENOTYPE_OUTPUTS["align_phenotype"][1],
     output:
         PHENOTYPE_OUTPUTS_MAPPED["extract_phenotype_info"],
     script:
@@ -78,8 +81,70 @@ rule combine_phenotype_info:
         "../scripts/shared/combine_dfs.py"
 
 
-# Extract full phenotype information from phenotype images
-rule extract_phenotype:
+# Identify secondary objects from aligned phenotype image and cell segmentation
+if config.get("phenotype", {}).get("second_obj_detection", False):
+    rule identify_second_objs:
+        input:
+            # aligned phenotype image
+            PHENOTYPE_OUTPUTS["align_phenotype"][0],
+            # cell segmentation map
+            PHENOTYPE_OUTPUTS["segment_phenotype"][1],
+            # cytoplasm mask
+            PHENOTYPE_OUTPUTS["identify_cytoplasm"],
+            # phenotype info with nuclei centroids
+            PHENOTYPE_OUTPUTS["extract_phenotype_info"],
+        output:
+            # secondary object mask
+            PHENOTYPE_OUTPUTS_MAPPED["identify_second_objs"][0],
+            # cell secondary object table
+            PHENOTYPE_OUTPUTS_MAPPED["identify_second_objs"][1],
+            # updated cytoplasm masks
+            PHENOTYPE_OUTPUTS_MAPPED["identify_second_objs"][2],
+        params:
+            # Pass all secondary object parameters from config
+            second_obj_params=config.get("phenotype", {}),
+        script:
+            "../scripts/phenotype/identify_second_objs.py"
+
+# Extract secondary object phenotype features
+if config.get("phenotype", {}).get("second_obj_detection", False):
+    rule extract_phenotype_second_objs:
+        input:
+            # aligned phenotype image
+            PHENOTYPE_OUTPUTS["align_phenotype"][0],
+            # secondary object mask
+            PHENOTYPE_OUTPUTS["identify_second_objs"][0],
+            # cell secondary object table
+            PHENOTYPE_OUTPUTS["identify_second_objs"][1],
+        output:
+            PHENOTYPE_OUTPUTS_MAPPED["extract_phenotype_second_objs"],
+        params:
+            foci_channel_index=config.get("phenotype", {}).get("foci_channel_index"),
+            channel_names=config.get("phenotype", {}).get("channel_names"),
+        script:
+            "../scripts/phenotype/extract_phenotype_second_objs.py"
+
+
+# Combine secondary object phenotype results from different tiles
+if config.get("phenotype", {}).get("second_obj_detection", False):
+    rule merge_phenotype_second_objs:
+        input:
+            lambda wildcards: output_to_input(
+                PHENOTYPE_OUTPUTS["extract_phenotype_second_objs"],
+                wildcards=wildcards,
+                expansion_values=["tile"],
+                metadata_combos=phenotype_wildcard_combos,
+            ),
+        params:
+            channel_names=config.get("phenotype", {}).get("channel_names"),
+        output:
+            PHENOTYPE_OUTPUTS_MAPPED["merge_phenotype_second_objs"],
+        script:
+            "../scripts/phenotype/merge_phenotype_second_objs.py"
+
+
+# Extract full phenotype information using CellProfiler from phenotype images
+rule extract_phenotype_cp:
     input:
         # aligned phenotype image
         PHENOTYPE_OUTPUTS["align_phenotype"][0],
@@ -89,8 +154,10 @@ rule extract_phenotype:
         PHENOTYPE_OUTPUTS["segment_phenotype"][1],
         # cytoplasm segmentation map
         PHENOTYPE_OUTPUTS["identify_cytoplasm"][0],
+        # alignment metrics TSV (offset_y, offset_x)
+        PHENOTYPE_OUTPUTS["align_phenotype"][1],
     output:
-        PHENOTYPE_OUTPUTS_MAPPED["extract_phenotype"],
+        PHENOTYPE_OUTPUTS_MAPPED["extract_phenotype_cp"],
     params:
         foci_channel_index=config.get("phenotype", {}).get("foci_channel_index"),
         channel_names=config.get("phenotype", {}).get("channel_names"),
@@ -101,11 +168,27 @@ rule extract_phenotype:
         "../scripts/phenotype/extract_phenotype.py"
 
 
+# Merge secondary object data with main phenotype data
+if config.get("phenotype", {}).get("second_obj_detection", False):
+    rule merge_second_objs_phenotype_cp:
+        input:
+            # main phenotype data
+            PHENOTYPE_OUTPUTS["extract_phenotype_cp"],
+            # secondary object data
+            PHENOTYPE_OUTPUTS["identify_second_objs"][1],
+        output:
+            PHENOTYPE_OUTPUTS_MAPPED["merge_second_objs_phenotype_cp"],
+        script:
+            "../scripts/phenotype/merge_second_objs_phenotype_cp.py"
+
+
 # Combine phenotype results from different tiles
 rule merge_phenotype:
     input:
         lambda wildcards: output_to_input(
-            PHENOTYPE_OUTPUTS["extract_phenotype"],
+            PHENOTYPE_OUTPUTS["merge_second_objs_phenotype_cp"]
+            if config.get("phenotype", {}).get("second_obj_detection", False)
+            else PHENOTYPE_OUTPUTS["extract_phenotype_cp"],
             wildcards=wildcards,
             expansion_values=["tile"],
             metadata_combos=phenotype_wildcard_combos,
@@ -114,7 +197,7 @@ rule merge_phenotype:
         channel_names=config.get("phenotype", {}).get("channel_names"),
         segment_cells=config.get("phenotype", {}).get("segment_cells", True),
     output:
-        PHENOTYPE_OUTPUTS_MAPPED["merge_phenotype"],
+        PHENOTYPE_OUTPUTS_MAPPED["merge_phenotype_cp"],
     script:
         "../scripts/phenotype/merge_phenotype.py"
 
@@ -153,7 +236,7 @@ rule eval_features:
     input:
         # use minimum phenotype features for evaluation
         cells_paths=lambda wildcards: output_to_input(
-            PHENOTYPE_OUTPUTS["merge_phenotype"][1],
+            PHENOTYPE_OUTPUTS["merge_phenotype_cp"][1],
             wildcards=wildcards,
             expansion_values=_phen_tile_expand,
             metadata_combos=phenotype_wildcard_combos,
@@ -185,7 +268,7 @@ if PHENOTYPE_IMG_FMT == "zarr":
                 for store in ["aligned", "illumination_corrected"]
             ],
             channels_metadata=config["preprocess"].get("phenotype_channels_metadata", None),
-            channel_names=config["phenotype"].get("channel_names", None),
+            channel_names=config.get("phenotype", {}).get("channel_names", None),
             modality="phenotype",
         script:
             "../scripts/shared/write_hcs_metadata.py"

--- a/workflow/rules/sbs.smk
+++ b/workflow/rules/sbs.smk
@@ -13,7 +13,8 @@ rule align_sbs:
             ancient_output=True,
         ),
     output:
-        SBS_OUTPUTS_MAPPED["align_sbs"],
+        SBS_OUTPUTS_MAPPED["align_sbs"][0],  # aligned image
+        SBS_OUTPUTS_MAPPED["align_sbs"][1],  # alignment metrics TSV
     params:
         method=config.get("sbs", {}).get("alignment_method"),
         channel_names=config.get("sbs", {}).get("channel_names"),
@@ -29,7 +30,7 @@ rule align_sbs:
 # Apply Laplacian-of-Gaussian filter to all channels
 rule log_filter:
     input:
-        SBS_OUTPUTS["align_sbs"],
+        SBS_OUTPUTS["align_sbs"][0],
     output:
         SBS_OUTPUTS_MAPPED["log_filter"],
     params:
@@ -53,7 +54,7 @@ rule compute_standard_deviation:
 # Find local maxima of SBS reads across cycles
 rule find_peaks:
     input:
-        SBS_OUTPUTS["compute_standard_deviation"] if config.get("sbs", {}).get("spot_detection_method", "standard") == "standard" else SBS_OUTPUTS["align_sbs"],
+        SBS_OUTPUTS["compute_standard_deviation"] if config.get("sbs", {}).get("spot_detection_method", "standard") == "standard" else SBS_OUTPUTS["align_sbs"][0],
     output:
         SBS_OUTPUTS_MAPPED["find_peaks"],
     params:
@@ -78,7 +79,7 @@ rule max_filter:
 # Apply illumination correction field from segmentation cycle
 rule apply_ic_field_sbs:
     input:
-        SBS_OUTPUTS["align_sbs"],
+        SBS_OUTPUTS["align_sbs"][0],
         # extra channel illumination correction field
         lambda wildcards: output_to_input(
             PREPROCESS_OUTPUTS["calculate_ic_sbs"],
@@ -171,6 +172,8 @@ rule extract_sbs_info:
     input:
         # use nuclei segmentation map
         SBS_OUTPUTS["segment_sbs"][0],
+        # alignment metrics TSV
+        SBS_OUTPUTS["align_sbs"][1],
     output:
         SBS_OUTPUTS_MAPPED["extract_sbs_info"],
     script:

--- a/workflow/scripts/aggregate/aggregate.py
+++ b/workflow/scripts/aggregate/aggregate.py
@@ -31,15 +31,27 @@ metadata, tvn_normalized = split_cell_data(cell_data, metadata_cols)
 tvn_normalized = tvn_normalized.to_numpy()
 del cell_data
 
+# Carry the control/gene name column through when it differs from the aggregation ID.
+pert_col = snakemake.params.perturbation_name_col
+control_name_col = snakemake.params.get("control_name_col")
+carry_cols = None
+if (
+    control_name_col
+    and control_name_col != pert_col
+    and control_name_col in metadata.columns
+):
+    carry_cols = [control_name_col]
+
 # Aggregate
 aggregated_embeddings, aggregated_metadata = aggregate(
     tvn_normalized,
     metadata,
-    snakemake.params.perturbation_name_col,
+    pert_col,
     group_cols=snakemake.params.group_cols,
     method=snakemake.params.agg_method,
     ps_probability_threshold=snakemake.params.ps_probability_threshold,
     ps_percentile_threshold=snakemake.params.ps_percentile_threshold,
+    carry_cols=carry_cols,
 )
 
 # Save aggregated data

--- a/workflow/scripts/aggregate/aggregate_cells_second_objs.py
+++ b/workflow/scripts/aggregate/aggregate_cells_second_objs.py
@@ -1,0 +1,45 @@
+import pandas as pd
+
+from lib.shared.file_utils import validate_dtypes
+from lib.aggregate.second_obj_utils import aggregate_second_obj_data
+
+# Load cell-level data from final_merge
+cells_df = validate_dtypes(pd.read_parquet(snakemake.input[0]))
+
+# Load per-object secondary object data
+second_objs_df = validate_dtypes(pd.read_parquet(snakemake.input[1]))
+
+# Get aggregation strategy from config
+agg_strategy = snakemake.params.agg_strategy
+
+print(f"Aggregating secondary objects with strategy: {agg_strategy}")
+print(f"  Cells: {len(cells_df)} rows")
+print(f"  Secondary objects: {len(second_objs_df)} rows")
+
+# Screen-level guard: a non-"none" strategy with zero secondary objects screen-wide is a misconfiguration (per-well empties are legal and NaN-filled downstream)
+if agg_strategy != "none" and second_objs_df.empty:
+    raise ValueError(
+        f"aggregate.second_obj_agg_strategy is '{agg_strategy}' but no secondary "
+        f"objects were detected anywhere in the screen ({snakemake.input[1]} has 0 "
+        f"rows). Set second_obj_agg_strategy: none, or disable "
+        f"phenotype.second_obj_detection."
+    )
+
+# Filter secondary objects to matching plate/well
+plate = int(
+    snakemake.wildcards.plate
+)  # plate is int64 in both merge_final and phenotype parquets
+well = str(snakemake.wildcards.well)  # well is always string ("A1", etc.)
+second_objs_filtered = second_objs_df[
+    (second_objs_df["plate"] == plate) & (second_objs_df["well"] == well)
+]
+
+print(f"  Secondary objects after plate/well filter: {len(second_objs_filtered)} rows")
+
+# Aggregate
+result = aggregate_second_obj_data(cells_df, second_objs_filtered, agg_strategy)
+
+print(f"  Result: {len(result)} rows, {len(result.columns)} columns")
+
+# Save
+result.to_parquet(snakemake.output[0])

--- a/workflow/scripts/aggregate/aggregate_cells_second_objs.py
+++ b/workflow/scripts/aggregate/aggregate_cells_second_objs.py
@@ -26,14 +26,17 @@ if agg_strategy != "none" and second_objs_df.empty:
         f"phenotype.second_obj_detection."
     )
 
-# Filter secondary objects to matching plate/well
+# Filter secondary objects to matching plate/well; an empty screen-wide table has no columns
 plate = int(
     snakemake.wildcards.plate
 )  # plate is int64 in both merge_final and phenotype parquets
 well = str(snakemake.wildcards.well)  # well is always string ("A1", etc.)
-second_objs_filtered = second_objs_df[
-    (second_objs_df["plate"] == plate) & (second_objs_df["well"] == well)
-]
+if second_objs_df.empty:
+    second_objs_filtered = second_objs_df
+else:
+    second_objs_filtered = second_objs_df[
+        (second_objs_df["plate"] == plate) & (second_objs_df["well"] == well)
+    ]
 
 print(f"  Secondary objects after plate/well filter: {len(second_objs_filtered)} rows")
 

--- a/workflow/scripts/aggregate/aggregate_cells_second_objs.py
+++ b/workflow/scripts/aggregate/aggregate_cells_second_objs.py
@@ -1,13 +1,14 @@
 import pandas as pd
 
 from lib.shared.file_utils import validate_dtypes
+from lib.shared.parquet_io import read_parquet, write_parquet
 from lib.aggregate.second_obj_utils import aggregate_second_obj_data
 
 # Load cell-level data from final_merge
-cells_df = validate_dtypes(pd.read_parquet(snakemake.input[0]))
+cells_df = validate_dtypes(read_parquet(snakemake.input[0]))
 
 # Load per-object secondary object data
-second_objs_df = validate_dtypes(pd.read_parquet(snakemake.input[1]))
+second_objs_df = validate_dtypes(read_parquet(snakemake.input[1]))
 
 # Get aggregation strategy from config
 agg_strategy = snakemake.params.agg_strategy
@@ -42,4 +43,4 @@ result = aggregate_second_obj_data(cells_df, second_objs_filtered, agg_strategy)
 print(f"  Result: {len(result)} rows, {len(result.columns)} columns")
 
 # Save
-result.to_parquet(snakemake.output[0])
+write_parquet(result, snakemake.output[0])

--- a/workflow/scripts/aggregate/align.py
+++ b/workflow/scripts/aggregate/align.py
@@ -16,6 +16,7 @@ from lib.aggregate.align import (
     centerscale_by_batch,
     tvn_on_controls,
 )
+from lib.aggregate.filter import harmonize_pool_schema
 from lib.aggregate.perturbation_score import perturbation_score
 
 warnings.filterwarnings(
@@ -56,14 +57,32 @@ n_sample = min(PCA_SUBSET, total_rows)
 random_indices = np.random.choice(total_rows, size=n_sample, replace=False)
 random_indices.sort()
 
-# load sample df; drop null columns as the batch loop below does, since filter drops
-# columns per well and pyarrow fills the missing ones with nulls the PCA cannot consume
-sample_df = cell_dataset.scanner().take(random_indices)
-sample_df = sample_df.to_pandas(use_threads=True, memory_pool=None).dropna(axis=1)
-
 # load sample df as pandas dataframe
 use_classifier = snakemake.params.use_classifier
 metadata_cols = load_metadata_cols(snakemake.params.metadata_cols_fp, use_classifier)
+
+# Harmonize the pool's column set once (drop partial cols, apply pool-level drop_cols_threshold).
+kept_metadata_cols, kept_feature_cols, _pool_report = harmonize_pool_schema(
+    non_empty_paths,
+    metadata_cols,
+    drop_cols_threshold=snakemake.params.get("drop_cols_threshold"),
+)
+scan_cols = kept_metadata_cols + kept_feature_cols
+
+# load sample df
+sample_df = (
+    cell_dataset.scanner(columns=scan_cols)
+    .take(random_indices)
+    .to_pandas(use_threads=True, memory_pool=None)
+)
+
+# Drop rows with residual NaN so the PCA training sample is clean.
+_sample_pre = len(sample_df)
+sample_df = sample_df.dropna(subset=kept_feature_cols).reset_index(drop=True)
+if len(sample_df) < _sample_pre:
+    print(
+        f"[pool] dropped {_sample_pre - len(sample_df)} PCA-sample rows with residual NaN"
+    )
 metadata, features = split_cell_data(sample_df, metadata_cols)
 metadata, features = prepare_alignment_data(
     metadata,
@@ -93,11 +112,18 @@ for i, indices in enumerate(subset_indices):
     print(f"Processing subset {i + 1}/{num_align_batches} with {len(indices)} cells")
 
     subset_df = (
-        cell_dataset.scanner()
+        cell_dataset.scanner(columns=scan_cols)
         .take(pa.array(indices))
         .to_pandas(use_threads=True, memory_pool=None)
-        .dropna(axis=1)
     )
+    # Drop any residual per-row NaN.
+    _pre = len(subset_df)
+    subset_df = subset_df.dropna(subset=kept_feature_cols).reset_index(drop=True)
+    if len(subset_df) < _pre:
+        print(
+            f"[pool] dropped {_pre - len(subset_df)} rows with residual NaN "
+            f"from batch {i + 1}"
+        )
 
     # CALCULATE PERTURBATION SCORE
     subset_df["perturbation_score"] = np.nan
@@ -109,6 +135,9 @@ for i, indices in enumerate(subset_indices):
             metadata_cols,
             snakemake.params.perturbation_name_col,
             snakemake.params.control_key,
+            perturbation_id_col=snakemake.params.perturbation_id_col,
+            control_name_col=snakemake.params.get("control_name_col"),
+            batch_cols=snakemake.params.batch_cols,
         )
 
     for col in subset_df.columns:

--- a/workflow/scripts/aggregate/bootstrap_gene.py
+++ b/workflow/scripts/aggregate/bootstrap_gene.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pandas as pd
 import glob
-from pathlib import Path
 
 from lib.aggregate.bootstrap import load_construct_null_arrays, calculate_pvals
 from lib.aggregate.cell_data_utils import get_feature_table_cols

--- a/workflow/scripts/aggregate/eval_aggregate.py
+++ b/workflow/scripts/aggregate/eval_aggregate.py
@@ -64,16 +64,26 @@ aligned_data = aligned_data.to_pandas(use_threads=True, memory_pool=None)
 
 # determine original and aligned columns
 random.seed(42)
-# Prefer cell-level features, fall back to nuclear if none found
-merge_feature_cols = [
-    col for col in merge_data.columns if ("cell_" in col and col.endswith("_mean"))
+# Try compartment prefixes in priority order (wildcard combo first, then fallback chain).
+compartment_combo = snakemake.params.compartment_combo.split("-")
+prefix_priority = compartment_combo + [
+    c
+    for c in ("cell", "nucleus", "cytoplasm", "second_obj")
+    if c not in compartment_combo
 ]
-if len(merge_feature_cols) == 0:
+merge_feature_cols = []
+for prefix in prefix_priority:
     merge_feature_cols = [
         col
         for col in merge_data.columns
-        if ("nucleus_" in col and col.endswith("_mean"))
+        if col.startswith(f"{prefix}_") and col.endswith("_mean")
     ]
+    if merge_feature_cols:
+        print(
+            f"[eval] using {len(merge_feature_cols)} '{prefix}_*_mean' feature columns"
+        )
+        break
+
 pc_cols = [col for col in aligned_data.columns if col.startswith("PC_")]
 aligned_feature_cols = random.sample(
     pc_cols, k=min(len(merge_feature_cols), len(pc_cols))

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -16,6 +16,7 @@ from lib.aggregate.cell_data_utils import (
     GROUP_KEY_SEP,
 )
 from lib.aggregate.bootstrap import create_pseudogene_groups
+from lib.aggregate.filter import harmonize_pool_schema
 
 # Validate required params
 for _param_name in ["perturbation_name_col", "control_key", "metadata_cols_fp"]:
@@ -26,8 +27,19 @@ for _param_name in ["perturbation_name_col", "control_key", "metadata_cols_fp"]:
 pert_col = snakemake.params.perturbation_name_col
 pert_id_col = snakemake.params.perturbation_id_col or pert_col
 control_key = snakemake.params.control_key
+# Column used with control_key to identify controls; falls back to pert_col when unset.
+control_name_col = snakemake.params.get("control_name_col") or pert_col
 num_batches = snakemake.params.num_align_batches
 group_cols = list(snakemake.params.get("group_cols", None) or [])
+
+if pert_id_col == pert_col:
+    print(
+        f"WARNING: perturbation_id_col is not set, so '{pert_col}' is being used as "
+        "the construct ID. Constructs collapse to gene level, which leaves a single "
+        "control construct and a bootstrap null that lacks construct-level variance "
+        "(p-values will be under-dispersed). Set perturbation_id_col to your "
+        "construct column (e.g. cell_barcode_0 or sgRNA_0)."
+    )
 
 # Load cell data using PyArrow dataset (lazy - no data loaded yet)
 print("Loading cell data as PyArrow dataset...")
@@ -55,10 +67,13 @@ if missing_group_cols:
         f"aggregate group_cols not found in cell data: {missing_group_cols}"
     )
 metadata_cols += [col for col in group_cols if col not in metadata_cols]
-feature_cols = [col for col in cell_dataset.schema.names if col not in metadata_cols]
 
-# Filter metadata_cols to only include columns that exist in the parquet
-existing_metadata_cols = [col for col in metadata_cols if col in cell_data_cols]
+# Harmonize the pool's column set once (drop partial cols, apply pool-level drop_cols_threshold).
+existing_metadata_cols, feature_cols, _pool_report = harmonize_pool_schema(
+    non_empty_paths,
+    metadata_cols,
+    drop_cols_threshold=snakemake.params.get("drop_cols_threshold"),
+)
 
 print(
     f"Number of metadata columns: {len(existing_metadata_cols)} | Number of feature columns: {len(feature_cols)}"
@@ -82,10 +97,10 @@ print(f"Processing data in {num_batches} batch(es), ~{chunk_size} rows per batch
 aligned_output = snakemake.output[0]
 writer = None
 
-# Accumulators for construct-level aggregation
-# We'll collect per-construct data across batches
+# Accumulators for per-construct data collected across batches
 construct_cell_counts = {}  # {construct_id: count}
 construct_gene_map = {}  # {construct_id: gene_name}
+construct_control_map = {}  # {construct_id: control_name_col value (for control id)}
 construct_feature_sums = {}  # {construct_id: [sum of features]}
 construct_feature_counts = {}  # {construct_id: count for averaging}
 # For median, we need all values - store them
@@ -136,6 +151,7 @@ for batch_idx, indices in enumerate(subset_indices):
         control_key,
         "batch_values",
         method=snakemake.params.feature_normalization,
+        control_col=control_name_col,
     ).astype(np.float32)
 
     # fold group values into the perturbation labels so a point is perturbation x group
@@ -173,10 +189,12 @@ for batch_idx, indices in enumerate(subset_indices):
         mask = metadata[pert_id_col].values == construct_id
         construct_features = features[mask]
         gene_name = metadata.loc[mask, pert_col].iloc[0]
+        control_name = metadata.loc[mask, control_name_col].iloc[0]
 
         if construct_id not in construct_cell_counts:
             construct_cell_counts[construct_id] = 0
             construct_gene_map[construct_id] = gene_name
+            construct_control_map[construct_id] = control_name
             construct_feature_values[construct_id] = []
             if group_cols:
                 construct_group_map[construct_id] = group_labels[mask].iloc[0]
@@ -208,6 +226,7 @@ for construct_id in construct_cell_counts.keys():
     row = {
         pert_id_col: construct_id,
         pert_col: construct_gene_map[construct_id],
+        control_name_col: construct_control_map[construct_id],
         "cell_count": construct_cell_counts[construct_id],
     }
     for i, col in enumerate(feature_cols):
@@ -221,9 +240,12 @@ gc.collect()
 construct_table = pd.DataFrame(construct_rows)
 
 # Reorder columns: sgRNA, gene, cell_count, features
-# List the label column once when the id and name columns coincide
-label_cols = [pert_id_col, pert_col] if pert_id_col != pert_col else [pert_col]
-construct_columns = label_cols + ["cell_count"] + feature_cols
+# Dedupe preserving order; control_name_col must survive for the control filter below
+construct_columns = list(
+    dict.fromkeys(
+        [pert_id_col, pert_col, control_name_col, "cell_count"] + feature_cols
+    )
+)
 construct_table = construct_table[construct_columns]
 
 print(f"Construct table shape: {construct_table.shape}")
@@ -233,7 +255,7 @@ print("\n=== Creating gene-level table ===")
 
 # Filter out controls for gene-level aggregation
 non_control_constructs = construct_table[
-    ~control_mask(construct_table[pert_col], control_key)
+    ~control_mask(construct_table[control_name_col], control_key)
 ]
 
 # Calculate gene-level sample sizes (sum of construct cell counts)
@@ -255,7 +277,7 @@ gene_table = pd.merge(gene_features, gene_sample_sizes, on=pert_col, how="left")
 
 # Add controls to gene table (controls are their own "genes")
 control_constructs = construct_table[
-    control_mask(construct_table[pert_col], control_key)
+    control_mask(construct_table[control_name_col], control_key)
 ]
 control_gene_table = control_constructs[[pert_col, "cell_count"] + feature_cols].copy()
 

--- a/workflow/scripts/aggregate/split_datasets.py
+++ b/workflow/scripts/aggregate/split_datasets.py
@@ -1,14 +1,20 @@
+from pathlib import Path
+
 import pandas as pd
 import numpy as np
 
 from lib.aggregate.cell_classification import CellClassifier
 from lib.shared.parquet_io import read_parquet, write_parquet
 from lib.aggregate.cell_data_utils import (
+    COMPARTMENT_PREFIXES,
     load_metadata_cols,
     split_cell_data,
     channel_combo_subset,
     join_well_annotations,
+    compartment_combo_subset,
 )
+from lib.shared.compartment_utils import add_compartment_metadata
+from lib.shared.file_utils import get_filename
 
 
 def apply_confidence_thresholds(metadata, features, thresholds, class_col="class"):
@@ -160,8 +166,20 @@ else:
 # Load all channels
 all_channels = snakemake.params.all_channels
 
-# split cells by cell class
-for cell_class in snakemake.params.cell_classes:
+# Each row pairs a channel_combo with its compartment_combo; compartments are zipped not crossed.
+aggregate_wildcard_combos = snakemake.params.aggregate_wildcard_combos
+unique_specs = aggregate_wildcard_combos[
+    ["cell_class", "channel_combo", "compartment_combo"]
+].drop_duplicates()
+
+# Universe of compartment prefixes that may exist in the input, from the known prefix set.
+all_compartments_run = sorted(COMPARTMENT_PREFIXES.keys())
+
+for _, row in unique_specs.iterrows():
+    cell_class = row["cell_class"]
+    channel_combo = row["channel_combo"]
+    compartment_combo = row["compartment_combo"]
+
     if cell_class == "all":
         cell_class_metadata = metadata
         cell_class_features = features
@@ -170,22 +188,35 @@ for cell_class in snakemake.params.cell_classes:
         cell_class_metadata = metadata[cell_class_mask]
         cell_class_features = features[cell_class_mask]
 
-    # split features into channel combos
-    for channel_combo in snakemake.params.channel_combos:
-        channel_combo_list = channel_combo.split("_")
-        channel_combo_features = channel_combo_subset(
-            cell_class_features, channel_combo_list, all_channels
-        )
+    channel_combo_list = channel_combo.split("_")
+    compartment_combo_list = compartment_combo.split("-")
 
-        # concatenate metadata and features
-        cell_class_data = pd.concat(
-            [cell_class_metadata, channel_combo_features], axis=1
-        ).reset_index(drop=True)
+    filtered = channel_combo_subset(
+        cell_class_features, channel_combo_list, all_channels
+    )
+    filtered = compartment_combo_subset(
+        filtered, compartment_combo_list, all_compartments_run
+    )
 
-        # Save data
-        dataset_fp = [
-            f
-            for f in snakemake.output
-            if f"CeCl-{cell_class}_ChCo-{channel_combo}__" in f
-        ][0]
-        write_parquet(cell_class_data, dataset_fp)
+    cell_class_data = pd.concat([cell_class_metadata, filtered], axis=1).reset_index(
+        drop=True
+    )
+
+    dataset_name = get_filename(
+        add_compartment_metadata(
+            {
+                "plate": snakemake.wildcards.plate,
+                "well": snakemake.wildcards.well,
+                "cell_class": cell_class,
+                "channel_combo": channel_combo,
+            },
+            compartment_combo,
+            snakemake.params.split_by_compartment,
+        ),
+        "merge_data",
+        "parquet",
+    )
+    dataset_fp = next(
+        output for output in snakemake.output if Path(output).name == dataset_name
+    )
+    write_parquet(cell_class_data, dataset_fp)

--- a/workflow/scripts/phenotype/align_phenotype.py
+++ b/workflow/scripts/phenotype/align_phenotype.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from lib.phenotype.align_channels import align_phenotype_channels
 from lib.shared.align import apply_custom_offsets
 from lib.shared.image_io import read_image, save_image
@@ -11,6 +13,9 @@ print("Alignment config:", align_config)
 
 # Start with original image data
 aligned_data = image_data
+
+# Dictionary to collect all alignment metrics
+all_metrics = {}
 
 # STEP 1: Apply custom offsets FIRST (if they exist)
 if align_config.get("custom_channel_offsets"):
@@ -35,7 +40,7 @@ if align_config["align"]:
         for i, step in enumerate(align_config["steps"], 1):
             print(f"  Step {i}: Aligning channels...")
             print(f"  Step parameters: {step}")
-            aligned_data = align_phenotype_channels(
+            aligned_data, metrics = align_phenotype_channels(
                 aligned_data,
                 target=step["target"],
                 source=step["source"],
@@ -45,11 +50,15 @@ if align_config["align"]:
                     "upsample_factor", align_config.get("upsample_factor", 2)
                 ),
                 window=step.get("window", align_config.get("window", 2)),
+                return_metrics=True,
             )
+            # Add step-suffixed metrics
+            all_metrics[f"offset_y_step{i}"] = metrics["offset"][0]
+            all_metrics[f"offset_x_step{i}"] = metrics["offset"][1]
     else:
         # Handle single-step alignment
         print("Performing single-step alignment...")
-        aligned_data = align_phenotype_channels(
+        aligned_data, metrics = align_phenotype_channels(
             aligned_data,
             target=align_config["target"],
             source=align_config["source"],
@@ -57,9 +66,26 @@ if align_config["align"]:
             remove_channel=align_config["remove_channel"],
             upsample_factor=align_config.get("upsample_factor", 2),
             window=align_config.get("window", 2),
+            return_metrics=True,
         )
+        # Add metrics without step suffix for single-step
+        all_metrics["offset_y"] = metrics["offset"][0]
+        all_metrics["offset_x"] = metrics["offset"][1]
 else:
     print("STEP 2: Skipping automatic alignment")
+    # No alignment - write placeholder metrics
+    all_metrics["offset_y"] = 0
+    all_metrics["offset_x"] = 0
 
 # Save the aligned/unaligned data
 save_image(aligned_data, snakemake.output[0])
+
+# Save alignment metrics to TSV (one row per tile); synthesize 'well' from 'row'+'col' in zarr mode
+wc = dict(snakemake.wildcards)
+if "row" in wc and "col" in wc and "well" not in wc:
+    wc["well"] = wc["row"] + wc["col"]
+metrics_df = pd.DataFrame(
+    [{"plate": wc["plate"], "well": wc["well"], "tile": wc["tile"], **all_metrics}]
+)
+metrics_df.to_csv(snakemake.output[1], index=False, sep="\t")
+print(f"Alignment metrics saved to {snakemake.output[1]}")

--- a/workflow/scripts/phenotype/extract_phenotype.py
+++ b/workflow/scripts/phenotype/extract_phenotype.py
@@ -1,4 +1,5 @@
 from lib.shared.image_io import read_image
+import pandas as pd
 
 # foci_channel_index intentionally omitted — extract_phenotype_cp_emulator handles foci_channel=None
 for _param_name in ["cp_method", "channel_names"]:
@@ -63,5 +64,11 @@ else:
         f"Unknown cp_method: {cp_method}. Choose 'cp_measure' or 'cp_emulator'."
     )
 
-# Save phenotype cp
+# Broadcast tile-level alignment offsets to each cell row
+alignment_metrics = pd.read_csv(snakemake.input[4], sep="\t")
+offset_cols = [c for c in alignment_metrics.columns if c.startswith("offset_")]
+for col in offset_cols:
+    phenotype_cp[col] = alignment_metrics[col].iloc[0]
+
+# save phenotype cp
 phenotype_cp.to_csv(snakemake.output[0], index=False, sep="\t")

--- a/workflow/scripts/phenotype/extract_phenotype_second_objs.py
+++ b/workflow/scripts/phenotype/extract_phenotype_second_objs.py
@@ -1,0 +1,45 @@
+from tifffile import imread
+import pandas as pd
+
+from lib.phenotype.extract_phenotype_second_objs import extract_phenotype_second_objs
+
+# Load inputs
+data_phenotype = imread(snakemake.input[0])
+second_obj_masks = imread(snakemake.input[1])
+
+# Load only the second_obj_cell_mapping table from the combined dataframe
+combined_df = pd.read_csv(snakemake.input[2], sep="\t")
+second_obj_cell_mapping_df = combined_df[
+    combined_df["table_type"] == "second_obj_cell_mapping"
+].copy()
+
+# Create a dictionary to rename columns by removing the 'second_obj_mapping_' prefix
+rename_dict = {}
+for col in second_obj_cell_mapping_df.columns:
+    if col.startswith("second_obj_mapping_"):
+        rename_dict[col] = col.replace("second_obj_mapping_", "")
+
+# Rename columns
+second_obj_cell_mapping_df = second_obj_cell_mapping_df.rename(columns=rename_dict)
+
+# Get a list of all columns that start with 'cell_summary_'
+cell_summary_cols = [
+    col for col in second_obj_cell_mapping_df.columns if col.startswith("cell_summary_")
+]
+
+# Drop the table_type column and all cell_summary columns
+columns_to_drop = ["table_type"] + cell_summary_cols
+second_obj_cell_mapping_df = second_obj_cell_mapping_df.drop(columns=columns_to_drop)
+
+# Extract secondary object phenotype features
+second_obj_phenotype = extract_phenotype_second_objs(
+    data_phenotype=data_phenotype,
+    second_objs=second_obj_masks,
+    wildcards=snakemake.wildcards,
+    second_obj_cell_mapping_df=second_obj_cell_mapping_df,
+    foci_channel=snakemake.params.foci_channel_index,
+    channel_names=snakemake.params.channel_names,
+)
+
+# Save results
+second_obj_phenotype.to_csv(snakemake.output[0], sep="\t", index=False)

--- a/workflow/scripts/phenotype/extract_phenotype_second_objs.py
+++ b/workflow/scripts/phenotype/extract_phenotype_second_objs.py
@@ -1,11 +1,12 @@
-from tifffile import imread
 import pandas as pd
+
+from lib.shared.image_io import read_image
 
 from lib.phenotype.extract_phenotype_second_objs import extract_phenotype_second_objs
 
 # Load inputs
-data_phenotype = imread(snakemake.input[0])
-second_obj_masks = imread(snakemake.input[1])
+data_phenotype = read_image(snakemake.input[0])
+second_obj_masks = read_image(snakemake.input[1])
 
 # Load only the second_obj_cell_mapping table from the combined dataframe
 combined_df = pd.read_csv(snakemake.input[2], sep="\t")
@@ -31,11 +32,16 @@ cell_summary_cols = [
 columns_to_drop = ["table_type"] + cell_summary_cols
 second_obj_cell_mapping_df = second_obj_cell_mapping_df.drop(columns=columns_to_drop)
 
+# Build wildcards dict, synthesizing 'well' from 'row'+'col' in zarr mode
+wc = dict(snakemake.wildcards)
+if "row" in wc and "col" in wc and "well" not in wc:
+    wc["well"] = wc["row"] + wc["col"]
+
 # Extract secondary object phenotype features
 second_obj_phenotype = extract_phenotype_second_objs(
     data_phenotype=data_phenotype,
     second_objs=second_obj_masks,
-    wildcards=snakemake.wildcards,
+    wildcards=wc,
     second_obj_cell_mapping_df=second_obj_cell_mapping_df,
     foci_channel=snakemake.params.foci_channel_index,
     channel_names=snakemake.params.channel_names,

--- a/workflow/scripts/phenotype/identify_second_objs.py
+++ b/workflow/scripts/phenotype/identify_second_objs.py
@@ -1,0 +1,59 @@
+from tifffile import imread, imwrite
+import pandas as pd
+
+from lib.phenotype.segment_secondary_object import segment_second_objs_from_config
+
+# Load input files
+data_phenotype = imread(snakemake.input[0])
+cells = imread(snakemake.input[1])
+cytoplasms = imread(snakemake.input[2])
+phenotype_info = pd.read_csv(snakemake.input[3], sep="\t")
+
+# Prepare nuclei centroids from phenotype info (for cell-nucleus distance calculations)
+nuclei_centroids_dict = None
+if "i" in phenotype_info.columns and "j" in phenotype_info.columns:
+    nuclei_centroids_dict = {
+        row.get("nuclei_id", idx): (row["i"], row["j"])
+        for idx, row in phenotype_info.iterrows()
+    }
+
+# Dispatch segmentation (ML or classical) from the config params
+second_obj_masks, cell_second_obj_table, updated_cytoplasm_masks = (
+    segment_second_objs_from_config(
+        image=data_phenotype,
+        cell_masks=cells,
+        cytoplasm_masks=cytoplasms,
+        second_obj_params=snakemake.params.second_obj_params,
+        nuclei_centroids=nuclei_centroids_dict,
+    )
+)
+
+# Save secondary object masks as TIFF
+imwrite(snakemake.output[0], second_obj_masks)
+
+# Combine the two tables into one TSV, prefixing columns by table type
+cell_summary_df = cell_second_obj_table["cell_summary"]
+second_obj_cell_mapping_df = cell_second_obj_table["second_obj_cell_mapping"]
+cell_summary_df["table_type"] = "cell_summary"
+second_obj_cell_mapping_df["table_type"] = "second_obj_cell_mapping"
+cell_summary_df = cell_summary_df.rename(
+    columns={
+        col: f"cell_summary_{col}"
+        for col in cell_summary_df.columns
+        if col != "table_type"
+    }
+)
+second_obj_cell_mapping_df = second_obj_cell_mapping_df.rename(
+    columns={
+        col: f"second_obj_mapping_{col}"
+        for col in second_obj_cell_mapping_df.columns
+        if col != "table_type"
+    }
+)
+combined_df = pd.concat(
+    [cell_summary_df, second_obj_cell_mapping_df], ignore_index=True
+)
+combined_df.to_csv(snakemake.output[1], sep="\t", index=False)
+
+# Save updated cytoplasm masks as TIFF
+imwrite(snakemake.output[2], updated_cytoplasm_masks)

--- a/workflow/scripts/phenotype/identify_second_objs.py
+++ b/workflow/scripts/phenotype/identify_second_objs.py
@@ -1,12 +1,13 @@
-from tifffile import imread, imwrite
 import pandas as pd
+
+from lib.shared.image_io import read_image, save_image
 
 from lib.phenotype.segment_secondary_object import segment_second_objs_from_config
 
 # Load input files
-data_phenotype = imread(snakemake.input[0])
-cells = imread(snakemake.input[1])
-cytoplasms = imread(snakemake.input[2])
+data_phenotype = read_image(snakemake.input[0])
+cells = read_image(snakemake.input[1])
+cytoplasms = read_image(snakemake.input[2])
 phenotype_info = pd.read_csv(snakemake.input[3], sep="\t")
 
 # Prepare nuclei centroids from phenotype info (for cell-nucleus distance calculations)
@@ -28,8 +29,8 @@ second_obj_masks, cell_second_obj_table, updated_cytoplasm_masks = (
     )
 )
 
-# Save secondary object masks as TIFF
-imwrite(snakemake.output[0], second_obj_masks)
+# Save secondary object masks
+save_image(second_obj_masks, snakemake.output[0], is_label=True)
 
 # Combine the two tables into one TSV, prefixing columns by table type
 cell_summary_df = cell_second_obj_table["cell_summary"]
@@ -55,5 +56,5 @@ combined_df = pd.concat(
 )
 combined_df.to_csv(snakemake.output[1], sep="\t", index=False)
 
-# Save updated cytoplasm masks as TIFF
-imwrite(snakemake.output[2], updated_cytoplasm_masks)
+# Save updated cytoplasm masks
+save_image(updated_cytoplasm_masks, snakemake.output[2], is_label=True)

--- a/workflow/scripts/phenotype/merge_phenotype.py
+++ b/workflow/scripts/phenotype/merge_phenotype.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from joblib import Parallel, delayed
 
+from lib.shared.file_utils import read_tsv_safe
 from lib.shared.parquet_io import write_parquet
 
 
@@ -9,19 +10,12 @@ if getattr(snakemake.params, "channel_names", None) is None:
     raise ValueError("Required config parameter 'channel_names' is not set")
 
 
-# Define function to read df tsv files
-def get_file(f):
-    try:
-        return pd.read_csv(f, sep="\t")
-    except pd.errors.EmptyDataError:
-        pass
-
-
 # Load, concatenate, and save the phenotype CellProfiler data
 arr_reads = Parallel(n_jobs=snakemake.threads)(
-    delayed(get_file)(file) for file in snakemake.input
+    delayed(read_tsv_safe)(file) for file in snakemake.input
 )
-phenotype_cp = pd.concat(arr_reads)
+valid_dfs = [df for df in arr_reads if not df.empty]
+phenotype_cp = pd.concat(valid_dfs) if valid_dfs else pd.DataFrame()
 write_parquet(phenotype_cp, snakemake.output[0])
 
 

--- a/workflow/scripts/phenotype/merge_phenotype_second_objs.py
+++ b/workflow/scripts/phenotype/merge_phenotype_second_objs.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from joblib import Parallel, delayed
+
+from lib.shared.file_utils import read_tsv_safe
+
+# Load, concatenate, and save the secondary object phenotype data
+arr_reads = Parallel(n_jobs=snakemake.threads)(
+    delayed(read_tsv_safe)(file) for file in snakemake.input
+)
+
+# Combine all dataframes, filtering out empty dataframes
+valid_dfs = [df for df in arr_reads if not df.empty]
+if valid_dfs:
+    second_obj_phenotype = pd.concat(valid_dfs)
+    print(
+        f"Combined {len(valid_dfs)} files with a total of {len(second_obj_phenotype)} secondary object records"
+    )
+else:
+    print("Warning: No valid data files found!")
+    second_obj_phenotype = pd.DataFrame()
+
+# Save the combined secondary object phenotype data
+second_obj_phenotype.to_parquet(snakemake.output[0])

--- a/workflow/scripts/phenotype/merge_phenotype_second_objs.py
+++ b/workflow/scripts/phenotype/merge_phenotype_second_objs.py
@@ -2,6 +2,7 @@ import pandas as pd
 from joblib import Parallel, delayed
 
 from lib.shared.file_utils import read_tsv_safe
+from lib.shared.parquet_io import write_parquet
 
 # Load, concatenate, and save the secondary object phenotype data
 arr_reads = Parallel(n_jobs=snakemake.threads)(
@@ -20,4 +21,4 @@ else:
     second_obj_phenotype = pd.DataFrame()
 
 # Save the combined secondary object phenotype data
-second_obj_phenotype.to_parquet(snakemake.output[0])
+write_parquet(second_obj_phenotype, snakemake.output[0])

--- a/workflow/scripts/phenotype/merge_second_objs_phenotype_cp.py
+++ b/workflow/scripts/phenotype/merge_second_objs_phenotype_cp.py
@@ -1,0 +1,63 @@
+import pandas as pd
+
+# Load the datasets
+phenotype_data = pd.read_csv(snakemake.input[0], sep="\t")
+
+# Load the combined secondary object file and extract cell summary data
+combined_second_obj_df = pd.read_csv(snakemake.input[1], sep="\t")
+cell_summary_df = combined_second_obj_df[
+    combined_second_obj_df["table_type"] == "cell_summary"
+].copy()
+
+# Check if we have phenotype data and cell summary data
+if len(phenotype_data) > 0 and len(cell_summary_df) > 0:
+    # Filter to only keep cell_summary columns (and table_type)
+    cell_summary_columns = [
+        col
+        for col in cell_summary_df.columns
+        if col.startswith("cell_summary_") or col == "table_type"
+    ]
+    cell_summary_df = cell_summary_df[cell_summary_columns]
+
+    # Remove the 'cell_summary_' prefix from column names
+    rename_dict = {}
+    for col in cell_summary_df.columns:
+        if col.startswith("cell_summary_"):
+            rename_dict[col] = col.replace("cell_summary_", "")
+
+    cell_summary_df = cell_summary_df.rename(columns=rename_dict)
+
+    # Drop the table_type column
+    cell_summary_df = cell_summary_df.drop(columns=["table_type"])
+
+    # Merge on cell_id (secondary objects) = label (phenotype)
+    merged_data = phenotype_data.merge(
+        cell_summary_df, left_on="label", right_on="cell_id", how="left"
+    )
+
+    # Drop the redundant cell_id column
+    merged_data = merged_data.drop("cell_id", axis=1)
+
+    print(
+        f"Merged {len(phenotype_data)} phenotype records with {len(cell_summary_df)} secondary object records"
+    )
+
+elif len(phenotype_data) > 0:
+    # No cell summary data available, just use phenotype data
+    merged_data = phenotype_data.copy()
+    print(
+        f"No secondary object data available - using phenotype data only ({len(phenotype_data)} records)"
+    )
+
+else:
+    # Both datasets are empty - create an empty DataFrame
+    merged_data = pd.DataFrame()
+    print(
+        "Both phenotype and secondary object datasets are empty - creating empty output"
+    )
+
+# Save the merged dataset
+merged_data.to_csv(snakemake.output[0], sep="\t", index=False)
+print(
+    f"Final dataset has {len(merged_data)} rows and {len(merged_data.columns)} columns"
+)

--- a/workflow/scripts/preprocess/combine_metadata.py
+++ b/workflow/scripts/preprocess/combine_metadata.py
@@ -2,21 +2,12 @@
 
 import pandas as pd
 from joblib import Parallel, delayed
-from lib.shared.file_utils import validate_dtypes
+from lib.shared.file_utils import validate_dtypes, read_tsv_safe
 from lib.shared.parquet_io import write_parquet
-
-
-def get_file(f):
-    """Read a TSV file safely."""
-    try:
-        return pd.read_csv(f, sep="\t")
-    except pd.errors.EmptyDataError:
-        return pd.DataFrame()
-
 
 # Load all metadata files
 all_dfs = Parallel(n_jobs=snakemake.threads)(
-    delayed(get_file)(file) for file in snakemake.input
+    delayed(read_tsv_safe)(file) for file in snakemake.input
 )
 
 # Combine all dataframes

--- a/workflow/scripts/sbs/align_cycles.py
+++ b/workflow/scripts/sbs/align_cycles.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from lib.sbs.align_cycles import align_cycles
 from lib.shared.image_io import read_image, save_image
 
@@ -8,8 +10,8 @@ if getattr(snakemake.params, "channel_names", None) is None:
 # Load image data
 image_data = [read_image(file_path) for file_path in snakemake.input]
 
-# Align cycles
-aligned_data = align_cycles(
+# align cycles
+aligned_data, metrics = align_cycles(
     image_data,
     channel_order=snakemake.params.channel_names,
     method=snakemake.params.method,
@@ -18,7 +20,17 @@ aligned_data = align_cycles(
     skip_cycles=snakemake.params.skip_cycles_indices,
     manual_background_cycle=snakemake.params.manual_background_cycle_index,
     manual_channel_mapping=snakemake.params.manual_channel_mapping,
+    return_metrics=True,
 )
 
 # Save the aligned data
 save_image(aligned_data, snakemake.output[0])
+
+# Save alignment metrics to TSV (one row per tile); synthesize 'well' from 'row'+'col' in zarr mode
+wc = dict(snakemake.wildcards)
+if "row" in wc and "col" in wc and "well" not in wc:
+    wc["well"] = wc["row"] + wc["col"]
+metrics_df = pd.DataFrame(
+    [{"plate": wc["plate"], "well": wc["well"], "tile": wc["tile"], **metrics}]
+)
+metrics_df.to_csv(snakemake.output[1], index=False, sep="\t")

--- a/workflow/scripts/shared/combine_dfs.py
+++ b/workflow/scripts/shared/combine_dfs.py
@@ -1,23 +1,17 @@
 import pandas as pd
 from joblib import Parallel, delayed
 
-from lib.shared.file_utils import validate_dtypes
+from lib.shared.file_utils import validate_dtypes, read_tsv_safe
 from lib.shared.parquet_io import write_parquet
-
-
-# Define function to read df tsv files
-def get_file(f):
-    try:
-        return pd.read_csv(f, sep="\t")
-    except pd.errors.EmptyDataError:
-        pass
-
 
 # Load and concatenate data
 all_dfs = Parallel(n_jobs=snakemake.threads)(
-    delayed(get_file)(file) for file in snakemake.input
+    delayed(read_tsv_safe)(file) for file in snakemake.input
 )
-combined_df = pd.concat(all_dfs).reset_index(drop=True)
+valid_dfs = [df for df in all_dfs if not df.empty]
+combined_df = (
+    pd.concat(valid_dfs).reset_index(drop=True) if valid_dfs else pd.DataFrame()
+)
 
 # Validate col types
 # Empty dfs can cause issues with dtype

--- a/workflow/scripts/shared/extract_phenotype_minimal.py
+++ b/workflow/scripts/shared/extract_phenotype_minimal.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from lib.shared.extract_phenotype_minimal import extract_phenotype_minimal
 from lib.shared.image_io import read_image
 
@@ -15,6 +17,16 @@ phenotype_minimal = extract_phenotype_minimal(
     nuclei_data=nuclei_data,
     wildcards=wc,
 )
+
+# Add alignment metrics columns if provided (e.g., phenotype has them, SBS does not)
+if len(snakemake.input) > 1:
+    alignment_metrics = pd.read_csv(snakemake.input[1], sep="\t")
+    # Excludes plate/well/tile as those are already in phenotype_minimal
+    metrics_cols = [
+        c for c in alignment_metrics.columns if c not in ["plate", "well", "tile"]
+    ]
+    for col in metrics_cols:
+        phenotype_minimal[col] = alignment_metrics[col].iloc[0]
 
 # save minimal phenotype data
 phenotype_minimal.to_csv(snakemake.output[0], index=False, sep="\t")

--- a/workflow/targets/aggregate.smk
+++ b/workflow/targets/aggregate.smk
@@ -1,11 +1,28 @@
 from lib.shared.file_utils import get_filename
+from lib.shared.compartment_utils import (
+    add_compartment_metadata,
+    add_compartment_suffix,
+    normalize_compartment_records,
+)
 from lib.shared.target_utils import map_outputs, outputs_to_targets
 
 
 AGGREGATE_FP = ROOT_FP / "aggregate"
+AGGREGATE_COMPARTMENT_METADATA = add_compartment_metadata(
+    {}, "{compartment_combo}", SPLIT_BY_COMPARTMENT
+)
 
 # Define standard (non-montage) aggreagte outputs
 AGGREGATE_OUTPUTS = {
+    "aggregate_cells_second_objs": [
+        AGGREGATE_FP
+        / "parquets"
+        / get_filename(
+            {"plate": "{plate}", "well": "{well}"},
+            "aggregated_cells_second_objs",
+            "parquet",
+        ),
+    ],
     "split_datasets": [
         AGGREGATE_FP
         / "parquets"
@@ -15,6 +32,7 @@ AGGREGATE_OUTPUTS = {
                 "well": "{well}",
                 "cell_class": "{cell_class}",
                 "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
             },
             "merge_data",
             "parquet",
@@ -29,6 +47,7 @@ AGGREGATE_OUTPUTS = {
                 "well": "{well}",
                 "cell_class": "{cell_class}",
                 "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
             },
             "filtered",
             "parquet",
@@ -38,21 +57,33 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "parquets"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "features_singlecell",
             "parquet",
         ),
         AGGREGATE_FP
         / "tsvs"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "features_constructs",
             "tsv",
         ),
         AGGREGATE_FP
         / "tsvs"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "features_genes",
             "tsv",
         ),
@@ -61,7 +92,11 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "parquets"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "aligned",
             "parquet",
         ),
@@ -70,7 +105,11 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "tsvs"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "aggregated",
             "tsv",
         ),
@@ -79,21 +118,33 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "eval"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "na_stats",
             "tsv",
         ),
         AGGREGATE_FP
         / "eval"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "na_stats",
             "png",
         ),
         AGGREGATE_FP
         / "eval"
         / get_filename(
-            {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+            {
+                "cell_class": "{cell_class}",
+                "channel_combo": "{channel_combo}",
+                **AGGREGATE_COMPARTMENT_METADATA,
+            },
             "feature_distributions",
             "png",
         ),
@@ -103,7 +154,7 @@ AGGREGATE_OUTPUTS = {
         AGGREGATE_FP
         / "anndata"
         / get_filename(
-            {"channel_combo": "{channel_combo}"},
+            {"channel_combo": "{channel_combo}", **AGGREGATE_COMPARTMENT_METADATA},
             "singlecell",
             "h5ad",
         ),
@@ -111,6 +162,7 @@ AGGREGATE_OUTPUTS = {
 }
 
 AGGREGATE_OUTPUT_MAPPINGS = {
+    "aggregate_cells_second_objs": None,
     "split_datasets": None,
     "filter": None,
     "perturbation_score_filter": None,
@@ -121,7 +173,25 @@ AGGREGATE_OUTPUT_MAPPINGS = {
     "format_singlecell_anndata": None,
 }
 
-AGGREGATE_OUTPUTS_MAPPED = map_outputs(AGGREGATE_OUTPUTS, AGGREGATE_OUTPUT_MAPPINGS)
+# Determine which outputs to include based on config
+AGGREGATE_SECOND_OBJ_DETECTION = config.get("phenotype", {}).get("second_obj_detection", False)
+
+if not AGGREGATE_SECOND_OBJ_DETECTION:
+    # Filter out secondary object rules when disabled
+    AGGREGATE_OUTPUTS_FILTERED = {
+        k: v for k, v in AGGREGATE_OUTPUTS.items()
+        if k not in ["aggregate_cells_second_objs"]
+    }
+
+    AGGREGATE_OUTPUT_MAPPINGS_FILTERED = {
+        k: v for k, v in AGGREGATE_OUTPUT_MAPPINGS.items()
+        if k not in ["aggregate_cells_second_objs"]
+    }
+else:
+    AGGREGATE_OUTPUTS_FILTERED = AGGREGATE_OUTPUTS
+    AGGREGATE_OUTPUT_MAPPINGS_FILTERED = AGGREGATE_OUTPUT_MAPPINGS
+
+AGGREGATE_OUTPUTS_MAPPED = map_outputs(AGGREGATE_OUTPUTS_FILTERED, AGGREGATE_OUTPUT_MAPPINGS_FILTERED)
 
 # TODO: Use all combos
 # aggregate_wildcard_combos = aggregate_wildcard_combos[
@@ -132,7 +202,7 @@ AGGREGATE_OUTPUTS_MAPPED = map_outputs(AGGREGATE_OUTPUTS, AGGREGATE_OUTPUT_MAPPI
 # ]
 
 AGGREGATE_TARGETS_ALL = outputs_to_targets(
-    AGGREGATE_OUTPUTS, aggregate_wildcard_combos, AGGREGATE_OUTPUT_MAPPINGS
+    AGGREGATE_OUTPUTS_FILTERED, aggregate_wildcard_combos, AGGREGATE_OUTPUT_MAPPINGS_FILTERED
 )
 
 
@@ -198,59 +268,119 @@ else:
         / "{cell_class}__montages_complete.flag",
     }
 cell_classes = aggregate_wildcard_combos["cell_class"].unique()
-MONTAGE_TARGETS_ALL = [
-    str(MONTAGE_OUTPUTS["montage_flag"]).format(cell_class=cell_class)
-    for cell_class in cell_classes
-]
+generate_montages = config.get("aggregate", {}).get("generate_montages", True)
+MONTAGE_TARGETS_ALL = (
+    [
+        str(MONTAGE_OUTPUTS["montage_flag"]).format(cell_class=cell_class)
+        for cell_class in cell_classes
+    ]
+    if generate_montages
+    else []
+)
 
 
 # Define bootstrap outputs
 # These are special because we dynamically derive outputs
+BOOTSTRAP_COMBO_STEM = add_compartment_suffix(
+    "{cell_class}__{channel_combo}",
+    "{compartment_combo}",
+    SPLIT_BY_COMPARTMENT,
+)
 BOOTSTRAP_OUTPUTS = {
     # Data preparation outputs
-    "bootstrap_data_dir": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__bootstrap_data",
-    "construct_data": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__bootstrap_data" / "{gene}__{construct}__construct_data.tsv",
-    
+    "bootstrap_data_dir": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__bootstrap_data",
+    "construct_data": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__bootstrap_data"
+    / "{gene}__{construct}__construct_data.tsv",
+
     # Input arrays
     "controls_arr": AGGREGATE_FP / "bootstrap" / "inputs" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            **AGGREGATE_COMPARTMENT_METADATA,
+        },
         "controls_arr", "tsv"
     ),
     "construct_features_arr": AGGREGATE_FP / "bootstrap" / "inputs" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            **AGGREGATE_COMPARTMENT_METADATA,
+        },
         "construct_features_arr", "tsv"
     ),
     "sample_sizes": AGGREGATE_FP / "bootstrap" / "inputs" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            **AGGREGATE_COMPARTMENT_METADATA,
+        },
         "sample_sizes", "tsv"
     ),
 
     # Construct-level outputs
-    "bootstrap_construct_nulls": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__constructs" / "{gene}__{construct}__nulls.npy",
-    "bootstrap_construct_pvals": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__constructs" / "{gene}__{construct}__pvals.tsv",
-    
+    "bootstrap_construct_nulls": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__constructs"
+    / "{gene}__{construct}__nulls.npy",
+    "bootstrap_construct_pvals": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__constructs"
+    / "{gene}__{construct}__pvals.tsv",
+
     # Gene-level outputs
-    "bootstrap_gene_nulls": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__genes" / "{gene}__nulls.npy",
-    "bootstrap_gene_pvals": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__genes" / "{gene}__pvals.tsv",
-    
+    "bootstrap_gene_nulls": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__genes"
+    / "{gene}__nulls.npy",
+    "bootstrap_gene_pvals": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__genes"
+    / "{gene}__pvals.tsv",
+
     # Completion flags
-    "bootstrap_flag": AGGREGATE_FP / "bootstrap" / "{cell_class}__{channel_combo}__bootstrap_complete.flag",
+    "construct_bootstrap_flag": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__construct_bootstrap_complete.flag",
+    "bootstrap_flag": AGGREGATE_FP
+    / "bootstrap"
+    / f"{BOOTSTRAP_COMBO_STEM}__bootstrap_complete.flag",
 
     # Combined results
     "combined_construct_results": AGGREGATE_FP / "bootstrap" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            **AGGREGATE_COMPARTMENT_METADATA,
+        },
         "all_construct_bootstrap_results", "tsv"
     ),
     "combined_gene_results": AGGREGATE_FP / "bootstrap" / get_filename(
-        {"cell_class": "{cell_class}", "channel_combo": "{channel_combo}"},
+        {
+            "cell_class": "{cell_class}",
+            "channel_combo": "{channel_combo}",
+            **AGGREGATE_COMPARTMENT_METADATA,
+        },
         "all_gene_bootstrap_results", "tsv"
     ),
 }
 
 # Bootstrap target combinations
-bootstrap_combos = config.get("aggregate", {}).get("bootstrap_combinations", [])
+bootstrap_combos = normalize_compartment_records(
+    config.get("aggregate", {}).get("bootstrap_combinations", []),
+    SPLIT_BY_COMPARTMENT,
+    DEFAULT_COMPARTMENT_COMBO,
+)
 BOOTSTRAP_TARGETS_ALL = [
-    str(output_path).format(cell_class=combo["cell_class"], channel_combo=combo["channel_combo"])
+    str(output_path).format(
+        cell_class=combo["cell_class"],
+        channel_combo=combo["channel_combo"],
+        compartment_combo=combo["compartment_combo"],
+    )
     for combo in bootstrap_combos
     for output_path in [
         BOOTSTRAP_OUTPUTS["combined_construct_results"],

--- a/workflow/targets/cluster.smk
+++ b/workflow/targets/cluster.smk
@@ -1,22 +1,23 @@
-import pandas as pd
-from itertools import product
-
+from lib.shared.compartment_utils import add_compartment_path
 from lib.shared.file_utils import get_filename
 from lib.shared.target_utils import map_outputs, outputs_to_targets
 
 
 CLUSTER_FP = ROOT_FP / "cluster"
+CLUSTER_OUTPUT_BASE = add_compartment_path(
+    CLUSTER_FP / "{channel_combo}",
+    "{compartment_combo}",
+    SPLIT_BY_COMPARTMENT,
+)
 
 CLUSTER_OUTPUTS = {
     "clean_aggregate": [
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / get_filename({}, "aggregate_cleaned", "tsv"),
     ],
     "phate_leiden_clustering": [
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename(
@@ -24,67 +25,55 @@ CLUSTER_OUTPUTS = {
             "phate_leiden_clustering",
             "tsv",
         ),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({}, "cluster_sizes", "png"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({}, "clusters", "png"),
     ],
     "benchmark_clusters": [
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "integrated_results", "json"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Shuffled"}, "integrated_results", "json"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "combined_table", "tsv"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Shuffled"}, "combined_table", "tsv"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "global_metrics", "json"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Shuffled"}, "global_metrics", "json"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "pie_chart", "png"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename(
             {"cluster_benchmark": "Shuffled"}, "enrichment_pie_chart", "png"
         ),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename({"cluster_benchmark": "Real"}, "enrichment_bar_chart", "png"),
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "{leiden_resolution}"
         / get_filename(

--- a/workflow/targets/cluster.smk
+++ b/workflow/targets/cluster.smk
@@ -81,8 +81,7 @@ CLUSTER_OUTPUTS = {
         ),
     ],
     "format_cluster_anndata": [
-        CLUSTER_FP
-        / "{channel_combo}"
+        CLUSTER_OUTPUT_BASE
         / "{cell_class}"
         / "h5ad"
         / get_filename({}, "cluster", "h5ad"),

--- a/workflow/targets/phenotype.smk
+++ b/workflow/targets/phenotype.smk
@@ -29,6 +29,7 @@ PHENOTYPE_OUTPUTS = {
     ],
     "align_phenotype": [
         PHENOTYPE_FP / get_image_output_path(_tile, "aligned", PHENOTYPE_IMG_FMT),
+        PHENOTYPE_FP / "tsvs" / get_data_output_path(_tile, "alignment_metrics", "tsv", PHENOTYPE_IMG_FMT),
     ],
     "segment_phenotype": [
         PHENOTYPE_FP / get_image_output_path(_tile, "nuclei", PHENOTYPE_IMG_FMT, subdirectory="labels"),
@@ -44,10 +45,24 @@ PHENOTYPE_OUTPUTS = {
     "combine_phenotype_info": [
         PHENOTYPE_FP / "parquets" / get_data_output_path(_well, "phenotype_info", "parquet", PHENOTYPE_IMG_FMT),
     ],
-    "extract_phenotype": [
+    "identify_second_objs": [
+        PHENOTYPE_FP / get_image_output_path(_tile, "identified_second_objs", PHENOTYPE_IMG_FMT, subdirectory="labels"),
+        PHENOTYPE_FP / "tsvs" / get_data_output_path(_tile, "cell_second_obj_table", "tsv", PHENOTYPE_IMG_FMT),
+        PHENOTYPE_FP / get_image_output_path(_tile, "updated_cytoplasms", PHENOTYPE_IMG_FMT, subdirectory="labels"),
+    ],
+    "extract_phenotype_cp": [
         PHENOTYPE_FP / "tsvs" / get_data_output_path(_tile, "phenotype_cp", "tsv", PHENOTYPE_IMG_FMT),
     ],
-    "merge_phenotype": [
+    "extract_phenotype_second_objs": [
+        PHENOTYPE_FP / "tsvs" / get_data_output_path(_tile, "phenotype_second_objs", "tsv", PHENOTYPE_IMG_FMT),
+    ],
+    "merge_phenotype_second_objs": [
+        PHENOTYPE_FP / "parquets" / get_data_output_path(_well, "phenotype_second_objs", "parquet", PHENOTYPE_IMG_FMT),
+    ],
+    "merge_second_objs_phenotype_cp": [
+        PHENOTYPE_FP / "tsvs" / get_data_output_path(_tile, "phenotype_with_second_objs", "tsv", PHENOTYPE_IMG_FMT),
+    ],
+    "merge_phenotype_cp": [
         PHENOTYPE_FP / "parquets" / get_data_output_path(_well, "phenotype_cp", "parquet", PHENOTYPE_IMG_FMT),
         PHENOTYPE_FP / "parquets" / get_data_output_path(_well, "phenotype_cp_min", "parquet", PHENOTYPE_IMG_FMT),
     ],
@@ -76,14 +91,33 @@ PHENOTYPE_OUTPUT_MAPPINGS = {
     "identify_cytoplasm": _phenotype_label_keep,
     "extract_phenotype_info": None,
     "combine_phenotype_info": None,
-    "extract_phenotype": None,
-    "merge_phenotype": None,
+    "identify_second_objs": [_phenotype_label_keep, None, _phenotype_label_keep],
+    "extract_phenotype_cp": None,
+    "extract_phenotype_second_objs": None,
+    "merge_phenotype_second_objs": None,
+    "merge_second_objs_phenotype_cp": None,
+    "merge_phenotype_cp": None,
     "eval_segmentation_phenotype": None,
     "eval_features": None,
 }
 
-PHENOTYPE_OUTPUTS_MAPPED = map_outputs(PHENOTYPE_OUTPUTS, PHENOTYPE_OUTPUT_MAPPINGS)
+# Secondary object outputs only exist when detection is enabled
+PHENOTYPE_SECOND_OBJ_DETECTION = config.get("phenotype", {}).get("second_obj_detection", False)
+_second_obj_keys = [
+    "identify_second_objs",
+    "extract_phenotype_second_objs",
+    "merge_phenotype_second_objs",
+    "merge_second_objs_phenotype_cp",
+]
+if PHENOTYPE_SECOND_OBJ_DETECTION:
+    PHENOTYPE_OUTPUTS_FILTERED = PHENOTYPE_OUTPUTS
+    PHENOTYPE_OUTPUT_MAPPINGS_FILTERED = PHENOTYPE_OUTPUT_MAPPINGS
+else:
+    PHENOTYPE_OUTPUTS_FILTERED = {k: v for k, v in PHENOTYPE_OUTPUTS.items() if k not in _second_obj_keys}
+    PHENOTYPE_OUTPUT_MAPPINGS_FILTERED = {k: v for k, v in PHENOTYPE_OUTPUT_MAPPINGS.items() if k not in _second_obj_keys}
+
+PHENOTYPE_OUTPUTS_MAPPED = map_outputs(PHENOTYPE_OUTPUTS_FILTERED, PHENOTYPE_OUTPUT_MAPPINGS_FILTERED)
 
 PHENOTYPE_TARGETS_ALL = outputs_to_targets(
-    PHENOTYPE_OUTPUTS, phenotype_wildcard_combos, PHENOTYPE_OUTPUT_MAPPINGS
+    PHENOTYPE_OUTPUTS_FILTERED, phenotype_wildcard_combos, PHENOTYPE_OUTPUT_MAPPINGS_FILTERED
 )

--- a/workflow/targets/sbs.smk
+++ b/workflow/targets/sbs.smk
@@ -20,6 +20,7 @@ _sbs_tile_expand = ["row", "col", "tile"] if SBS_IMG_FMT == "zarr" else ["well",
 SBS_OUTPUTS = {
     "align_sbs": [
         SBS_FP / get_image_output_path(_tile, "aligned", SBS_IMG_FMT),
+        SBS_FP / "tsvs" / get_data_output_path(_tile, "alignment_metrics", "tsv", SBS_IMG_FMT),
     ],
     "log_filter": [
         SBS_FP / get_image_output_path(_tile, "log_filtered", SBS_IMG_FMT),


### PR DESCRIPTION
# Description

Port of the secondary-object feature (#171, `secondary_object` → `main`) onto the `zarr3` line. Adds the option to segment and phenotype additional objects contained within cells, plus the alignment-metrics (`offset_*`) QC columns and the optional `split_by_compartment` aggregation, all working in both tiff and OME-Zarr output modes.

The feature was brought over as the squashed `main...secondary_object` diff (not cherry-picked), then reconciled by hand where zarr3 had rewritten the same files. Behaviour with `second_obj_detection: false` and `split_by_compartment: false` is unchanged; existing zarr3 screens keep byte-identical output paths.

## How the feature was expressed on zarr3

- **Rule/output names** follow the `main` feature: `extract_phenotype` → `extract_phenotype_cp`, `merge_phenotype` → `merge_phenotype_cp`; merge/eval references updated. Keeps zarr3 and `main` aligned once #171 lands.
- **Paths** for the new outputs go through `get_image_output_path` / `get_data_output_path` (alignment metrics TSVs, second-object label images under `labels/`, per-tile and per-well tables), so they nest correctly in zarr mode.
- **Scripts** for the second-object stages read/write via `image_io` (`read_image` / `save_image(..., is_label=True)`) and `parquet_io`, and synthesize `well` from `row` + `col` where zarr wildcards apply.
- **`aggregate_cells_second_objs`** bridges the phenotype well-level parquet through `output_to_input` with row/col expansion, the same way `merge.smk` does.
- **Aggregate overlap with #258** (grouped aggregation / well annotations / `control_mask`): both are kept. `split_datasets` iterates the zipped `(cell_class, channel_combo, compartment_combo)` specs and still honours `split_col` and well annotations; `generate_feature_table` and `perturbation_score` detect controls with `control_mask(<control_name_col>, control_key)` so composite group keys and `control_name_col` work together.
- **zarr3-only anndata rules** (`format_singlecell_anndata`, `format_cluster_anndata`) now resolve their inputs/outputs on the compartment path so they work with `split_by_compartment: true`.
- **Two feature-branch bugs surfaced by running small_test with detection on** (main never runs that configuration): `aggregate_cells_second_objs` crashed on a screen with zero detected objects (empty, column-less per-well table with strategy `none`), and `split_cell_data` rejected the per-cell `second_obj_ids` list as a non-numeric feature. Fixed here by passing the empty table through and reserving `second_obj_ids` as metadata; both fixes apply to `main` as well (noted on #171).
- **Residual-QC blocks** in `align_cycles` / `align_channels` unpack the new `(offsets, errors)` return of `calculate_offsets`.
- **small_test** config gets `compartment_combo` columns in the aggregate/cluster combos, `split_by_compartment: true`, and `second_obj_detection: false`, mirroring the `main` test.

## New config parameters

Same surface as #171 (see the parameter inventory comment there): `phenotype.second_obj_detection`, `phenotype.second_obj_channel_index` and the classical/ML segmentation knobs; `aggregate.split_by_compartment`, `aggregate.second_obj_agg_strategy`, `aggregate.generate_montages`, per-entry `bootstrap_combinations[].compartment_combo`; optional `compartment_combo` column in `aggregate_combo.tsv` / `cluster_combo.tsv`.

## Validation

- `snakemake -n` builds the full DAG in tiff and zarr modes, each with `second_obj_detection` on and off.
- Full `small_test_analysis` run: tiff (`run_brieflow.sh`), zarr (`run_brieflow.sh --zarr`), and zarr with secondary-object detection enabled — all three complete with no rule errors (Slurm, 16 cores; 3633 / 3646 / 373 steps).

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

- [x] My code follows the [conventions](https://github.com/cheeseman-lab/brieflow?tab=readme-ov-file#conventions) of this project.
- [ ] I have updated the `pyproject.toml` to reflect the change as designated by [semantic versioning](https://semver.org/).
- [x] I have checked linting and formatting with `ruff check` and `ruff format`.
- [x] I have performed a self-review of my own code.
- [x] I have deleted all non-relevant text in this pull request template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGSeYYFUjnFiBvDqA22MkN
