### PR TITLE
Make the Streamlit visualizer read OME-Zarr pipeline output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,12 @@ dependencies = [
   "marimo==0.23.6",
 ]
 
+[project.optional-dependencies]
+mozzarellm = [
+  "mozzarellm @ git+https://github.com/cheeseman-lab/mozzarellm.git@cot-mcp",
+  "python-dotenv==1.2.3",
+]
+
 
 [tool.setuptools]
 package-dir = {"" = "workflow"}

--- a/visualization/.streamlit/config.toml
+++ b/visualization/.streamlit/config.toml
@@ -1,0 +1,37 @@
+[theme]
+base = "light"
+primaryColor = "#2B6E8F"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F4F6F8"
+textColor = "#1F2A37"
+linkColor = "#2B6E8F"
+borderColor = "#E2E8F0"
+dataframeBorderColor = "#E2E8F0"
+dataframeHeaderBackgroundColor = "#F4F6F8"
+showSidebarBorder = true
+font = "sans-serif"
+headingFont = "sans-serif"
+codeFont = "monospace"
+baseRadius = "medium"
+chartCategoricalColors = [
+    "#2B6E8F",
+    "#C97B3C",
+    "#5B8C5A",
+    "#8E6C9B",
+    "#B55A5A",
+    "#4F7CA3",
+    "#7A8B99",
+    "#A38A4B",
+]
+chartSequentialColors = [
+    "#EDF3F6",
+    "#D5E3EB",
+    "#BAD2DF",
+    "#9CC0D3",
+    "#7CADC5",
+    "#5B99B6",
+    "#3D84A5",
+    "#2B6E8F",
+    "#1F5872",
+    "#144255",
+]

--- a/visualization/Cluster_Analysis.py
+++ b/visualization/Cluster_Analysis.py
@@ -1,9 +1,19 @@
 import streamlit as st
 import uuid
 
-st.set_page_config(
-    page_title="Cluster Analysis - Brieflow Analysis",
-    layout="wide",
+from src.theme import (
+    ACCENT,
+    CATEGORICAL,
+    empty_state,
+    page_setup,
+    sidebar_filters_header,
+    style_figure,
+)
+
+page_setup(
+    "Cluster Analysis",
+    "🧫",
+    "Gene clusters in the PHATE embedding, with per-cluster annotation and example cell montages.",
 )
 
 import anndata as ad
@@ -59,6 +69,9 @@ BOOKKEEPING_COLUMNS = [
 
 # bootstrap significance layers, most directly usable first
 SIGNIFICANCE_LAYERS = ("neg_log10_fdr", "fdr")
+
+# Montage crops per row, so a gene's examples read as a grid rather than a column
+MONTAGE_COLUMNS = 4
 
 # Common hover data columns
 HOVER_COLUMNS = ["gene_symbol_0", "cluster", "cell_count", "source"]
@@ -286,13 +299,13 @@ def get_montage_root(cell_class):
 def display_gene_montages(gene_montages_root, gene):
     gene_dir = os.path.join(gene_montages_root, gene)
     if not os.path.exists(gene_dir):
-        st.warning(f"No montage directory found for gene {gene}")
+        empty_state(f"No montage directory for gene {gene}.")
     elif IMAGE_FORMAT == "zarr":
         display_gene_montages_zarr(gene_montages_root, gene)
     else:
         montage_data = load_montage_data(gene_montages_root, gene)
         if montage_data.empty:
-            st.write(f"No montage data found for gene {gene}")
+            empty_state(f"No montage data found for gene {gene}.")
         else:
             # Add filters for guide and channel
             available_guides = sorted(montage_data["guide"].unique())
@@ -304,20 +317,27 @@ def display_gene_montages(gene_montages_root, gene):
             ]
 
             if len(filtered_montage_data) > 0:
-                # Display each image in the filtered data
-                for _, row in filtered_montage_data.iterrows():
+                # Display each image in the filtered data, capped columns per row
+                rows = list(filtered_montage_data.iterrows())
+                cols = st.columns(min(MONTAGE_COLUMNS, len(rows)))
+                for index, (_, row) in enumerate(rows):
                     # Construct the full path including the montages directory
                     image_path = os.path.join(gene_montages_root, row["file_path"])
                     channel_name = row["channel"]
                     channel_name = channel_name.replace("CH-", "")
 
-                    try:
-                        if os.path.exists(image_path):
-                            st.image(image_path, caption=f"Channel: {channel_name}")
-                        else:
-                            st.error(f"Image file not found: {image_path}")
-                    except Exception as e:
-                        st.error(f"Error displaying image: {str(e)}")
+                    with cols[index % len(cols)]:
+                        try:
+                            if os.path.exists(image_path):
+                                st.image(
+                                    image_path,
+                                    caption=channel_name,
+                                    use_container_width=True,
+                                )
+                            else:
+                                st.error(f"Image file not found: {image_path}")
+                        except Exception as e:
+                            st.error(f"Error displaying image: {str(e)}")
 
                 # Add download button for overlay TIFF
                 overlay_tiff_path = os.path.join(
@@ -340,38 +360,41 @@ def display_gene_montages(gene_montages_root, gene):
                                 key=f"download_{gene}_{selected_guide}_{row['channel']}_{uuid.uuid4()}",
                             )
                 else:
-                    st.warning(f"No overlay tiff found: {overlay_tiff_path}")
+                    st.caption("No overlay TIFF written for this guide.")
             else:
-                st.warning(f"No image found for {gene} - {selected_guide}")
+                empty_state(f"No montage image for {gene} - {selected_guide}.")
 
 
 def display_gene_montages_zarr(gene_montages_root, gene):
     """Display the per-cell OME-Zarr crops the zarr pipeline writes instead of montage PNGs."""
     available_guides = sorted(list_montage_guides(gene_montages_root, gene))
     if not available_guides:
-        st.write(f"No montage data found for gene {gene}")
+        empty_state(f"No montage data found for gene {gene}.")
         return
 
     selected_guide = select_montage_guide(gene, available_guides)
     crop_paths = load_montage_crops(gene_montages_root, gene, selected_guide)
     if not crop_paths:
-        st.warning(f"No image found for {gene} - {selected_guide}")
+        empty_state(f"No montage image for {gene} - {selected_guide}.")
         return
 
     channel_names = read_zarr_channel_names(crop_paths[0])
-    for crop_path in crop_paths:
+    for crop_index, crop_path in enumerate(crop_paths):
         crop = read_image(crop_path)
         if crop.ndim == 2:
             crop = crop[np.newaxis, ...]
-        cols = st.columns(len(crop))
+        st.caption(f"Cell {crop_index + 1} of {len(crop_paths)}")
+        cols = st.columns(min(MONTAGE_COLUMNS, len(crop)))
         for index, channel_image in enumerate(crop):
             label = (
                 channel_names[index]
                 if channel_names and index < len(channel_names)
                 else f"Channel {index}"
             )
-            cols[index].image(
-                scale_to_uint8(channel_image), caption=f"Channel: {label}"
+            cols[index % len(cols)].image(
+                scale_to_uint8(channel_image),
+                caption=label,
+                use_container_width=True,
             )
 
 
@@ -420,7 +443,7 @@ def select_montage_guide(gene, available_guides):
         st.session_state[f"selected_guide_{gene}"] = available_guides[0]
 
     return st.selectbox(
-        "Select Guide",
+        "Guide",
         available_guides,
         index=selected_index,
         key=f"guide_dropdown_{gene}",  # Use a stable key based on the selected gene
@@ -456,20 +479,17 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
         # Build a color map using the group names and the color palette
         group_names = cluster_data[st.session_state.groupby_column].unique()
 
-        # Create a color palette optimized for visibility on a black background
+        # Use the theme palette while it has enough distinct colors, then fall back
+        # to a perceptually uniform colormap for runs with many clusters
         def get_optimized_color_palette(num_colors):
-            # Use a perceptually uniform colormap that works well on dark backgrounds
-            # Options: 'viridis', 'plasma', 'inferno', 'magma', 'cividis'
-            colormap_name = "turbo"  # Good visibility on dark backgrounds
+            if num_colors <= len(CATEGORICAL):
+                return CATEGORICAL[:num_colors]
 
-            # Get evenly spaced colors from the colormap
-            cmap = plt.get_cmap(colormap_name)
-            colors = [
+            cmap = plt.get_cmap("turbo")
+            return [
                 mcolors.rgb2hex(cmap(i / (num_colors - 1 if num_colors > 1 else 1)))
                 for i in range(num_colors)
             ]
-
-            return colors
 
         # Get enough colors for all groups
         optimized_palette = get_optimized_color_palette(len(group_names))
@@ -495,9 +515,9 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
                 if group != selected_item:
                     group_df = cluster_data[cluster_data[groupby_column] == group]
                     marker = dict(
-                        color="gray",  # All unselected points are gray
-                        size=8,
-                        opacity=0.3,
+                        color="#C7D0D7",  # All unselected points are muted gray
+                        size=7,
+                        opacity=0.55,
                     )
                     fig.add_trace(
                         make_scatter_trace(
@@ -535,9 +555,9 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
                     if not other_genes_df.empty:
                         marker = dict(
                             color=color_map[group],
-                            size=10,
+                            size=9,
                             opacity=1.0,
-                            line=dict(width=2, color="black"),
+                            line=dict(width=1, color="#FFFFFF"),
                         )
                         fig.add_trace(
                             make_scatter_trace(
@@ -554,15 +574,11 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
                     # Add the selected gene with special highlighting
                     if not selected_gene_df.empty:
                         marker = dict(
-                            color=color_map[
-                                group
-                            ],  # Use the cluster's color instead of red
-                            size=15,  # Larger size
+                            color=color_map[group],  # Use the cluster's color
+                            size=16,
                             opacity=1.0,
-                            symbol="circle",  # Filled circle
-                            line=dict(
-                                width=3, color="white"
-                            ),  # White border for contrast
+                            symbol="circle",
+                            line=dict(width=2, color="#1F2A37"),
                         )
                         fig.add_trace(
                             make_scatter_trace(
@@ -581,8 +597,8 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
                 group_df = cluster_data[cluster_data[groupby_column] == group]
                 marker = dict(
                     color=color_map[group],
-                    size=8,
-                    opacity=1.0,
+                    size=7,
+                    opacity=0.9,
                 )
                 fig.add_trace(
                     make_scatter_trace(
@@ -597,12 +613,14 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
                 )
 
         # Update layout
-        fig.update_layout(
+        style_figure(
+            fig,
             hovermode="closest",
             showlegend=False,
             title="",
-            width=1000,
-            height=800,
+            height=760,
+            xaxis_title="PHATE 0",
+            yaxis_title="PHATE 1",
         )
 
         # Apply saved zoom coordinates if they exist
@@ -684,14 +702,21 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
                 ]
 
     else:
-        st.write("No cluster data files found.")
+        empty_state(
+            "No cluster data found for the selected filters.",
+            "The cluster step writes one h5ad per channel combo under `cluster/`.",
+        )
 
 
 def cluster_table(cluster_data):
     # Display data overview
-    st.markdown("## Cluster Data Overview")
+    st.subheader("Genes")
+    st.caption("One row per gene, with its cluster assignment and gene metadata.")
     if cluster_data.empty:
-        st.warning("No cluster data found for the selected filters.")
+        empty_state(
+            "No cluster data found for the selected filters.",
+            "The cluster step writes one h5ad per channel combo under `cluster/`.",
+        )
         return
 
     table_data = cluster_data.drop(
@@ -704,19 +729,33 @@ def cluster_table(cluster_data):
         ]
 
     if table_data.empty:
-        st.warning("⚠️ WARNING: No genes found for the selected cluster.")
+        empty_state("No genes found for the selected cluster.")
         return
-    st.dataframe(table_data.set_index("gene_symbol_0"))
+    st.dataframe(
+        table_data.set_index("gene_symbol_0"),
+        use_container_width=True,
+        height=360,
+        column_config={
+            "cluster": st.column_config.TextColumn("Cluster", width="small"),
+            "cell_count": st.column_config.NumberColumn("Cells", format="%d"),
+            "uniprot_link": st.column_config.LinkColumn(
+                "UniProt", display_text="entry"
+            ),
+        },
+    )
 
 
 def feature_table(adata):
     # Feature Data Overview
-    st.markdown("## Feature Data Overview")
-    st.markdown(
+    st.subheader("Features")
+    st.caption(
         "Median feature values per gene after center scaling all single cell data on control cells by well."
     )
     if adata is None:
-        st.warning("⚠️ WARNING: No cluster h5ad found for the selected filters.")
+        empty_state(
+            "No cluster h5ad found for the selected filters.",
+            "`rule format_cluster_anndata` writes `cluster/**/h5ad/*.h5ad`.",
+        )
         return
 
     feature_df = pd.DataFrame(
@@ -726,18 +765,21 @@ def feature_table(adata):
         feature_df.insert(0, "cell_count", adata.obs["cell_count"].to_numpy())
     feature_df.index.name = "gene_symbol_0"
 
-    # Create a container with a fixed height and scrolling
-    with st.container():
-        # Display the dataframe with all columns and sorting enabled
+    # Wide and long, so it opens on demand inside a scrolling expander
+    with st.expander(
+        f"{feature_df.shape[0]:,} genes x {feature_df.shape[1]:,} columns",
+        expanded=False,
+    ):
         st.dataframe(
             feature_df,
             use_container_width=True,
             height=400,  # Fixed height for scrolling
             column_config={
-                # Configure all columns to be sortable
-                col: st.column_config.NumberColumn(width="medium")
+                col: st.column_config.NumberColumn(width="medium", format="%.3f")
                 for col in feature_df.columns
-            },
+                if col != "cell_count"
+            }
+            | {"cell_count": st.column_config.NumberColumn("Cells", format="%d")},
         )
 
 
@@ -759,21 +801,22 @@ def gene_significance_chart(adata, gene):
     if layer == "fdr":
         significance = -np.log10(np.clip(significance, 1e-300, None))
 
-    st.markdown("#### Feature Significance")
+    st.markdown("##### Feature significance")
     fig = go.Figure(
         go.Scattergl(
             x=effect,
             y=significance,
             mode="markers",
             text=adata.var_names.to_list(),
-            marker=dict(size=6, opacity=0.7),
+            marker=dict(size=6, opacity=0.7, color=ACCENT),
             hovertemplate="%{text}<br>value=%{x}<br>-log10 FDR=%{y}<extra></extra>",
         )
     )
-    fig.update_layout(
+    style_figure(
+        fig,
         xaxis_title="Feature value",
         yaxis_title="-log10 FDR",
-        height=400,
+        height=360,
         showlegend=False,
     )
     st.plotly_chart(fig, use_container_width=True, key=f"significance_{gene}")
@@ -783,13 +826,15 @@ def cluster_size_charts(cluster_data):
     if cluster_data.empty:
         return
 
+    st.subheader("Cluster composition")
+
     # Create two equal-sized columns
     col1, col2 = st.columns([1, 1])
 
     cluster_dir = get_cluster_dir(cluster_data)
 
     with col1:
-        st.markdown("### Cluster Sizes")
+        st.markdown("##### Cluster sizes")
         # Cluster membership lives in obs, so count the genes per cluster instead of
         # reading the PNG the pipeline renders.
         sizes = (
@@ -800,10 +845,24 @@ def cluster_size_charts(cluster_data):
             .reset_index(name="genes")
             .sort_values("cluster", key=lambda values: values.astype(int))
         )
-        st.bar_chart(sizes, x="cluster", y="genes")
+        sizes_fig = go.Figure(
+            go.Bar(x=sizes["cluster"], y=sizes["genes"], marker_color=ACCENT)
+        )
+        style_figure(
+            sizes_fig,
+            height=320,
+            yaxis_title="Genes",
+            xaxis=dict(
+                title="Cluster",
+                type="category",
+                categoryorder="array",
+                categoryarray=sizes["cluster"].tolist(),
+            ),
+        )
+        st.plotly_chart(sizes_fig, use_container_width=True, key="cluster_sizes")
 
     with col2:
-        st.markdown("### Cluster Enrichment")
+        st.markdown("##### Cluster enrichment")
         # Construct the path to the enrichment pie chart
         enrichment_pie_path = os.path.join(cluster_dir, "CB-Real__pie_chart.png")
 
@@ -811,8 +870,10 @@ def cluster_size_charts(cluster_data):
         if os.path.exists(enrichment_pie_path):
             st.image(enrichment_pie_path, use_container_width=True)
         else:
-            st.warning(
-                f"Cluster enrichment pie chart not found at: {enrichment_pie_path}"
+            empty_state(
+                "No cluster enrichment chart for this resolution.",
+                "`rule benchmark_clusters` writes `CB-Real__pie_chart.png` next to the "
+                "clustering outputs.",
             )
 
 
@@ -840,72 +901,44 @@ def display_cluster_json(cluster_data, container=st.container()):
         )
 
         # Always show the section header
-        st.markdown("### LLM Cluster Analysis")
+        st.subheader("LLM cluster analysis")
 
         if os.path.exists(cluster_json_path):
             with open(cluster_json_path, "r") as f:
                 c = json.load(f)
-            # Card layout using markdown and Streamlit elements
-            st.markdown(
-                f"""
-                <div style='background-color:#1e1e1e; border-radius:10px; padding:20px; margin-bottom:20px; box-shadow:0 2px 8px #00000040;'>
-                    <div style='display:flex; justify-content:space-between; align-items:center;'>
-                        <div>
-                            <span style='font-size:1.3em; font-weight:bold; color:#e0e0e0;'>Dominant Process:</span>
-                            <span style='font-size:1.3em; color:#60a5fa; font-weight:bold;'>{
-                    c.get("dominant_process", "")
-                }</span>
-                        </div>
-                        <div>
-                            <span style='background:#1e3a8a; color:#93c5fd; border-radius:6px; padding:4px 12px; font-weight:600;'>Confidence: {
-                    c.get("pathway_confidence", "")
-                }</span>
-                        </div>
-                    </div>
-                    <div style='margin-top:10px; margin-bottom:10px; font-size:1.1em; color:#d1d5db;'>
-                        {c.get("summary", "")}
-                    </div>
-                    <div style='margin-top:18px;'>
-                        <span style='font-weight:600; color:#60a5fa;'>Established Genes:</span>
-                        <span style='margin-left:8px;'>{
-                    " ".join(
-                        [
-                            f"<span style='background:#064e3b; color:#6ee7b7; border-radius:4px; padding:2px 8px; margin-right:4px;'>{gene}</span>"
-                            for gene in c.get("established_genes", [])
-                        ]
-                    )
-                }</span>
-                    </div>
-                    <div style='margin-top:10px;'>
-                        <span style='font-weight:600; color:#fbbf24;'>Novel Role Genes:</span>
-                        <ul style='margin:0; padding-left:20px;'>
-                        {
-                    "".join(
-                        [
-                            f"<li><span style='background:#78350f; color:#fcd34d; border-radius:4px; padding:2px 8px; margin-right:4px;'>{gene['gene']}</span> <span style='color:#9ca3af;'>{gene['rationale']}</span></li>"
-                            for gene in c.get("novel_role_genes", [])
-                        ]
-                    )
-                }</ul>
-                    </div>
-                    <div style='margin-top:10px;'>
-                        <span style='font-weight:600; color:#c084fc;'>Uncharacterized Genes:</span>
-                        <ul style='margin:0; padding-left:20px;'>
-                        {
-                    "".join(
-                        [
-                            f"<li><span style='background:#5b21b6; color:#d8b4fe; border-radius:4px; padding:2px 8px; margin-right:4px;'>{gene['gene']}</span> <span style='color:#9ca3af;'>{gene['rationale']}</span></li>"
-                            for gene in c.get("uncharacterized_genes", [])
-                        ]
-                    )
-                }</ul>
-                    </div>
-                </div>
-            """,
-                unsafe_allow_html=True,
+
+            process_col, confidence_col = st.columns([3, 1])
+            process_col.metric("Dominant process", c.get("dominant_process", "—"))
+            confidence_col.metric(
+                "Pathway confidence", str(c.get("pathway_confidence", "—")).title()
             )
+
+            summary = c.get("summary", "")
+            if summary:
+                st.markdown(summary)
+
+            established = c.get("established_genes", [])
+            if established:
+                st.markdown("**Established genes**")
+                st.markdown(" ".join(f":green-badge[{gene}]" for gene in established))
+
+            novel = c.get("novel_role_genes", [])
+            if novel:
+                st.markdown("**Novel role genes**")
+                for gene in novel:
+                    st.markdown(
+                        f":orange-badge[{gene['gene']}] {gene.get('rationale', '')}"
+                    )
+
+            uncharacterized = c.get("uncharacterized_genes", [])
+            if uncharacterized:
+                st.markdown("**Uncharacterized genes**")
+                for gene in uncharacterized:
+                    st.markdown(
+                        f":violet-badge[{gene['gene']}] {gene.get('rationale', '')}"
+                    )
         else:
-            # Show placeholder card when LLM data is not available
+            # Show a hint about where the analysis does exist when it is missing here
             current_cell_class = st.session_state.get("cell_class", "unknown")
             current_resolution = st.session_state.get("leiden_resolution", "unknown")
             channel_combo = st.session_state.get("channel_combo", "")
@@ -915,7 +948,10 @@ def display_cluster_json(cluster_data, container=st.container()):
 
             # Smart context: tailor message based on what's wrong
             if not available:
-                available_text = "No LLM analysis available for this dataset."
+                available_text = (
+                    "The `mozzarellm` step writes `mozzarellm/clusters/cluster_*.json` "
+                    "next to the clustering outputs."
+                )
             else:
                 # Check if current cell class has any LLM data
                 cell_classes_with_llm = set(cc for cc, res in available)
@@ -935,20 +971,10 @@ def display_cluster_json(cluster_data, container=st.container()):
                         f"Available for: {', '.join(sorted(cell_classes_with_llm))}"
                     )
 
-            st.markdown(
-                f"""
-                <div style='background-color:#1e1e1e; border-radius:10px; padding:20px; margin-bottom:20px; box-shadow:0 2px 8px #00000040; border: 1px solid #374151;'>
-                    <div style='color:#9ca3af; font-size:1.1em;'>
-                        <span style='font-size:1.2em;'>ℹ️</span>
-                        LLM analysis is not available for <strong>{current_cell_class}</strong> cells
-                        at resolution <strong>{current_resolution}</strong>.
-                    </div>
-                    <div style='margin-top:12px; color:#6b7280; font-size:0.95em;'>
-                        {available_text}
-                    </div>
-                </div>
-            """,
-                unsafe_allow_html=True,
+            empty_state(
+                f"No LLM analysis for **{current_cell_class}** cells at resolution "
+                f"**{current_resolution}**.",
+                available_text,
             )
 
 
@@ -962,14 +988,14 @@ def display_uniprot_info():
     if gene_rows.empty or "uniprot_entry" not in gene_rows.columns:
         return
 
-    st.write(
-        f"Uniprot Entry: [{gene_rows['uniprot_entry'].values[0]}]({gene_rows['uniprot_link'].values[0]})"
+    st.markdown(
+        f"**UniProt entry:** [{gene_rows['uniprot_entry'].values[0]}]({gene_rows['uniprot_link'].values[0]})"
     )
     function_text = gene_rows["uniprot_function"].values[0]
     if isinstance(function_text, str) and function_text.strip():
-        st.markdown(f"Uniprot Function:\n>{function_text}")
+        st.markdown(f"> {function_text}")
     else:
-        st.write("Uniprot Function: Not available")
+        st.caption("No UniProt function annotation for this gene.")
 
 
 # -- Search/Filter state management --
@@ -1129,8 +1155,9 @@ def apply_all_filters(data):
 
     # Create the radio button with a stable key
     selected_channel_combo = st.sidebar.radio(
-        "**Channel Combo** - *Used to subset features during aggregation*",
+        "Channel combo",
         channel_combo_options,
+        help="Which channels' features the aggregation step kept.",
         index=channel_combo_options.index(st.session_state.channel_combo)
         if st.session_state.channel_combo in channel_combo_options
         else 0,
@@ -1155,8 +1182,9 @@ def apply_all_filters(data):
 
     # Create the radio button with a stable key
     selected_cell_class = st.sidebar.radio(
-        "**Cell Class** - *Used to subset single cell data with classifier provided during aggregation*",
+        "Cell class",
         cell_class_options,
+        help="Single-cell subset chosen by the classifier supplied during aggregation.",
         index=cell_class_options.index(st.session_state.cell_class),
         key="cell_class_radio_main",
         on_change=on_cell_class_change,
@@ -1180,8 +1208,9 @@ def apply_all_filters(data):
 
     # Create the radio button with a stable key
     selected_lr = st.sidebar.radio(
-        """**Leiden Resolution** - *Used in the Leiden clustering algorithm to determine gene clusters*""",
+        "Leiden resolution",
         leiden_options,
+        help="Resolution the Leiden algorithm used to form the gene clusters.",
         index=leiden_options.index(st.session_state.leiden_resolution)
         if st.session_state.leiden_resolution in leiden_options
         else 0,
@@ -1238,21 +1267,24 @@ all_clusters = sorted(
     [str(c) for c in cluster_data["cluster"].unique()], key=lambda x: int(x)
 )
 
-st.sidebar.title("Filters")
+sidebar_filters_header("Pick the clustering run to explore.")
 cluster_data = apply_all_filters(cluster_data)
 cluster_genes = get_cluster_genes(cluster_data, st.session_state.selected_item)
 
 # --- UI Layout ---
-st.title("Cluster Analysis")
-st.markdown(
-    "*Click a cluster to see details, panning and zooming is easily done through the top right of the cluster panel*"
-)
-
 # Add filters section in sidebar FIRST
 # Remove duplicate call to apply_all_filters since it's already called above
 # cluster_data = apply_all_filters(cluster_data)  # This line is removed
 
 # --- Widget Rendering ---
+genes_col, clusters_col, res_col, class_col = st.columns(4)
+genes_col.metric("Genes", f"{cluster_data['gene_symbol_0'].nunique():,}")
+clusters_col.metric("Clusters", f"{cluster_data['cluster'].nunique():,}")
+res_col.metric("Leiden resolution", str(st.session_state.leiden_resolution))
+class_col.metric("Cell class", str(st.session_state.cell_class))
+
+st.divider()
+
 col1, col2 = st.columns(2)
 with col1:
     # Global gene dropdown with placeholder
@@ -1265,8 +1297,9 @@ with col1:
     )
     st.session_state.selected_gene_global = gene_val
     selected_gene = st.selectbox(
-        "Gene Search",
+        "Find a gene",
         options=gene_options,
+        help="Jumps to the gene and selects the cluster it belongs to.",
         index=gene_options.index(gene_val) if gene_val in gene_options else 0,
         key="selected_gene_global",
         on_change=on_global_gene_select,
@@ -1285,8 +1318,9 @@ with col2:
     )
     st.session_state.cluster_dropdown = cluster_val
     st.selectbox(
-        "Cluster Search",
+        "Open a cluster",
         options=cluster_options,
+        help="Opens the cluster detail panel; also set by clicking a point in the embedding.",
         index=cluster_options.index(cluster_val)
         if cluster_val in cluster_options
         else 0,
@@ -1302,6 +1336,10 @@ cluster_adata = get_active_h5ad(cluster_data)
 
 if not st.session_state.selected_item:
     # No cluster selected: Just show the full width cluster plot
+    st.subheader("PHATE embedding")
+    st.caption(
+        "Click a point to open its cluster; pan and zoom from the toolbar above the plot."
+    )
     display_cluster(
         cluster_data,
         cell_class=st.session_state.cell_class,
@@ -1313,8 +1351,12 @@ if not st.session_state.selected_item:
 
 else:
     # Cluster selected: Two columns: plot | detail.
-    col1, col2 = st.columns([1, 1])
+    col1, col2 = st.columns([3, 2], gap="large")
     with col1:
+        st.subheader("PHATE embedding")
+        st.caption(
+            "Click a point to open its cluster; pan and zoom from the toolbar above the plot."
+        )
         display_cluster(
             cluster_data, cell_class=cell_class, channel_combo=channel_combo
         )
@@ -1334,26 +1376,13 @@ else:
 
         ## Cluster Info
         # Create two columns for the title and clear button
-        title_col, button_col = st.columns([2, 1])
+        title_col, button_col = st.columns([3, 2], vertical_alignment="bottom")
         with title_col:
-            st.write(f"## Cluster {st.session_state.selected_item}: {len(genes)} genes")
+            st.subheader(f"Cluster {st.session_state.selected_item}")
+            st.caption(f"{len(genes)} genes")
         with button_col:
-            # Add float styling and red color specifically for the Close Cluster button
-            st.markdown(
-                """
-                <style>
-                div[data-testid="stButton"] button {
-                    float: right;
-                    background-color: #dc2626 !important;
-                    border-color: #dc2626 !important;
-                    color: white !important;
-                }
-                </style>
-            """,
-                unsafe_allow_html=True,
-            )
             # Show selected item and clear button if an item is selected
-            if st.button("Close Cluster"):
+            if st.button("Close cluster"):
                 st.session_state.selected_item = None
                 st.session_state.selected_gene = None
                 st.rerun()
@@ -1363,7 +1392,9 @@ else:
         ## Montages
         # Check if gene_montages_root directory exists
         if os.path.exists(gene_montages_root):
-            st.markdown("#### Gene Montages")
+            st.divider()
+            st.subheader("Gene montages")
+            st.caption("Example cells for one gene and guide in this cluster.")
 
             # Cluster gene dropdown
             if cluster_genes:
@@ -1374,14 +1405,15 @@ else:
                 )
                 st.session_state.selected_gene_cluster = gene_val
                 st.selectbox(
-                    "Select a gene to view (within this cluster)",
+                    "Gene",
                     options=cluster_genes,
+                    help="Genes assigned to this cluster.",
                     index=cluster_genes.index(gene_val),
                     key="selected_gene_cluster",
                     on_change=on_cluster_gene_select,
                 )
             else:
-                st.write("No genes found in this cluster.")
+                empty_state("No genes found in this cluster.")
 
             display_uniprot_info()
             gene_significance_chart(cluster_adata, st.session_state.selected_gene)
@@ -1397,8 +1429,9 @@ else:
                     st.session_state.selected_gene = genes[0]
                     st.rerun()
                 else:
-                    st.write("No genes found in this cluster.")
+                    empty_state("No genes found in this cluster.")
         else:
-            st.warning(
-                f"⚠️ WARNING: Gene montages root directory does not exist: {gene_montages_root}"
+            empty_state(
+                "No montages available for this cell class.",
+                "The aggregate step writes example cells to `aggregate/montages/`.",
             )

--- a/visualization/Cluster_Analysis.py
+++ b/visualization/Cluster_Analysis.py
@@ -37,6 +37,7 @@ from src.config import BRIEFLOW_OUTPUT_PATH, STATIC_ASSET_URL_ROOT, STATIC_ASSET
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from workflow.lib.shared.image_io import read_image
+from workflow.lib.cluster.mozzarellm_io import latest_mozzarellm_run
 
 # =====================
 # CONSTANTS
@@ -87,7 +88,7 @@ SOURCE_INDEX = 3
 
 
 def find_mozzarellm_dirs(channel_combo: str) -> list:
-    """Find every mozzarellm/clusters directory under a channel combo.
+    """Find every mozzarellm run directory holding an annotation under a channel combo.
 
     Globs rather than walking fixed levels because the cluster tree gains a
     compartment_combo level when the run defines compartments.
@@ -95,17 +96,41 @@ def find_mozzarellm_dirs(channel_combo: str) -> list:
     return sorted(
         d
         for d in glob.glob(
-            os.path.join(CLUSTER_ROOT, channel_combo, "**", "mozzarellm", "clusters"),
+            os.path.join(CLUSTER_ROOT, channel_combo, "**", "mozzarellm", "run_*"),
             recursive=True,
         )
-        if os.path.isdir(d)
+        if os.path.isdir(d) and glob.glob(os.path.join(d, "*_clusters.json"))
     )
 
 
 def parse_mozzarellm_dir(mozzarellm_dir: str) -> tuple:
-    """Return the (cell_class, leiden_resolution) a mozzarellm/clusters directory belongs to."""
+    """Return the (cell_class, leiden_resolution) a mozzarellm run directory belongs to."""
     leiden_dir = os.path.dirname(os.path.dirname(mozzarellm_dir))
     return os.path.basename(os.path.dirname(leiden_dir)), os.path.basename(leiden_dir)
+
+
+@st.cache_data
+def load_mozzarellm_run(cluster_dir: str) -> tuple:
+    """Load the newest mozzarellm run for a resolution directory.
+
+    Returns:
+        tuple: (clusters dict keyed by cluster id, per-gene DataFrame). Both are
+        empty when the resolution has no mozzarellm run yet.
+    """
+    run_dir = latest_mozzarellm_run(cluster_dir)
+    if run_dir is None:
+        return {}, pd.DataFrame()
+
+    clusters_json = sorted(run_dir.glob("*_clusters.json"))[-1]
+    with open(clusters_json, "r") as f:
+        clusters = json.load(f).get("clusters", {})
+
+    genes_csv = clusters_json.with_name(
+        clusters_json.name.replace("_clusters.json", "_genes.csv")
+    )
+    genes = pd.read_csv(genes_csv) if genes_csv.exists() else pd.DataFrame()
+
+    return clusters, genes
 
 
 def has_mozzarellm_analysis(channel_combo: str) -> bool:
@@ -879,11 +904,9 @@ def cluster_size_charts(cluster_data):
 
 def get_available_llm_combinations(channel_combo: str) -> list:
     """Find all cell_class/resolution combinations that have LLM data."""
-    return [
-        parse_mozzarellm_dir(d)
-        for d in find_mozzarellm_dirs(channel_combo)
-        if os.listdir(d)
-    ]
+    return sorted(
+        {parse_mozzarellm_dir(d) for d in find_mozzarellm_dirs(channel_combo)}
+    )
 
 
 def display_cluster_json(cluster_data, container=st.container()):
@@ -894,35 +917,43 @@ def display_cluster_json(cluster_data, container=st.container()):
         cluster_dir = get_cluster_dir(cluster_data)
         cluster_id = str(st.session_state.selected_item)
 
-        # Build the path to the individual cluster JSON file in mozzarellm/clusters/
-        mozzarellm_clusters_dir = os.path.join(cluster_dir, "mozzarellm", "clusters")
-        cluster_json_path = os.path.join(
-            mozzarellm_clusters_dir, f"cluster_{cluster_id}.json"
-        )
+        # The newest mozzarellm run holds one JSON for every cluster it annotated
+        clusters, genes = load_mozzarellm_run(cluster_dir)
+        c = clusters.get(cluster_id)
 
         # Always show the section header
         st.subheader("LLM cluster analysis")
 
-        if os.path.exists(cluster_json_path):
-            with open(cluster_json_path, "r") as f:
-                c = json.load(f)
-
+        if c:
             process_col, confidence_col = st.columns([3, 1])
             process_col.metric("Dominant process", c.get("dominant_process", "—"))
             confidence_col.metric(
                 "Pathway confidence", str(c.get("pathway_confidence", "—")).title()
             )
 
+            established = c.get("established_genes", [])
+            novel = c.get("novel_role_genes", [])
+            uncharacterized = c.get("uncharacterized_genes", [])
+            for col, label, count in zip(
+                st.columns(4),
+                ["Genes", "Established", "Novel role", "Uncharacterized"],
+                [
+                    c.get("total_genes_in_cluster", len(established)),
+                    len(established),
+                    len(novel),
+                    len(uncharacterized),
+                ],
+            ):
+                col.metric(label, count)
+
             summary = c.get("summary", "")
             if summary:
                 st.markdown(summary)
 
-            established = c.get("established_genes", [])
             if established:
                 st.markdown("**Established genes**")
                 st.markdown(" ".join(f":green-badge[{gene}]" for gene in established))
 
-            novel = c.get("novel_role_genes", [])
             if novel:
                 st.markdown("**Novel role genes**")
                 for gene in novel:
@@ -930,12 +961,27 @@ def display_cluster_json(cluster_data, container=st.container()):
                         f":orange-badge[{gene['gene']}] {gene.get('rationale', '')}"
                     )
 
-            uncharacterized = c.get("uncharacterized_genes", [])
             if uncharacterized:
                 st.markdown("**Uncharacterized genes**")
                 for gene in uncharacterized:
                     st.markdown(
                         f":violet-badge[{gene['gene']}] {gene.get('rationale', '')}"
+                    )
+
+            if not genes.empty and "cluster_id" in genes.columns:
+                cluster_genes = genes[genes["cluster_id"].astype(str) == cluster_id]
+                if not cluster_genes.empty:
+                    st.markdown("**Per-gene calls**")
+                    st.dataframe(
+                        cluster_genes[
+                            [
+                                col
+                                for col in ["gene", "category", "subclass", "rationale"]
+                                if col in cluster_genes.columns
+                            ]
+                        ],
+                        use_container_width=True,
+                        hide_index=True,
                     )
         else:
             # Show a hint about where the analysis does exist when it is missing here
@@ -947,10 +993,16 @@ def display_cluster_json(cluster_data, container=st.container()):
             available = get_available_llm_combinations(channel_combo)
 
             # Smart context: tailor message based on what's wrong
-            if not available:
+            if clusters:
                 available_text = (
-                    "The `mozzarellm` step writes `mozzarellm/clusters/cluster_*.json` "
-                    "next to the clustering outputs."
+                    f"The newest run annotated clusters "
+                    f"{', '.join(sorted(clusters, key=int))}."
+                )
+            elif not available:
+                available_text = (
+                    "The `mozzarellm` step writes "
+                    "`mozzarellm/run_*/<screen>_clusters.json` next to the "
+                    "clustering outputs."
                 )
             else:
                 # Check if current cell class has any LLM data

--- a/visualization/Cluster_Analysis.py
+++ b/visualization/Cluster_Analysis.py
@@ -10,20 +10,34 @@ import pandas as pd
 import glob
 import os
 import json
+import sys
 
 import plotly.graph_objects as go
 
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 
-from src.config import load_config
-from src.filesystem import FileSystem
+import numpy as np
+
+from src.config import get_image_format, load_config
+from src.filesystem import FileSystem, read_zarr_channel_names
 from src.filtering import create_filter_radio, apply_filter
 from src.config import BRIEFLOW_OUTPUT_PATH, STATIC_ASSET_URL_ROOT, STATIC_ASSET_PATH
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from workflow.lib.shared.image_io import read_image
 
 # =====================
 # CONSTANTS
 CLUSTER_ROOT = os.path.join(BRIEFLOW_OUTPUT_PATH, "cluster")
+IMAGE_FORMAT = get_image_format()
+
+# Cluster outputs nest as channel_combo/[compartment_combo/]cell_class/leiden_resolution,
+# so name the levels by how many there are rather than by fixed position.
+CLUSTER_DIR_LEVELS = {
+    3: ["channel_combo", "cell_class", "leiden_resolution"],
+    4: ["channel_combo", "compartment_combo", "cell_class", "leiden_resolution"],
+}
 
 # Common hover data columns
 HOVER_COLUMNS = ["gene_symbol_0", "cluster", "cell_count", "source"]
@@ -38,47 +52,48 @@ SOURCE_INDEX = 3
 # FUNCTIONS
 
 
+def find_mozzarellm_dirs(channel_combo: str) -> list:
+    """Find every mozzarellm/clusters directory under a channel combo.
+
+    Globs rather than walking fixed levels because the cluster tree gains a
+    compartment_combo level when the run defines compartments.
+    """
+    return sorted(
+        d
+        for d in glob.glob(
+            os.path.join(CLUSTER_ROOT, channel_combo, "**", "mozzarellm", "clusters"),
+            recursive=True,
+        )
+        if os.path.isdir(d)
+    )
+
+
+def parse_mozzarellm_dir(mozzarellm_dir: str) -> tuple:
+    """Return the (cell_class, leiden_resolution) a mozzarellm/clusters directory belongs to."""
+    leiden_dir = os.path.dirname(os.path.dirname(mozzarellm_dir))
+    return os.path.basename(os.path.dirname(leiden_dir)), os.path.basename(leiden_dir)
+
+
 def has_mozzarellm_analysis(channel_combo: str) -> bool:
     """Check if a channel combo has mozzarellm analysis for any cell_class/leiden_resolution."""
-    channel_dir = os.path.join(CLUSTER_ROOT, channel_combo)
-    if not os.path.exists(channel_dir):
-        return False
-    # Check all cell_class/leiden_resolution subdirectories for mozzarellm/clusters
-    for cell_class in os.listdir(channel_dir):
-        cell_class_dir = os.path.join(channel_dir, cell_class)
-        if not os.path.isdir(cell_class_dir):
-            continue
-        for leiden_res in os.listdir(cell_class_dir):
-            mozzarellm_clusters = os.path.join(
-                cell_class_dir, leiden_res, "mozzarellm", "clusters"
-            )
-            if os.path.exists(mozzarellm_clusters):
-                return True
-    return False
+    return len(find_mozzarellm_dirs(channel_combo)) > 0
 
 
 def has_mozzarellm_for_cell_class(channel_combo: str, cell_class: str) -> bool:
     """Check if mozzarellm exists for channel_combo + cell_class + any leiden_resolution."""
-    cell_class_dir = os.path.join(CLUSTER_ROOT, channel_combo, cell_class)
-    if not os.path.exists(cell_class_dir):
-        return False
-    for leiden_res in os.listdir(cell_class_dir):
-        mozzarellm_clusters = os.path.join(
-            cell_class_dir, leiden_res, "mozzarellm", "clusters"
-        )
-        if os.path.exists(mozzarellm_clusters):
-            return True
-    return False
+    return any(
+        parse_mozzarellm_dir(d)[0] == cell_class
+        for d in find_mozzarellm_dirs(channel_combo)
+    )
 
 
 def has_mozzarellm_for_leiden(channel_combo: str, cell_class: str, leiden_res) -> bool:
     """Check if mozzarellm exists for the exact channel_combo + cell_class + leiden_resolution."""
     # Convert to int then string to handle float values like 15.0 -> "15"
     leiden_str = str(int(float(leiden_res)))
-    mozzarellm_clusters = os.path.join(
-        CLUSTER_ROOT, channel_combo, cell_class, leiden_str, "mozzarellm", "clusters"
-    )
-    return os.path.exists(mozzarellm_clusters)
+    return (cell_class, leiden_str) in [
+        parse_mozzarellm_dir(d) for d in find_mozzarellm_dirs(channel_combo)
+    ]
 
 
 # -- Data Load Methods --
@@ -100,17 +115,11 @@ def load_cluster_data():
         df["source_full_path"] = file_path
         df["source"] = base_name
         parts = dirname.split(os.sep)
-        for i, part in enumerate(parts):
-            df[f"dir_level_{i}"] = part
-
-        df.rename(
-            columns={
-                "dir_level_0": "channel_combo",
-                "dir_level_1": "cell_class",
-                "dir_level_2": "leiden_resolution",
-            },
-            inplace=True,
+        level_names = CLUSTER_DIR_LEVELS.get(
+            len(parts), [f"dir_level_{i}" for i in range(len(parts))]
         )
+        for name, part in zip(level_names, parts):
+            df[name] = part
 
         dfs.append(df)
 
@@ -183,10 +192,24 @@ def make_scatter_trace(x, y, marker, text, customdata, name, showlegend, color=N
 
 
 # -- Display helpers --
+def get_montage_root(cell_class):
+    """Return the directory holding this cell class's montages for the active image format.
+
+    TIFF mode writes a PNG per channel under ``{cell_class}__montages``; zarr mode writes
+    one OME-Zarr store per cell crop under ``{cell_class}__examples.zarr``.
+    """
+    montages_dir = os.path.join(BRIEFLOW_OUTPUT_PATH, "aggregate", "montages")
+    if IMAGE_FORMAT == "zarr":
+        return os.path.join(montages_dir, f"{cell_class}__examples.zarr")
+    return os.path.join(montages_dir, f"{cell_class}__montages")
+
+
 def display_gene_montages(gene_montages_root, gene):
     gene_dir = os.path.join(gene_montages_root, gene)
     if not os.path.exists(gene_dir):
         st.warning(f"No montage directory found for gene {gene}")
+    elif IMAGE_FORMAT == "zarr":
+        display_gene_montages_zarr(gene_montages_root, gene)
     else:
         montage_data = load_montage_data(gene_montages_root, gene)
         if montage_data.empty:
@@ -194,36 +217,7 @@ def display_gene_montages(gene_montages_root, gene):
         else:
             # Add filters for guide and channel
             available_guides = sorted(montage_data["guide"].unique())
-
-            # Initialize session state for selected guide if it doesn't exist
-            if f"selected_guide_{gene}" not in st.session_state:
-                st.session_state[f"selected_guide_{gene}"] = None
-
-            # Define a callback for when the guide dropdown changes
-            def on_guide_select():
-                st.session_state[f"selected_guide_{gene}"] = st.session_state[
-                    f"guide_dropdown_{gene}"
-                ]
-
-            # Determine the index of the selected guide in the dropdown
-            selected_index = 0
-            selected_guide = st.session_state.get(f"selected_guide_{gene}", None)
-
-            if selected_guide in available_guides:
-                selected_index = available_guides.index(selected_guide)
-            elif available_guides:
-                # If no guide is selected yet or the previously selected guide is not available, select the first one
-                selected_guide = available_guides[0]
-                st.session_state[f"selected_guide_{gene}"] = selected_guide
-
-            # Create a dropdown to select a guide
-            selected_guide = st.selectbox(
-                "Select Guide",
-                available_guides,
-                index=selected_index,
-                key=f"guide_dropdown_{gene}",  # Use a stable key based on the selected gene
-                on_change=on_guide_select,
-            )
+            selected_guide = select_montage_guide(gene, available_guides)
 
             # Filter the data based on selections
             filtered_montage_data = montage_data[
@@ -248,7 +242,7 @@ def display_gene_montages(gene_montages_root, gene):
 
                 # Add download button for overlay TIFF
                 overlay_tiff_path = os.path.join(
-                    gene_montages_root, gene, selected_guide, f"overlay_montage.tiff"
+                    gene_montages_root, gene, selected_guide, "overlay_montage.tiff"
                 )
 
                 if os.path.exists(overlay_tiff_path):
@@ -270,6 +264,98 @@ def display_gene_montages(gene_montages_root, gene):
                     st.warning(f"No overlay tiff found: {overlay_tiff_path}")
             else:
                 st.warning(f"No image found for {gene} - {selected_guide}")
+
+
+def display_gene_montages_zarr(gene_montages_root, gene):
+    """Display the per-cell OME-Zarr crops the zarr pipeline writes instead of montage PNGs."""
+    available_guides = sorted(list_montage_guides(gene_montages_root, gene))
+    if not available_guides:
+        st.write(f"No montage data found for gene {gene}")
+        return
+
+    selected_guide = select_montage_guide(gene, available_guides)
+    crop_paths = load_montage_crops(gene_montages_root, gene, selected_guide)
+    if not crop_paths:
+        st.warning(f"No image found for {gene} - {selected_guide}")
+        return
+
+    channel_names = read_zarr_channel_names(crop_paths[0])
+    for crop_path in crop_paths:
+        crop = read_image(crop_path)
+        if crop.ndim == 2:
+            crop = crop[np.newaxis, ...]
+        cols = st.columns(len(crop))
+        for index, channel_image in enumerate(crop):
+            label = (
+                channel_names[index]
+                if channel_names and index < len(channel_names)
+                else f"Channel {index}"
+            )
+            cols[index].image(
+                scale_to_uint8(channel_image), caption=f"Channel: {label}"
+            )
+
+
+@st.cache_data
+def list_montage_guides(gene_montages_root, gene):
+    """List the guide (sgRNA) directories available for a gene."""
+    gene_dir = os.path.join(gene_montages_root, gene)
+    if not os.path.isdir(gene_dir):
+        return []
+    return [
+        entry
+        for entry in os.listdir(gene_dir)
+        if os.path.isdir(os.path.join(gene_dir, entry))
+    ]
+
+
+@st.cache_data
+def load_montage_crops(gene_montages_root, gene, guide):
+    """List the per-cell OME-Zarr crop stores written for a gene/guide pair."""
+    return sorted(
+        FileSystem.find_files(
+            os.path.join(gene_montages_root, gene, guide), extensions=["zarr"]
+        )
+    )
+
+
+def select_montage_guide(gene, available_guides):
+    """Render the guide dropdown for a gene and return the selected guide."""
+    if f"selected_guide_{gene}" not in st.session_state:
+        st.session_state[f"selected_guide_{gene}"] = None
+
+    # Define a callback for when the guide dropdown changes
+    def on_guide_select():
+        st.session_state[f"selected_guide_{gene}"] = st.session_state[
+            f"guide_dropdown_{gene}"
+        ]
+
+    # Determine the index of the selected guide in the dropdown
+    selected_index = 0
+    selected_guide = st.session_state.get(f"selected_guide_{gene}", None)
+
+    if selected_guide in available_guides:
+        selected_index = available_guides.index(selected_guide)
+    elif available_guides:
+        # If no guide is selected yet or the previously selected guide is not available, select the first one
+        st.session_state[f"selected_guide_{gene}"] = available_guides[0]
+
+    return st.selectbox(
+        "Select Guide",
+        available_guides,
+        index=selected_index,
+        key=f"guide_dropdown_{gene}",  # Use a stable key based on the selected gene
+        on_change=on_guide_select,
+    )
+
+
+def scale_to_uint8(channel_image):
+    """Rescale a single-channel crop to uint8 so streamlit can display it."""
+    arr = channel_image.astype(np.float32)
+    low, high = float(arr.min()), float(arr.max())
+    if high <= low:
+        return np.zeros(arr.shape, dtype=np.uint8)
+    return (((arr - low) / (high - low)) * 255).astype(np.uint8)
 
 
 def display_cluster(cluster_data, cell_class=None, channel_combo=None):
@@ -525,6 +611,10 @@ def display_cluster(cluster_data, cell_class=None, channel_combo=None):
 def cluster_table(cluster_data):
     # Display data overview
     st.markdown("## Cluster Data Overview")
+    if cluster_data.empty:
+        st.warning("No cluster data found for the selected filters.")
+        return
+
     # If an item is selected, filter the dataframe
     source_tsv = cluster_data["source_full_path"].unique()[0]
     if os.path.exists(source_tsv):
@@ -552,18 +642,25 @@ def cluster_table(cluster_data):
         st.warning(f"⚠️ WARNING: Source TSV file not found at: {source_tsv}")
 
 
-def feature_table(cell_class, channel_combo):
+def get_compartment_combo(cluster_data):
+    """Return the compartment combo of the loaded cluster data, or None when it has none."""
+    if "compartment_combo" in cluster_data.columns and len(cluster_data) > 0:
+        return cluster_data["compartment_combo"].iloc[0]
+    return None
+
+
+def feature_table(cell_class, channel_combo, compartment_combo=None):
     # Feature Data Overview
     st.markdown("## Feature Data Overview")
     st.markdown(
         "Median feature values per gene after center scaling all single cell data on control cells by well."
     )
     # Construct the feature table path
+    name = f"CeCl-{cell_class}_ChCo-{channel_combo}"
+    if compartment_combo:
+        name = f"{name}_CmCo-{compartment_combo}"
     feature_table_path = os.path.join(
-        BRIEFLOW_OUTPUT_PATH,
-        "aggregate",
-        "tsvs",
-        f"CeCl-{cell_class}_ChCo-{channel_combo}__features_genes.tsv",
+        BRIEFLOW_OUTPUT_PATH, "aggregate", "tsvs", f"{name}__features_genes.tsv"
     )
     # Load and display the feature table if it exists
     if os.path.exists(feature_table_path):
@@ -587,21 +684,19 @@ def feature_table(cell_class, channel_combo):
         st.warning(f"⚠️ WARNING: Feature table not found at: {feature_table_path}")
 
 
-def cluster_size_charts(channel_combo, cell_class, leiden_resolution):
+def cluster_size_charts(cluster_data):
+    if cluster_data.empty:
+        return
+
     # Create two equal-sized columns
     col1, col2 = st.columns([1, 1])
+
+    cluster_dir = os.path.dirname(cluster_data["source_full_path"].unique()[0])
 
     with col1:
         st.markdown("### Cluster Sizes")
         # Construct the path to the cluster sizes plot
-        cluster_sizes_path = os.path.join(
-            BRIEFLOW_OUTPUT_PATH,
-            "cluster",
-            channel_combo,
-            cell_class,
-            leiden_resolution,
-            "cluster_sizes.png",
-        )
+        cluster_sizes_path = os.path.join(cluster_dir, "cluster_sizes.png")
 
         # Display the plot if it exists
         if os.path.exists(cluster_sizes_path):
@@ -612,14 +707,7 @@ def cluster_size_charts(channel_combo, cell_class, leiden_resolution):
     with col2:
         st.markdown("### Cluster Enrichment")
         # Construct the path to the enrichment pie chart
-        enrichment_pie_path = os.path.join(
-            BRIEFLOW_OUTPUT_PATH,
-            "cluster",
-            channel_combo,
-            cell_class,
-            leiden_resolution,
-            "CB-Real__pie_chart.png",
-        )
+        enrichment_pie_path = os.path.join(cluster_dir, "CB-Real__pie_chart.png")
 
         # Display the plot if it exists
         if os.path.exists(enrichment_pie_path):
@@ -632,21 +720,11 @@ def cluster_size_charts(channel_combo, cell_class, leiden_resolution):
 
 def get_available_llm_combinations(channel_combo: str) -> list:
     """Find all cell_class/resolution combinations that have LLM data."""
-    available = []
-    channel_dir = os.path.join(CLUSTER_ROOT, channel_combo)
-    if not os.path.exists(channel_dir):
-        return available
-    for cell_class in os.listdir(channel_dir):
-        cell_class_dir = os.path.join(channel_dir, cell_class)
-        if not os.path.isdir(cell_class_dir):
-            continue
-        for leiden_res in os.listdir(cell_class_dir):
-            mozzarellm_clusters = os.path.join(
-                cell_class_dir, leiden_res, "mozzarellm", "clusters"
-            )
-            if os.path.exists(mozzarellm_clusters) and os.listdir(mozzarellm_clusters):
-                available.append((cell_class, leiden_res))
-    return available
+    return [
+        parse_mozzarellm_dir(d)
+        for d in find_mozzarellm_dirs(channel_combo)
+        if os.listdir(d)
+    ]
 
 
 def display_cluster_json(cluster_data, container=st.container()):
@@ -965,10 +1043,13 @@ def apply_all_filters(data):
     data = apply_filter(data, "channel_combo", selected_channel_combo)
 
     # Cell Class filter - handle directly
-    cell_class_options = ["all", "Mitotic", "Interphase"]
+    # Options come from the data; "All" is the sentinel apply_filter treats as no filter.
+    cell_class_options = ["All"] + sorted(data["cell_class"].dropna().unique().tolist())
     # Initialize cell class in session state if needed
-    if "cell_class" not in st.session_state:
-        st.session_state.cell_class = "all"
+    if st.session_state.get("cell_class") not in cell_class_options:
+        st.session_state.cell_class = (
+            cell_class_options[1] if len(cell_class_options) > 1 else "All"
+        )
 
     # Format cell class display label
     def format_cell_class(cc: str) -> str:
@@ -1127,8 +1208,8 @@ if not st.session_state.selected_item:
         channel_combo=st.session_state.channel_combo,
     )
     cluster_table(cluster_data)
-    feature_table(cell_class, channel_combo)
-    cluster_size_charts(channel_combo, cell_class, leiden_resolution)
+    feature_table(cell_class, channel_combo, get_compartment_combo(cluster_data))
+    cluster_size_charts(cluster_data)
 
 else:
     # Cluster selected: Two columns: plot | detail.
@@ -1138,8 +1219,8 @@ else:
             cluster_data, cell_class=cell_class, channel_combo=channel_combo
         )
         cluster_table(cluster_data)
-        feature_table(cell_class, channel_combo)
-        cluster_size_charts(channel_combo, cell_class, leiden_resolution)
+        feature_table(cell_class, channel_combo, get_compartment_combo(cluster_data))
+        cluster_size_charts(cluster_data)
 
     with col2:
         # Selected Gene info
@@ -1149,9 +1230,7 @@ else:
             cluster_data["cluster"] == st.session_state.selected_item
         ]
         genes = sorted(selected_gene_info_df["gene_symbol_0"].tolist())
-        gene_montages_root = os.path.join(
-            BRIEFLOW_OUTPUT_PATH, "aggregate", "montages", f"{cell_class}__montages"
-        )
+        gene_montages_root = get_montage_root(cell_class)
 
         ## Cluster Info
         # Create two columns for the title and clear button

--- a/visualization/Cluster_Analysis.py
+++ b/visualization/Cluster_Analysis.py
@@ -6,6 +6,7 @@ st.set_page_config(
     layout="wide",
 )
 
+import anndata as ad
 import pandas as pd
 import glob
 import os
@@ -32,12 +33,32 @@ from workflow.lib.shared.image_io import read_image
 CLUSTER_ROOT = os.path.join(BRIEFLOW_OUTPUT_PATH, "cluster")
 IMAGE_FORMAT = get_image_format()
 
-# Cluster outputs nest as channel_combo/[compartment_combo/]cell_class/leiden_resolution,
+# One h5ad per channel_combo/[compartment_combo/]cell_class carries every resolution,
 # so name the levels by how many there are rather than by fixed position.
 CLUSTER_DIR_LEVELS = {
-    3: ["channel_combo", "cell_class", "leiden_resolution"],
-    4: ["channel_combo", "compartment_combo", "cell_class", "leiden_resolution"],
+    2: ["channel_combo", "cell_class"],
+    3: ["channel_combo", "compartment_combo", "cell_class"],
 }
+
+# obs holds one cluster assignment column per leiden resolution
+CLUSTER_GROUP_PREFIX = "cluster_group_"
+
+# obs columns the page already carries as a filter, so they stay out of the gene table
+OBS_EXCLUDED_COLUMNS = ["cell_cycle_phase"]
+
+# columns the page adds for its own bookkeeping, dropped before the gene table is shown
+BOOKKEEPING_COLUMNS = [
+    "source",
+    "source_h5ad_path",
+    "cluster_dir",
+    "channel_combo",
+    "compartment_combo",
+    "cell_class",
+    "leiden_resolution",
+]
+
+# bootstrap significance layers, most directly usable first
+SIGNIFICANCE_LAYERS = ("neg_log10_fdr", "fdr")
 
 # Common hover data columns
 HOVER_COLUMNS = ["gene_symbol_0", "cluster", "cell_count", "source"]
@@ -97,34 +118,92 @@ def has_mozzarellm_for_leiden(channel_combo: str, cell_class: str, leiden_res) -
 
 
 # -- Data Load Methods --
-# Load and merge cluster TSV files
 @st.cache_data
-def load_cluster_data():
-    # Find all relevant TSV files
-    tsv_files = glob.glob(
-        f"{CLUSTER_ROOT}/**/phate_leiden_clustering.tsv", recursive=True
+def find_cluster_h5ads() -> list:
+    """List every cluster h5ad written by ``rule format_cluster_anndata``."""
+    return sorted(
+        glob.glob(os.path.join(CLUSTER_ROOT, "**", "h5ad", "*.h5ad"), recursive=True)
     )
 
-    # Read each file and add source attribute
-    dfs = []
-    for file_path in tsv_files:
-        rel_path = os.path.relpath(file_path, CLUSTER_ROOT)
-        dirname = os.path.dirname(rel_path)
-        base_name = os.path.splitext(os.path.basename(file_path))[0]
-        df = pd.read_csv(file_path, sep="\t")
-        df["source_full_path"] = file_path
-        df["source"] = base_name
-        parts = dirname.split(os.sep)
-        level_names = CLUSTER_DIR_LEVELS.get(
-            len(parts), [f"dir_level_{i}" for i in range(len(parts))]
-        )
-        for name, part in zip(level_names, parts):
-            df[name] = part
 
-        dfs.append(df)
+@st.cache_resource
+def load_cluster_h5ad(h5ad_path: str):
+    """Read one cluster h5ad, the single source for clustering, features and gene metadata."""
+    return ad.read_h5ad(h5ad_path)
 
-    # Concatenate all dataframes
-    return pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+
+def cluster_base_dir(h5ad_path: str) -> str:
+    """Return the cell class directory that holds a cluster h5ad's ``h5ad/`` subdirectory."""
+    return os.path.dirname(os.path.dirname(h5ad_path))
+
+
+def parse_cluster_levels(h5ad_path: str) -> dict:
+    """Return the channel_combo / compartment_combo / cell_class a cluster h5ad belongs to.
+
+    The compartment_combo level is only present when the run splits by compartment.
+    """
+    parts = os.path.relpath(cluster_base_dir(h5ad_path), CLUSTER_ROOT).split(os.sep)
+    level_names = CLUSTER_DIR_LEVELS.get(
+        len(parts), [f"dir_level_{i}" for i in range(len(parts))]
+    )
+    return dict(zip(level_names, parts))
+
+
+def leiden_resolutions(adata) -> list:
+    """List the leiden resolutions an h5ad carries cluster assignments for."""
+    return [
+        col[len(CLUSTER_GROUP_PREFIX) :]
+        for col in adata.obs.columns
+        if col.startswith(CLUSTER_GROUP_PREFIX)
+    ]
+
+
+@st.cache_data
+def load_cluster_data():
+    """Build the gene table the page filters on, one row per gene per leiden resolution."""
+    frames = []
+    for h5ad_path in find_cluster_h5ads():
+        adata = load_cluster_h5ad(h5ad_path)
+        dropped = [
+            col
+            for col in adata.obs.columns
+            if col.startswith(CLUSTER_GROUP_PREFIX) or col in OBS_EXCLUDED_COLUMNS
+        ]
+        genes = adata.obs.drop(columns=dropped).reset_index(drop=True)
+        genes.insert(0, "gene_symbol_0", adata.obs_names.to_numpy())
+        if "X_phate" in adata.obsm:
+            genes["PHATE_0"] = adata.obsm["X_phate"][:, 0]
+            genes["PHATE_1"] = adata.obsm["X_phate"][:, 1]
+
+        levels = parse_cluster_levels(h5ad_path)
+        for resolution in leiden_resolutions(adata):
+            frame = genes.copy()
+            frame["cluster"] = adata.obs[
+                f"{CLUSTER_GROUP_PREFIX}{resolution}"
+            ].to_numpy()
+            frame["leiden_resolution"] = resolution
+            frame["source"] = os.path.basename(h5ad_path)
+            frame["source_h5ad_path"] = h5ad_path
+            frame["cluster_dir"] = os.path.join(cluster_base_dir(h5ad_path), resolution)
+            for name, part in levels.items():
+                frame[name] = part
+            frames.append(frame)
+
+    return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+
+def get_active_h5ad(cluster_data):
+    """Return the AnnData behind the filtered cluster data, or None when nothing matches."""
+    if cluster_data.empty:
+        return None
+    return load_cluster_h5ad(cluster_data["source_h5ad_path"].iloc[0])
+
+
+def get_cluster_dir(cluster_data):
+    """Return the resolution directory holding the outputs that are not in the h5ad."""
+    if cluster_data.empty:
+        return None
+    return cluster_data["cluster_dir"].iloc[0]
 
 
 @st.cache_data
@@ -615,73 +694,89 @@ def cluster_table(cluster_data):
         st.warning("No cluster data found for the selected filters.")
         return
 
+    table_data = cluster_data.drop(
+        columns=[c for c in BOOKKEEPING_COLUMNS if c in cluster_data.columns]
+    )
     # If an item is selected, filter the dataframe
-    source_tsv = cluster_data["source_full_path"].unique()[0]
-    if os.path.exists(source_tsv):
-        table_data = pd.read_csv(source_tsv, sep="\t")
-        if st.session_state.selected_item:
-            # Convert selected_item to integer since cluster column is int64
-            try:
-                selected_item_int = int(st.session_state.selected_item)
-                table_data = table_data[table_data["cluster"] == selected_item_int]
-            except ValueError:
-                st.error(f"Invalid cluster value: {st.session_state.selected_item}")
+    if st.session_state.selected_item:
+        table_data = table_data[
+            table_data["cluster"].astype(str) == str(st.session_state.selected_item)
+        ]
 
-            if len(table_data.index) == 0:
-                st.warning(f"⚠️ WARNING: No data found in the TSV file: {source_tsv}")
-            else:
-                table_data.set_index("gene_symbol_0", inplace=True)
-                st.dataframe(table_data)
-        else:
-            if len(table_data.index) == 0:
-                st.warning(f"⚠️ WARNING: No data found in the TSV file: {source_tsv}")
-            else:
-                table_data.set_index("gene_symbol_0", inplace=True)
-                st.dataframe(table_data)
-    else:
-        st.warning(f"⚠️ WARNING: Source TSV file not found at: {source_tsv}")
+    if table_data.empty:
+        st.warning("⚠️ WARNING: No genes found for the selected cluster.")
+        return
+    st.dataframe(table_data.set_index("gene_symbol_0"))
 
 
-def get_compartment_combo(cluster_data):
-    """Return the compartment combo of the loaded cluster data, or None when it has none."""
-    if "compartment_combo" in cluster_data.columns and len(cluster_data) > 0:
-        return cluster_data["compartment_combo"].iloc[0]
-    return None
-
-
-def feature_table(cell_class, channel_combo, compartment_combo=None):
+def feature_table(adata):
     # Feature Data Overview
     st.markdown("## Feature Data Overview")
     st.markdown(
         "Median feature values per gene after center scaling all single cell data on control cells by well."
     )
-    # Construct the feature table path
-    name = f"CeCl-{cell_class}_ChCo-{channel_combo}"
-    if compartment_combo:
-        name = f"{name}_CmCo-{compartment_combo}"
-    feature_table_path = os.path.join(
-        BRIEFLOW_OUTPUT_PATH, "aggregate", "tsvs", f"{name}__features_genes.tsv"
-    )
-    # Load and display the feature table if it exists
-    if os.path.exists(feature_table_path):
-        feature_df = pd.read_csv(feature_table_path, sep="\t")
-        feature_df.set_index("gene_symbol_0", inplace=True)
+    if adata is None:
+        st.warning("⚠️ WARNING: No cluster h5ad found for the selected filters.")
+        return
 
-        # Create a container with a fixed height and scrolling
-        with st.container():
-            # Display the dataframe with all columns and sorting enabled
-            st.dataframe(
-                feature_df,
-                use_container_width=True,
-                height=400,  # Fixed height for scrolling
-                column_config={
-                    # Configure all columns to be sortable
-                    col: st.column_config.NumberColumn(width="medium")
-                    for col in feature_df.columns
-                },
-            )
-    else:
-        st.warning(f"⚠️ WARNING: Feature table not found at: {feature_table_path}")
+    feature_df = pd.DataFrame(
+        adata.X, index=adata.obs_names, columns=adata.var_names.to_list()
+    )
+    if "cell_count" in adata.obs.columns:
+        feature_df.insert(0, "cell_count", adata.obs["cell_count"].to_numpy())
+    feature_df.index.name = "gene_symbol_0"
+
+    # Create a container with a fixed height and scrolling
+    with st.container():
+        # Display the dataframe with all columns and sorting enabled
+        st.dataframe(
+            feature_df,
+            use_container_width=True,
+            height=400,  # Fixed height for scrolling
+            column_config={
+                # Configure all columns to be sortable
+                col: st.column_config.NumberColumn(width="medium")
+                for col in feature_df.columns
+            },
+        )
+
+
+def gene_significance_chart(adata, gene):
+    """Plot each feature's value against its bootstrap significance for one gene.
+
+    Renders nothing unless the h5ad carries bootstrap layers, which only runs with
+    gene-level bootstrap results have.
+    """
+    if adata is None or not gene or gene not in adata.obs_names:
+        return
+    layer = next((name for name in SIGNIFICANCE_LAYERS if name in adata.layers), None)
+    if layer is None:
+        return
+
+    row = adata.obs_names.get_loc(gene)
+    effect = np.asarray(adata.X[row, :]).ravel()
+    significance = np.asarray(adata.layers[layer][row, :]).ravel()
+    if layer == "fdr":
+        significance = -np.log10(np.clip(significance, 1e-300, None))
+
+    st.markdown("#### Feature Significance")
+    fig = go.Figure(
+        go.Scattergl(
+            x=effect,
+            y=significance,
+            mode="markers",
+            text=adata.var_names.to_list(),
+            marker=dict(size=6, opacity=0.7),
+            hovertemplate="%{text}<br>value=%{x}<br>-log10 FDR=%{y}<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        xaxis_title="Feature value",
+        yaxis_title="-log10 FDR",
+        height=400,
+        showlegend=False,
+    )
+    st.plotly_chart(fig, use_container_width=True, key=f"significance_{gene}")
 
 
 def cluster_size_charts(cluster_data):
@@ -691,18 +786,21 @@ def cluster_size_charts(cluster_data):
     # Create two equal-sized columns
     col1, col2 = st.columns([1, 1])
 
-    cluster_dir = os.path.dirname(cluster_data["source_full_path"].unique()[0])
+    cluster_dir = get_cluster_dir(cluster_data)
 
     with col1:
         st.markdown("### Cluster Sizes")
-        # Construct the path to the cluster sizes plot
-        cluster_sizes_path = os.path.join(cluster_dir, "cluster_sizes.png")
-
-        # Display the plot if it exists
-        if os.path.exists(cluster_sizes_path):
-            st.image(cluster_sizes_path, use_container_width=True)
-        else:
-            st.warning(f"Cluster sizes plot not found at: {cluster_sizes_path}")
+        # Cluster membership lives in obs, so count the genes per cluster instead of
+        # reading the PNG the pipeline renders.
+        sizes = (
+            cluster_data["cluster"]
+            .astype(str)
+            .value_counts()
+            .rename_axis("cluster")
+            .reset_index(name="genes")
+            .sort_values("cluster", key=lambda values: values.astype(int))
+        )
+        st.bar_chart(sizes, x="cluster", y="genes")
 
     with col2:
         st.markdown("### Cluster Enrichment")
@@ -732,8 +830,7 @@ def display_cluster_json(cluster_data, container=st.container()):
         "selected_item" in st.session_state
         and st.session_state.selected_item is not None
     ):
-        # Because the interphase folder has mixed case
-        cluster_dir = os.path.dirname(cluster_data["source_full_path"].unique()[0])
+        cluster_dir = get_cluster_dir(cluster_data)
         cluster_id = str(st.session_state.selected_item)
 
         # Build the path to the individual cluster JSON file in mozzarellm/clusters/
@@ -856,22 +953,23 @@ def display_cluster_json(cluster_data, container=st.container()):
 
 
 def display_uniprot_info():
-    if st.session_state.selected_gene:
-        source_tsv = cluster_data["source_full_path"].unique()[0]
-        if os.path.exists(source_tsv):
-            table_data = pd.read_csv(source_tsv, sep="\t")
-            table_data = table_data[
-                table_data["gene_symbol_0"] == st.session_state.selected_gene
-            ]
-            if len(table_data.index) != 0:
-                st.write(
-                    f"Uniprot Entry: [{table_data['uniprot_entry'].values[0]}]({table_data['uniprot_link'].values[0]})"
-                )
-                function_text = table_data["uniprot_function"].values[0]
-                if isinstance(function_text, str) and function_text.strip():
-                    st.markdown(f"Uniprot Function:\n>{function_text}")
-                else:
-                    st.write("Uniprot Function: Not available")
+    """Show the uniprot entry and function text the h5ad carries in obs for the selected gene."""
+    if not st.session_state.selected_gene:
+        return
+    gene_rows = cluster_data[
+        cluster_data["gene_symbol_0"] == st.session_state.selected_gene
+    ]
+    if gene_rows.empty or "uniprot_entry" not in gene_rows.columns:
+        return
+
+    st.write(
+        f"Uniprot Entry: [{gene_rows['uniprot_entry'].values[0]}]({gene_rows['uniprot_link'].values[0]})"
+    )
+    function_text = gene_rows["uniprot_function"].values[0]
+    if isinstance(function_text, str) and function_text.strip():
+        st.markdown(f"Uniprot Function:\n>{function_text}")
+    else:
+        st.write("Uniprot Function: Not available")
 
 
 # -- Search/Filter state management --
@@ -1200,6 +1298,8 @@ cell_class = st.session_state.cell_class
 channel_combo = st.session_state.channel_combo
 leiden_resolution = st.session_state.leiden_resolution
 
+cluster_adata = get_active_h5ad(cluster_data)
+
 if not st.session_state.selected_item:
     # No cluster selected: Just show the full width cluster plot
     display_cluster(
@@ -1208,7 +1308,7 @@ if not st.session_state.selected_item:
         channel_combo=st.session_state.channel_combo,
     )
     cluster_table(cluster_data)
-    feature_table(cell_class, channel_combo, get_compartment_combo(cluster_data))
+    feature_table(cluster_adata)
     cluster_size_charts(cluster_data)
 
 else:
@@ -1219,7 +1319,7 @@ else:
             cluster_data, cell_class=cell_class, channel_combo=channel_combo
         )
         cluster_table(cluster_data)
-        feature_table(cell_class, channel_combo, get_compartment_combo(cluster_data))
+        feature_table(cluster_adata)
         cluster_size_charts(cluster_data)
 
     with col2:
@@ -1284,6 +1384,7 @@ else:
                 st.write("No genes found in this cluster.")
 
             display_uniprot_info()
+            gene_significance_chart(cluster_adata, st.session_state.selected_gene)
 
             # Display montages only for the selected gene
             if st.session_state.selected_gene:

--- a/visualization/pages/1_Pipeline_Stats.py
+++ b/visualization/pages/1_Pipeline_Stats.py
@@ -5,18 +5,21 @@ import glob
 import streamlit as st
 
 from src.config import BRIEFLOW_OUTPUT_PATH
+from src.theme import empty_state, page_setup
 
-st.set_page_config(
-    page_title="Pipeline Stats - Brieflow Analysis",
-    layout="wide",
+page_setup(
+    "Pipeline Statistics",
+    "📈",
+    "Per-module counts and summaries collected from the run's stats report.",
 )
 
 # Find stats file
 stats_files = glob.glob(os.path.join(BRIEFLOW_OUTPUT_PATH, "*_stats.txt"))
 
 if not stats_files:
-    st.info(
-        "No pipeline stats file found. Run the stats collection step to generate one."
+    empty_state(
+        "No pipeline stats file found.",
+        "The `generate_stats` step writes `*_stats.txt` into the output root.",
     )
     st.stop()
 
@@ -24,8 +27,6 @@ stats_path = stats_files[0]
 
 with open(stats_path, "r") as f:
     stats_content = f.read()
-
-st.title("Pipeline Statistics")
 
 
 # ---------------------------------------------------------------------------
@@ -98,16 +99,19 @@ HEADER_MAP = {
     "CLUSTERING STATISTICS": "Clustering",
 }
 
-for header, body in sections:
-    display_name = HEADER_MAP.get(header, header.title())
-    st.header(display_name)
-    st.markdown(body_to_markdown(body))
-    st.divider()
-
-# Download
-st.download_button(
-    label="Download Stats File",
+st.sidebar.subheader("Report")
+st.sidebar.caption(os.path.basename(stats_path))
+st.sidebar.download_button(
+    label="Download stats file",
     data=stats_content,
     file_name=os.path.basename(stats_path),
     mime="text/plain",
+    use_container_width=True,
 )
+
+for index, (header, body) in enumerate(sections):
+    display_name = HEADER_MAP.get(header, header.title())
+    st.subheader(display_name)
+    st.markdown(body_to_markdown(body))
+    if index < len(sections) - 1:
+        st.divider()

--- a/visualization/pages/2_Quality_Control.py
+++ b/visualization/pages/2_Quality_Control.py
@@ -6,11 +6,12 @@ from src.filesystem import FileSystem
 from src.rendering import VisualizationRenderer
 from src.filtering import create_filter_radio, apply_filter
 from src.config import BRIEFLOW_OUTPUT_PATH
+from src.theme import empty_state, page_setup, sidebar_filters_header
 
-st.set_page_config(
-    page_title="Quality Control - Brieflow Analysis",
-    page_icon=":microscope:",
-    layout="wide",
+page_setup(
+    "Quality Control",
+    "🔬",
+    "Evaluation plots and tables each pipeline module writes to its `eval/` directory.",
 )
 
 
@@ -55,13 +56,23 @@ def apply_all_filters(df, sidebar):
     return filtered_df, selected_values
 
 
-st.title("Quality Control")
-st.markdown("Review the quality control metrics from the brieflow pipeline")
-
 # Load the data
-filtered_df = load_data(BRIEFLOW_OUTPUT_PATH)
+eval_df = load_data(BRIEFLOW_OUTPUT_PATH)
 
-st.sidebar.title("Filters")
-filtered_df, selected_values = apply_all_filters(filtered_df, st.sidebar)
+if eval_df.empty:
+    empty_state(
+        "No quality control files found.",
+        "Each module writes its plots and tables to `<module>/eval/` as it completes.",
+    )
+    st.stop()
+
+sidebar_filters_header("Narrow the plots shown on the right.")
+filtered_df, selected_values = apply_all_filters(eval_df, st.sidebar)
+
+metric_col, plate_col, well_col = st.columns(3)
+metric_col.metric("Metrics shown", f"{filtered_df['metric_name'].nunique():,}")
+plate_col.metric("Plates", f"{filtered_df['plate_id'].dropna().nunique():,}")
+well_col.metric("Wells", f"{filtered_df['well_id'].dropna().nunique():,}")
+st.divider()
 
 VisualizationRenderer.display_plots_and_tables(filtered_df, BRIEFLOW_OUTPUT_PATH)

--- a/visualization/pages/3_Screen_Overview.py
+++ b/visualization/pages/3_Screen_Overview.py
@@ -6,8 +6,16 @@ import yaml
 
 from src.config import BRIEFLOW_OUTPUT_PATH, CONFIG_PATH, SCREEN_PATH, load_config
 from src.filesystem import read_table
+from src.theme import empty_state, page_setup
 
-st.set_page_config(page_title="Screen Overview - Brieflow Analysis", layout="wide")
+page_setup(
+    "Screen Overview",
+    "🧬",
+    "What was screened: the screen definition, the perturbation library and the features measured.",
+)
+
+# Number of rows previewed for the library tables
+PREVIEW_ROWS = 50
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -43,8 +51,6 @@ def resolve_path(path):
 # ---------------------------------------------------------------------------
 config = load_config()
 
-st.title("Screen Overview")
-
 # ---------------------------------------------------------------------------
 # Tabs
 # ---------------------------------------------------------------------------
@@ -54,29 +60,34 @@ tab_screen, tab_library, tab_features = st.tabs(
 
 # ========================== Screen Info (raw YAML) =========================
 with tab_screen:
-    st.header("Screen Info")
+    st.caption(os.path.abspath(SCREEN_PATH))
     st.code(load_raw_yaml(SCREEN_PATH), language="yaml")
 
 # ========================== Perturbation Library ===========================
 with tab_library:
-    st.header("Perturbation Library")
-
     # --- Processed barcode library (from config) ---
     barcode_path = resolve_path(config.get("sbs", {}).get("df_barcode_library_fp", ""))
 
     if barcode_path:
         st.subheader("Barcode Library")
+        st.caption(os.path.abspath(barcode_path))
         df_lib = read_table(barcode_path)
 
         n_guides = len(df_lib)
         gene_col = "gene_symbol" if "gene_symbol" in df_lib.columns else None
         n_genes = df_lib[gene_col].nunique() if gene_col else "N/A"
 
-        col1, col2 = st.columns(2)
+        col1, col2, col3 = st.columns(3)
         col1.metric(
             "Unique Genes", f"{n_genes:,}" if isinstance(n_genes, int) else n_genes
         )
         col2.metric("Total Guides", f"{n_guides:,}")
+        col3.metric(
+            "Guides per Gene",
+            f"{n_guides / n_genes:.1f}"
+            if isinstance(n_genes, int) and n_genes
+            else "—",
+        )
 
         st.download_button(
             label="Download barcode library",
@@ -86,9 +97,15 @@ with tab_library:
             key="download_barcode_lib",
         )
 
-        st.dataframe(df_lib.head(50), use_container_width=True)
+        with st.expander(f"Preview first {PREVIEW_ROWS} rows", expanded=True):
+            st.dataframe(
+                df_lib.head(PREVIEW_ROWS), use_container_width=True, hide_index=True
+            )
     else:
-        st.info("Barcode library not found in config.")
+        empty_state(
+            "No barcode library found.",
+            "Set `sbs.df_barcode_library_fp` in the config to the library the screen used.",
+        )
 
     # --- Raw perturbation library design file (optional) ---
     raw_lib_path = resolve_path(os.environ.get("PERTURBATION_LIBRARY_PATH", ""))
@@ -96,11 +113,12 @@ with tab_library:
     if raw_lib_path:
         st.divider()
         st.subheader("Raw Perturbation Library Design")
+        st.caption(os.path.abspath(raw_lib_path))
         df_raw = read_table(raw_lib_path)
 
-        st.markdown(
-            f"**Source:** `{raw_lib_path}` ({len(df_raw):,} rows, {len(df_raw.columns)} columns)"
-        )
+        col_rows, col_cols = st.columns(2)
+        col_rows.metric("Rows", f"{len(df_raw):,}")
+        col_cols.metric("Columns", f"{len(df_raw.columns):,}")
 
         st.download_button(
             label="Download raw library design",
@@ -110,12 +128,13 @@ with tab_library:
             key="download_raw_lib",
         )
 
-        st.dataframe(df_raw.head(50), use_container_width=True)
+        with st.expander(f"Preview first {PREVIEW_ROWS} rows", expanded=False):
+            st.dataframe(
+                df_raw.head(PREVIEW_ROWS), use_container_width=True, hide_index=True
+            )
 
 # ========================== Features =======================================
 with tab_features:
-    st.header("Features")
-
     # -- Summary table of all feature sets --
     agg_tsvs_dir = os.path.join(BRIEFLOW_OUTPUT_PATH, "aggregate", "tsvs")
     feature_files = []
@@ -149,12 +168,24 @@ with tab_features:
                 }
             )
 
+        st.subheader("Feature Sets")
         st.dataframe(
-            pd.DataFrame(summary_rows), use_container_width=True, hide_index=True
+            pd.DataFrame(summary_rows),
+            use_container_width=True,
+            hide_index=True,
+            column_config={
+                "Feature Set": st.column_config.TextColumn(width="large"),
+                "Total Columns": st.column_config.NumberColumn(format="%d"),
+                "Feature Columns": st.column_config.NumberColumn(format="%d"),
+            },
         )
 
         # Download button for selected feature set
-        selected_file = st.selectbox("Select feature set to download", feature_files)
+        selected_file = st.selectbox(
+            "Feature set",
+            feature_files,
+            help="Pick a feature set to download its column list.",
+        )
         fp = os.path.join(agg_tsvs_dir, selected_file)
         cols = list(pd.read_csv(fp, sep="\t", nrows=0).columns)
         feat_cols = [c for c in cols if not c.startswith(METADATA_PREFIXES)]
@@ -173,11 +204,14 @@ with tab_features:
             mime="text/markdown",
         )
     else:
-        st.info("No feature files found. Run the aggregate step first.")
+        empty_state(
+            "No feature files found.",
+            "The aggregate step writes `aggregate/tsvs/*__features_genes.tsv`.",
+        )
 
     # -- Feature description reference --
     st.divider()
-    st.header("Feature Descriptions")
+    st.subheader("Feature Descriptions")
 
     # Allow override via env var, else auto-discover from brieflow repo
     feature_doc_path = os.environ.get("FEATURE_DOC_PATH", "")
@@ -209,4 +243,7 @@ with tab_features:
             key="download_feature_doc",
         )
     else:
-        st.info("Feature documentation not found.")
+        empty_state(
+            "Feature documentation not found.",
+            "Point `FEATURE_DOC_PATH` at `workflow/lib/external/CP_EMULATOR_FEATURES.md`.",
+        )

--- a/visualization/pages/3_Screen_Overview.py
+++ b/visualization/pages/3_Screen_Overview.py
@@ -5,6 +5,7 @@ import streamlit as st
 import yaml
 
 from src.config import BRIEFLOW_OUTPUT_PATH, CONFIG_PATH, SCREEN_PATH, load_config
+from src.filesystem import read_table
 
 st.set_page_config(page_title="Screen Overview - Brieflow Analysis", layout="wide")
 
@@ -16,13 +17,6 @@ st.set_page_config(page_title="Screen Overview - Brieflow Analysis", layout="wid
 def load_raw_yaml(file_path):
     with open(file_path, "r") as file:
         return file.read()
-
-
-def read_tabular(path):
-    """Read a TSV or CSV based on file extension."""
-    if path.endswith(".csv"):
-        return pd.read_csv(path)
-    return pd.read_csv(path, sep="\t")
 
 
 def resolve_path(path):
@@ -72,7 +66,7 @@ with tab_library:
 
     if barcode_path:
         st.subheader("Barcode Library")
-        df_lib = read_tabular(barcode_path)
+        df_lib = read_table(barcode_path)
 
         n_guides = len(df_lib)
         gene_col = "gene_symbol" if "gene_symbol" in df_lib.columns else None
@@ -102,7 +96,7 @@ with tab_library:
     if raw_lib_path:
         st.divider()
         st.subheader("Raw Perturbation Library Design")
-        df_raw = read_tabular(raw_lib_path)
+        df_raw = read_table(raw_lib_path)
 
         st.markdown(
             f"**Source:** `{raw_lib_path}` ({len(df_raw):,} rows, {len(df_raw.columns)} columns)"

--- a/visualization/pages/4_Analysis_Overview.py
+++ b/visualization/pages/4_Analysis_Overview.py
@@ -2,10 +2,12 @@ import streamlit as st
 import git
 import os
 from src.config import CONFIG_PATHS
+from src.theme import page_setup
 
-st.set_page_config(
-    page_title="Analysis Overview - Brieflow Analysis",
-    layout="wide",
+page_setup(
+    "Analysis Overview",
+    "🗂️",
+    "The configuration, dependencies and repository state this analysis ran with.",
 )
 
 
@@ -28,28 +30,29 @@ def display_git_info():
                 if not hasattr(repo.remotes, "origin")
                 else repo.remotes.origin.url
             )
-            st.write(f"**Repository URL:** {remote_url}")
         else:
-            st.write("**Repository URL:** No remote repositories configured")
+            remote_url = "No remote repositories configured"
 
-        st.write(f"**Current Commit Hash:** {commit_hash}")
+        st.metric("Commit", commit_hash[:12])
+        st.caption("Repository")
+        st.code(remote_url, language=None)
+        st.caption("Full commit hash")
+        st.code(commit_hash, language=None)
     except Exception as e:
         st.error(f"Error retrieving git information: {str(e)}")
 
 
 def display_requirements():
-    st.header("Dependencies")
     try:
         _vis_dir = os.path.dirname(os.path.dirname(__file__))
         pyproject_path = os.path.join(os.path.dirname(_vis_dir), "pyproject.toml")
         with open(pyproject_path, "r") as file:
             content = file.read()
+        st.caption(f"`{os.path.basename(pyproject_path)}`")
         st.code(content, language="toml")
     except Exception as e:
         st.error(f"Error reading pyproject.toml: {str(e)}")
 
-
-st.title("Analysis Overview")
 
 # tabs for: config, dependencies, git
 tab1, tab2, tab3 = st.tabs(["Config", "Dependencies", "Git"])
@@ -57,6 +60,7 @@ with tab1:
     # CONFIG_PATH can name several files that the run deep-merged, so show each of them.
     for config_path in CONFIG_PATHS:
         st.subheader(os.path.basename(config_path))
+        st.caption(os.path.abspath(config_path))
         display_yaml(config_path)
 
 with tab2:

--- a/visualization/pages/4_Analysis_Overview.py
+++ b/visualization/pages/4_Analysis_Overview.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import git
 import os
-from src.config import CONFIG_PATH
+from src.config import CONFIG_PATHS
 
 st.set_page_config(
     page_title="Analysis Overview - Brieflow Analysis",
@@ -54,7 +54,10 @@ st.title("Analysis Overview")
 # tabs for: config, dependencies, git
 tab1, tab2, tab3 = st.tabs(["Config", "Dependencies", "Git"])
 with tab1:
-    display_yaml(CONFIG_PATH)
+    # CONFIG_PATH can name several files that the run deep-merged, so show each of them.
+    for config_path in CONFIG_PATHS:
+        st.subheader(os.path.basename(config_path))
+        display_yaml(config_path)
 
 with tab2:
     display_requirements()

--- a/visualization/src/config.py
+++ b/visualization/src/config.py
@@ -8,7 +8,9 @@ logger = logging.getLogger(__name__)
 
 # Get paths for visualization
 BRIEFLOW_OUTPUT_PATH = os.environ["BRIEFLOW_OUTPUT_PATH"]
-CONFIG_PATH = os.environ["CONFIG_PATH"]
+# CONFIG_PATH may list several YAML files, deep-merged left to right like `snakemake --configfile a b`
+CONFIG_PATHS = os.environ["CONFIG_PATH"].split()
+CONFIG_PATH = CONFIG_PATHS[0]
 SCREEN_PATH = os.environ["SCREEN_PATH"]
 
 # Static asset configuration - these can be None for local development
@@ -19,16 +21,34 @@ STATIC_ASSET_PATH = os.environ.get(
     "STATIC_ASSET_PATH", None
 )  # e.g. "/disk1/brieflow_datasets/aconcagua/"
 
-logger.info(f"CONFIG_PATH: {os.path.abspath(CONFIG_PATH)}")
+logger.info(f"CONFIG_PATH: {[os.path.abspath(p) for p in CONFIG_PATHS]}")
 logger.info(f"SCREEN_PATH: {os.path.abspath(SCREEN_PATH)}")
 
 
 def load_config():
-    """Load the YAML configuration file."""
-    try:
-        with open(CONFIG_PATH, "r") as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found at: {os.path.abspath(CONFIG_PATH)}")
-        logger.info(f"Current working directory: {os.getcwd()}")
-        raise
+    """Load the YAML configuration, deep-merging every path in CONFIG_PATH."""
+    config = {}
+    for config_path in CONFIG_PATHS:
+        try:
+            with open(config_path, "r") as file:
+                _deep_merge(config, yaml.safe_load(file) or {})
+        except FileNotFoundError:
+            logger.error(f"Config file not found at: {os.path.abspath(config_path)}")
+            logger.info(f"Current working directory: {os.getcwd()}")
+            raise
+    return config
+
+
+def get_image_format():
+    """Return the pipeline output image format, either ``tiff`` or ``zarr``."""
+    return load_config().get("all", {}).get("image_format", "tiff")
+
+
+def _deep_merge(base, overlay):
+    """Merge overlay into base in place, recursing into nested dicts."""
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base

--- a/visualization/src/filesystem.py
+++ b/visualization/src/filesystem.py
@@ -2,12 +2,28 @@ import glob
 import logging
 import os
 import re
+import sys
 import pandas as pd
 import streamlit as st
+import zarr
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from workflow.lib.shared.parquet_io import read_parquet
 
 logger = logging.getLogger(__name__)
 
 MANIFEST_FILENAME = ".file_manifest"
+
+# Zarr-mode outputs nest the data location as directories instead of encoding it in the
+# filename (sbs/eval/mapping/1/mapping_overview.tsv vs P-1__mapping_overview.tsv).
+# The trailing directory components below an anchor are the location chain, whose length
+# tells us which keys it carries.
+LOCATION_ANCHORS = ("eval", "tsvs", "parquets")
+LOCATION_CHAIN_KEYS = {
+    1: ("plate",),
+    3: ("plate", "row", "col"),
+    4: ("plate", "row", "col", "tile"),
+}
 
 # Module-level cache so the manifest is read at most once per process.
 _manifest_cache: dict[str, list[str]] = {}
@@ -53,6 +69,15 @@ def _find_data_root(root_dir: str) -> tuple[str, str] | None:
         candidate = parent
 
 
+def _zarr_store_of(rel_path):
+    """Return the innermost ``.zarr`` ancestor of a path, or None if it is not inside a store."""
+    parts = rel_path.split("/")
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i].endswith(".zarr"):
+            return "/".join(parts[: i + 1])
+    return None
+
+
 def _apply_path_filters(files, include_any=None, include_all=None):
     """Apply include_any / include_all directory-component filters."""
     filtered = files
@@ -69,6 +94,62 @@ def _apply_path_filters(files, include_any=None, include_all=None):
             if all(item in os.path.normpath(f).split(os.sep) for item in include_all)
         ]
     return filtered
+
+
+def read_table(path):
+    """Read a tabular file as a DataFrame, dispatching on its extension.
+
+    Parquet goes through the pipeline's own reader so the visualizer and the pipeline
+    agree on dtypes; TSV/CSV keep the plain pandas path.
+    """
+    if str(path).endswith(".parquet"):
+        return read_parquet(path)
+    if str(path).endswith(".csv"):
+        return pd.read_csv(path)
+    return pd.read_csv(path, sep="\t")
+
+
+def read_zarr_channel_names(store_path):
+    """Read channel labels from an OME-Zarr store's omero metadata.
+
+    Returns None when the store carries no channel metadata.
+    """
+    attrs = dict(zarr.open_group(str(store_path), mode="r").attrs)
+    # OME-NGFF v0.5 nests omero under "ome"; v0.4 keeps it at the top level.
+    omero = attrs.get("ome", {}).get("omero") or attrs.get("omero")
+    if not omero:
+        return None
+    return [channel.get("label") for channel in omero.get("channels", [])]
+
+
+def parse_nested_location(file_path):
+    """Extract the data location a zarr-mode path encodes as directory levels.
+
+    Returns a dict with some of ``plate``/``row``/``col``/``tile``, or an empty dict when
+    the path carries no recognizable location chain (TIFF mode, where the location lives
+    in the filename instead).
+    """
+    parts = os.path.normpath(file_path).split(os.sep)
+    # A "__" in the basename marks a flat TIFF-mode filename, which carries its own location.
+    if "__" in parts[-1]:
+        return {}
+
+    parts = parts[:-1]
+    anchor = max(
+        (i for i, part in enumerate(parts) if part in LOCATION_ANCHORS), default=None
+    )
+    if anchor is None:
+        return {}
+
+    chain = parts[anchor + 1 :]
+    # An eval group directory ("mapping", "segmentation", ...) can sit between the anchor
+    # and the location, so drop the leading component when the full chain has no valid shape.
+    if len(chain) not in LOCATION_CHAIN_KEYS and chain:
+        chain = chain[1:]
+    if len(chain) not in LOCATION_CHAIN_KEYS:
+        return {}
+
+    return dict(zip(LOCATION_CHAIN_KEYS[len(chain)], chain))
 
 
 class FileSystem:
@@ -90,7 +171,8 @@ class FileSystem:
             root_dir: The root directory to search in
             includes_any: List of strings where if the path includes any of the values, it is included
             include_all: List of strings where the path must include each and every element
-            extensions: List of file extensions to search for (default: ['png', 'tsv'])
+            extensions: List of file extensions to search for (default: ['png', 'tsv']).
+                Use 'zarr' to match OME-Zarr stores, which are directories rather than files.
 
         Returns:
             A list of file paths that match the filtering criteria
@@ -107,8 +189,17 @@ class FileSystem:
             manifest = _load_manifest(data_root)
             if manifest is not None:
                 all_files = []
+                seen_stores = set()
                 for rel in manifest:
                     if prefix and not rel.startswith(prefix + "/"):
+                        continue
+                    # A zarr store is a directory, so the manifest only lists the chunk
+                    # files inside it; collapse those back to the store they belong to.
+                    store = _zarr_store_of(rel) if "zarr" in ext_set else None
+                    if store is not None:
+                        if store not in seen_stores:
+                            seen_stores.add(store)
+                            all_files.append(os.path.join(data_root, store))
                         continue
                     ext = rel.rsplit(".", 1)[-1] if "." in rel else ""
                     if ext in ext_set:
@@ -126,7 +217,10 @@ class FileSystem:
     @staticmethod
     def extract_well_id(file_path):
         r"""
-        Extract well identifier (format: W-[A-Z]\d+) from a file path.
+        Extract well identifier from a file path.
+
+        Reads the TIFF-mode W-[A-Z]\d+ filename prefix, falling back to the row/col
+        directories that zarr mode nests the location into.
 
         Args:
             file_path: Path to the file
@@ -135,12 +229,20 @@ class FileSystem:
             Well ID if found, None otherwise
         """
         match = re.search(r"W-([A-Z]\d+)", file_path)
-        return match.group(1) if match else None
+        if match:
+            return match.group(1)
+        location = parse_nested_location(file_path)
+        if "row" in location and "col" in location:
+            return location["row"] + location["col"]
+        return None
 
     @staticmethod
     def extract_plate_id(file_path):
         r"""
-        Extract plate identifier (format: P-\d+) from a file path.
+        Extract plate identifier from a file path.
+
+        Reads the TIFF-mode P-\d+ filename prefix, falling back to the plate directory
+        that zarr mode nests the location into.
 
         Args:
             file_path: Path to the file
@@ -149,7 +251,9 @@ class FileSystem:
             Plate ID if found, None otherwise
         """
         match = re.search(r"P-(\d+)", file_path)
-        return match.group(1) if match else None
+        if match:
+            return match.group(1)
+        return parse_nested_location(file_path).get("plate")
 
     @staticmethod
     def extract_metric_name(file_path):
@@ -165,7 +269,8 @@ class FileSystem:
         base = os.path.splitext(os.path.basename(file_path))[0]
         if "__" in base:
             return base.split("__")[-1]
-        return None
+        # Zarr-mode basenames are the bare metric name, with the location in the directories.
+        return base or None
 
     @staticmethod
     def extract_leiden_resolution(file_path):

--- a/visualization/src/rendering.py
+++ b/visualization/src/rendering.py
@@ -1,5 +1,4 @@
 import os
-import pandas as pd
 import streamlit as st
 import sys
 import uuid
@@ -7,6 +6,7 @@ import uuid
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 from workflow.lib.shared.file_utils import parse_filename
 from src.config import STATIC_ASSET_URL_ROOT, STATIC_ASSET_PATH
+from src.filesystem import parse_nested_location, read_table
 
 
 class VisualizationRenderer:
@@ -27,11 +27,18 @@ class VisualizationRenderer:
         for (dir_name, base_name), group_df in grouped:
             with st.container():
                 attrs, metric_name, _ = parse_filename(base_name)
+                # Zarr mode encodes the location in the directories, not the filename.
+                if not attrs:
+                    attrs = parse_nested_location(
+                        os.path.join(dir_name, os.path.basename(base_name))
+                    )
                 metric_title = metric_name.replace("_", " ").title()
                 attr_parts = [
                     f"{k.replace('_', ' ').title()}: {v}" for k, v in attrs.items()
                 ]
-                title = f"{metric_title} - " + ", ".join(attr_parts)
+                title = " - ".join(
+                    [metric_title] + ([", ".join(attr_parts)] if attr_parts else [])
+                )
                 st.markdown(f"### {title}")
 
                 # Count only the items we'll actually display
@@ -88,8 +95,8 @@ class VisualizationRenderer:
                         elif row["ext"] == "tsv" and not has_png:
                             # Only show TSV if there's no PNG
                             try:
-                                tsv_data = pd.read_csv(
-                                    os.path.join(root_dir, row["file_path"]), sep="\t"
+                                tsv_data = read_table(
+                                    os.path.join(root_dir, row["file_path"])
                                 )
                                 st.dataframe(tsv_data)
                             except Exception as e:

--- a/visualization/src/rendering.py
+++ b/visualization/src/rendering.py
@@ -8,6 +8,9 @@ from workflow.lib.shared.file_utils import parse_filename
 from src.config import STATIC_ASSET_URL_ROOT, STATIC_ASSET_PATH
 from src.filesystem import parse_nested_location, read_table
 
+# Plots per row before wrapping, so a phase with many wells stays a grid
+COLUMNS_PER_ROW = 3
+
 
 class VisualizationRenderer:
     @staticmethod
@@ -18,13 +21,13 @@ class VisualizationRenderer:
             return
 
         if filtered_df.empty:
-            st.warning("No data found matching the selected filters.")
+            st.info("No quality control files match the selected filters.")
             return
 
         # Group by directory and basename
         grouped = filtered_df.groupby(["dir", "basename"])
         # Iterate through each group
-        for (dir_name, base_name), group_df in grouped:
+        for group_index, ((dir_name, base_name), group_df) in enumerate(grouped):
             with st.container():
                 attrs, metric_name, _ = parse_filename(base_name)
                 # Zarr mode encodes the location in the directories, not the filename.
@@ -36,26 +39,29 @@ class VisualizationRenderer:
                 attr_parts = [
                     f"{k.replace('_', ' ').title()}: {v}" for k, v in attrs.items()
                 ]
-                title = " - ".join(
-                    [metric_title] + ([", ".join(attr_parts)] if attr_parts else [])
-                )
-                st.markdown(f"### {title}")
+                if group_index:
+                    st.divider()
+                st.subheader(metric_title)
+                if attr_parts:
+                    st.caption(" · ".join(attr_parts))
 
                 # Count only the items we'll actually display
-                display_items = []
-                for _, row in group_df.iterrows():
-                    has_png = any(r["ext"] == "png" for _, r in group_df.iterrows())
-                    if row["ext"] == "png" or (row["ext"] == "tsv" and not has_png):
-                        display_items.append(row)
+                has_png = any(r["ext"] == "png" for _, r in group_df.iterrows())
+                display_items = [
+                    row
+                    for _, row in group_df.iterrows()
+                    if row["ext"] == "png" or (row["ext"] == "tsv" and not has_png)
+                ]
+                if not display_items:
+                    continue
 
                 # Create columns based on actual display items
-                cols = st.columns(min(3, len(display_items)))
+                cols = st.columns(min(COLUMNS_PER_ROW, len(display_items)))
 
                 for idx, row in enumerate(display_items):
                     col_idx = idx % len(cols)
                     with cols[col_idx]:
                         # Check if this group has both PNG and TSV
-                        has_png = any(r["ext"] == "png" for _, r in group_df.iterrows())
                         has_tsv = any(r["ext"] == "tsv" for _, r in group_df.iterrows())
 
                         if row["ext"] == "png":
@@ -63,7 +69,8 @@ class VisualizationRenderer:
                             try:
                                 st.image(
                                     os.path.join(root_dir, row["file_path"]),
-                                    caption=f"{row['metric_name']} - {row['well_id']}",
+                                    caption=f"{row['metric_name']} — well {row['well_id']}",
+                                    use_container_width=True,
                                 )
                             except Exception as e:
                                 st.error(f"Could not load image: {row['file_path']}")
@@ -90,6 +97,7 @@ class VisualizationRenderer:
                                             data=f,
                                             file_name=os.path.basename(tsv_path),
                                             key=f"download_{str(uuid.uuid4())}",
+                                            use_container_width=True,
                                         )
 
                         elif row["ext"] == "tsv" and not has_png:
@@ -98,8 +106,10 @@ class VisualizationRenderer:
                                 tsv_data = read_table(
                                     os.path.join(root_dir, row["file_path"])
                                 )
-                                st.dataframe(tsv_data)
+                                st.dataframe(
+                                    tsv_data,
+                                    hide_index=True,
+                                    use_container_width=True,
+                                )
                             except Exception as e:
                                 st.error(f"Error reading TSV file: {e}")
-
-                st.markdown("---")  # Add a separator between groups

--- a/visualization/src/theme.py
+++ b/visualization/src/theme.py
@@ -1,0 +1,84 @@
+import plotly.graph_objects as go
+import plotly.io as pio
+import streamlit as st
+
+# Accent and neutrals, kept in step with .streamlit/config.toml
+ACCENT = "#2B6E8F"
+MUTED = "#7A8B99"
+GRID = "#E8ECEF"
+
+# Categorical sequence shared by the plotly figures and the theme's chart colors
+CATEGORICAL = [
+    "#2B6E8F",
+    "#C97B3C",
+    "#5B8C5A",
+    "#8E6C9B",
+    "#B55A5A",
+    "#4F7CA3",
+    "#7A8B99",
+    "#A38A4B",
+]
+
+PLOTLY_TEMPLATE = "brieflow"
+
+# Registered once at import so every page's figures share one look
+pio.templates[PLOTLY_TEMPLATE] = go.layout.Template(
+    pio.templates["plotly_white"],
+    layout=dict(
+        colorway=CATEGORICAL,
+        font=dict(family="sans-serif", size=13, color="#1F2A37"),
+        title=dict(font=dict(size=16)),
+        margin=dict(l=48, r=24, t=32, b=48),
+        hoverlabel=dict(font_size=12),
+        legend=dict(
+            orientation="h",
+            yanchor="bottom",
+            y=1.02,
+            xanchor="left",
+            x=0,
+            font=dict(size=12),
+        ),
+        xaxis=dict(gridcolor=GRID, zerolinecolor=GRID, linecolor=GRID, ticks="outside"),
+        yaxis=dict(gridcolor=GRID, zerolinecolor=GRID, linecolor=GRID, ticks="outside"),
+    ),
+)
+
+# Spacing only: tighten the default gap above headings and around the block container
+_PAGE_CSS = """
+<style>
+    div.block-container {padding-top: 2.4rem; padding-bottom: 3rem;}
+    h2, h3 {margin-top: 0.6rem;}
+    div[data-testid="stMetric"] {padding: 0.25rem 0;}
+</style>
+"""
+
+
+def page_setup(title, icon, caption):
+    """Set the page config and render the shared title + one-line caption."""
+    st.set_page_config(
+        page_title=f"{title} - Brieflow Analysis",
+        page_icon=icon,
+        layout="wide",
+        initial_sidebar_state="expanded",
+    )
+    st.markdown(_PAGE_CSS, unsafe_allow_html=True)
+    st.title(title)
+    st.caption(caption)
+
+
+def sidebar_filters_header(subtitle=None):
+    """Render the shared sidebar filter heading."""
+    st.sidebar.subheader("Filters")
+    if subtitle:
+        st.sidebar.caption(subtitle)
+
+
+def empty_state(message, hint=None):
+    """Show a missing-data message, naming the pipeline step that produces the file."""
+    st.info(f"{message}\n\n:gray[{hint}]" if hint else message)
+
+
+def style_figure(fig, **layout):
+    """Apply the shared plotly template to a figure and return it."""
+    fig.update_layout(template=PLOTLY_TEMPLATE, **layout)
+    return fig

--- a/workflow/lib/cluster/mozzarellm_io.py
+++ b/workflow/lib/cluster/mozzarellm_io.py
@@ -1,0 +1,483 @@
+"""Adapters between brieflow cluster outputs and the mozzarellm LLM annotation package.
+
+The cluster h5ad written by ``rule format_cluster_anndata`` carries everything
+mozzarellm needs -- one row per perturbation, a cluster assignment per Leiden
+resolution, and a percentile-rank layer over the features -- so this module
+reshapes it into the gene/cluster/feature table mozzarellm consumes, builds the
+screen-context JSON from the screen description, and runs the analysis into a
+timestamped run directory next to the clustering outputs.
+"""
+
+import json
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from lib.aggregate.cell_data_utils import control_mask
+
+CLUSTER_GROUP_PREFIX = "cluster_group_"
+
+MOZZARELLM_DIR_NAME = "mozzarellm"
+
+RUN_DIR_PREFIX = "run_"
+
+# run_phate hard-codes its neighbourhood size, so the screen context reports that value
+PHATE_KNN = 10
+
+MOZZARELLM_IMPORT_HINT = (
+    "mozzarellm is not installed; install it with "
+    'python -m pip install "brieflow[mozzarellm]"'
+)
+
+PROVIDER_KEY_ENV = {
+    "claude": "ANTHROPIC_API_KEY",
+    "gpt": "OPENAI_API_KEY",
+    "o1": "OPENAI_API_KEY",
+    "o3": "OPENAI_API_KEY",
+    "o4": "OPENAI_API_KEY",
+    "gemini": "GOOGLE_API_KEY",
+}
+
+
+def cluster_table_from_h5ad(
+    h5ad_path,
+    leiden_resolution,
+    control_key=None,
+    n_features=5,
+    fdr_threshold=None,
+    cluster_ids=None,
+):
+    """Build the mozzarellm cluster table from a brieflow cluster h5ad.
+
+    The up/down feature lists are the features on which a perturbation sits
+    highest and lowest in the ``percentile_rank`` layer, named by
+    ``var["feature_name"]`` rather than by index so the model sees real feature
+    names. When ``fdr_threshold`` is given and the h5ad carries a bootstrap
+    ``fdr`` layer, only features below that threshold are eligible.
+
+    Args:
+        h5ad_path (str | Path): Cluster h5ad from ``rule format_cluster_anndata``.
+        leiden_resolution (int | float | str): Resolution whose
+            ``cluster_group_{res}`` column supplies the cluster assignments.
+        control_key (str | list, optional): Control identifier; matching
+            perturbations are dropped. Defaults to None (keep everything).
+        n_features (int, optional): Features per direction. Defaults to 5.
+        fdr_threshold (float, optional): Keep only features with an FDR below
+            this value. Defaults to None (no FDR filter).
+        cluster_ids (list, optional): Restrict the table to these clusters.
+            Defaults to None (every cluster).
+
+    Returns:
+        pd.DataFrame: Columns ``gene_symbol``, ``cluster``, ``up_features``,
+        ``down_features``, ``phenotypic_strength``.
+    """
+    adata = ad.read_h5ad(h5ad_path)
+    cluster_col = f"{CLUSTER_GROUP_PREFIX}{_resolution_label(leiden_resolution)}"
+    if cluster_col not in adata.obs.columns:
+        available = [c for c in adata.obs.columns if c.startswith(CLUSTER_GROUP_PREFIX)]
+        raise KeyError(f"{h5ad_path} has no {cluster_col}; available: {available}")
+
+    genes = pd.Index(adata.obs_names).astype(str)
+    ranks = np.asarray(adata.layers["percentile_rank"], dtype=float)
+    feature_names = adata.var["feature_name"].astype(str).to_numpy()
+
+    eligible = np.isfinite(ranks)
+    if fdr_threshold is not None and "fdr" in adata.layers:
+        fdr = np.asarray(adata.layers["fdr"], dtype=float)
+        eligible &= np.isfinite(fdr) & (fdr < fdr_threshold)
+
+    up_features, down_features = [], []
+    for row in range(ranks.shape[0]):
+        up, down = _extreme_feature_names(
+            ranks[row], eligible[row], feature_names, n_features
+        )
+        up_features.append(up)
+        down_features.append(down)
+
+    table = pd.DataFrame(
+        {
+            "gene_symbol": genes,
+            "cluster": adata.obs[cluster_col].to_numpy(),
+            "up_features": up_features,
+            "down_features": down_features,
+            "phenotypic_strength": pd.to_numeric(
+                adata.obs.get(
+                    "perturbation_auc", pd.Series(np.nan, index=adata.obs_names)
+                ),
+                errors="coerce",
+            ).to_numpy(),
+        }
+    )
+
+    table = table[table["cluster"].notna()]
+    if control_key is not None:
+        table = table[~control_mask(table["gene_symbol"], control_key)]
+    table["cluster"] = table["cluster"].astype(int)
+    if cluster_ids is not None:
+        table = table[table["cluster"].isin([int(c) for c in cluster_ids])]
+
+    return table.reset_index(drop=True)
+
+
+def screen_context_from_screen(screen, config, leiden_resolution):
+    """Build the mozzarellm screen-context dict from screen.yaml and config.yml.
+
+    Every key the mozzarellm template marks "required" is filled, falling back
+    to a brieflow default whenever the screen description leaves a value null.
+
+    Args:
+        screen (dict): Parsed ``screen.yaml``.
+        config (dict): Parsed ``config/config.yml``.
+        leiden_resolution (int | float | str): Resolution being annotated.
+
+    Returns:
+        dict: Screen context ready to be written as JSON.
+    """
+    experiment = _section(screen, "experiment")
+    library = _section(screen, "library")
+    collection = _section(screen, "collection")
+    cluster_config = _section(config, "cluster")
+
+    channels = _channel_names(screen, config)
+    channel_text = ", ".join(channels) if channels else "the phenotype"
+    gene_selection = library.get("gene_selection") or "pooled sgRNA library"
+    number_of_genes = library.get("number_of_genes")
+    if number_of_genes:
+        gene_selection = f"{gene_selection} ({number_of_genes} genes)"
+    metric = cluster_config.get("phate_distance_metric") or "euclidean"
+    resolutions = cluster_config.get("leiden_resolutions") or [leiden_resolution]
+
+    return {
+        "assay_type": experiment.get("assay") or "optical pooled screening",
+        "target_phenotype": (
+            "Morphological cell phenotype — shape, texture and intensity features "
+            f"measured across the {channel_text} imaging channels"
+        ),
+        "organism": experiment.get("organism") or "Homo sapiens",
+        "cell_line_or_system": experiment.get("tissue") or "unspecified cell line",
+        "perturbation": {
+            "type": library.get("vector") or "CRISPR-Cas9 knockout",
+            "library_or_reagent": gene_selection,
+        },
+        "readout": {
+            "measurement": "High-content fluorescence imaging of fixed cells",
+            "instrument_or_platform": (
+                "Optical pooled screening (in situ sequencing + imaging), "
+                "processed with brieflow"
+            ),
+            "primary_metric": (
+                "Perturbation-level morphological feature profiles aggregated from "
+                "single-cell measurements"
+            ),
+        },
+        "clustering": {
+            "method": (
+                "Leiden clustering of a PHATE graph over perturbation-level feature "
+                f"profiles ({metric} distance)"
+            ),
+            "parameters": {
+                "resolution": str(leiden_resolution),
+                "k_neighbors": str(PHATE_KNN),
+            },
+        },
+        "controls": {
+            "negative_controls": _control_text(
+                library.get("negative_controls"),
+                _section(config, "aggregate").get("control_key"),
+                "non-targeting sgRNAs",
+            ),
+            "positive_controls": _control_text(
+                library.get("positive_controls"), None, "none designated"
+            ),
+        },
+        "provenance": {
+            "dataset_name": (
+                collection.get("title")
+                or experiment.get("screen_title")
+                or "brieflow optical pooled screen"
+            ),
+            "citation": collection.get("publication_doi") or "unpublished screen",
+            "data_source": (
+                "brieflow cluster h5ad written by rule format_cluster_anndata"
+            ),
+        },
+        "notes": (
+            "Clusters group perturbations with similar morphological phenotypes, so "
+            "genes sharing a cluster plausibly perturb the same process. Up and down "
+            "features are the features on which a perturbation ranks highest and "
+            "lowest across the screen. Clustering was run at resolutions "
+            f"{', '.join(str(r) for r in resolutions)}; this context describes "
+            f"resolution {leiden_resolution}."
+        ),
+    }
+
+
+def organism_id_from_screen(screen):
+    """Return the NCBI taxonomy id the screen declares, defaulting to human.
+
+    Args:
+        screen (dict): Parsed ``screen.yaml``.
+
+    Returns:
+        int: NCBI taxonomy id, e.g. 9606 for ``NCBITaxon:9606``.
+    """
+    term = _section(screen, "experiment").get("organism_ontology_term_id")
+    match = re.search(r"(\d+)", str(term or ""))
+
+    return int(match.group(1)) if match else 9606
+
+
+def mozzarellm_run_dir(cluster_dir, stamp=None):
+    """Return the run directory a mozzarellm run writes into.
+
+    Args:
+        cluster_dir (str | Path): Resolution directory holding the clustering outputs.
+        stamp (str, optional): Run stamp. Defaults to None (the current time).
+
+    Returns:
+        Path: ``<cluster_dir>/mozzarellm/run_<stamp>``.
+    """
+    stamp = stamp or datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    return Path(cluster_dir) / MOZZARELLM_DIR_NAME / f"{RUN_DIR_PREFIX}{stamp}"
+
+
+def latest_mozzarellm_run(cluster_dir):
+    """Return the newest mozzarellm run directory holding a cluster JSON.
+
+    Args:
+        cluster_dir (str | Path): Resolution directory holding the clustering outputs.
+
+    Returns:
+        Path | None: Newest ``run_*`` directory with a ``*_clusters.json``, or None.
+    """
+    runs = [
+        run
+        for run in sorted(
+            Path(cluster_dir).glob(f"{MOZZARELLM_DIR_NAME}/{RUN_DIR_PREFIX}*")
+        )
+        if run.is_dir() and any(run.glob("*_clusters.json"))
+    ]
+
+    return runs[-1] if runs else None
+
+
+def run_mozzarellm(
+    h5ad_path,
+    cluster_dir,
+    screen,
+    config,
+    leiden_resolution,
+    model,
+    mode="cot",
+    mcp=False,
+    include_features=True,
+    n_features=5,
+    fdr_threshold=None,
+    temperature=None,
+    max_tokens=16000,
+    screen_name=None,
+    cluster_ids=None,
+):
+    """Annotate a resolution's clusters with mozzarellm and write the run outputs.
+
+    Args:
+        h5ad_path (str | Path): Cluster h5ad to annotate.
+        cluster_dir (str | Path): Resolution directory the run is written under.
+        screen (dict): Parsed ``screen.yaml``.
+        config (dict): Parsed ``config/config.yml``.
+        leiden_resolution (int | float | str): Resolution to annotate.
+        model (str): Model identifier, e.g. ``claude-sonnet-5``.
+        mode (str, optional): Prompt mode. Defaults to "cot".
+        mcp (bool, optional): Attach mozzarellm's literature tools. Defaults to False.
+        include_features (bool, optional): Feed the up/down feature lists to the
+            model. Defaults to True.
+        n_features (int, optional): Features per direction. Defaults to 5.
+        fdr_threshold (float, optional): FDR cutoff for eligible features.
+            Defaults to None.
+        temperature (float, optional): Sampling temperature. Defaults to None
+            (the mozzarellm client default).
+        max_tokens (int, optional): Response token budget. Defaults to 16000.
+        screen_name (str, optional): Label prefixing the output files. Defaults
+            to None (the screen title, else the cluster directory's cell class
+            and channel combo).
+        cluster_ids (list, optional): Restrict the run to these clusters.
+            Defaults to None (every cluster).
+
+    Returns:
+        dict: The ``analyze_screen`` result, with ``run_dir`` set to the run directory.
+
+    Raises:
+        ValueError: If ``mcp`` and ``include_features`` are both set, which
+            mozzarellm does not support.
+    """
+    if mcp and include_features:
+        raise ValueError(
+            "mozzarellm supports include_features only for mode='cot' without MCP; "
+            "set mcp=False or include_features=False"
+        )
+
+    try:
+        from mozzarellm.clients.llm_api_clients import create_client
+        from mozzarellm.pipeline.screen_analysis import (
+            analyze_screen,
+            prepare_screen_bundles,
+        )
+    except ImportError as e:
+        raise ImportError(MOZZARELLM_IMPORT_HINT) from e
+
+    screen_name = screen_name or _screen_name(screen, cluster_dir)
+    output_dir = Path(cluster_dir) / MOZZARELLM_DIR_NAME
+    run_dir = mozzarellm_run_dir(cluster_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    cluster_table = cluster_table_from_h5ad(
+        h5ad_path,
+        leiden_resolution,
+        control_key=_section(config, "aggregate").get("control_key"),
+        n_features=n_features,
+        fdr_threshold=fdr_threshold,
+        cluster_ids=cluster_ids,
+    )
+
+    screen_context_path = run_dir / "screen_context.json"
+    screen_context_path.write_text(
+        json.dumps(
+            screen_context_from_screen(screen, config, leiden_resolution), indent=2
+        ),
+        encoding="utf-8",
+    )
+
+    bundles = prepare_screen_bundles(
+        screen_name=screen_name,
+        cluster_table=cluster_table,
+        output_dir=output_dir,
+        organism_id=organism_id_from_screen(screen),
+        feature_columns=["up_features", "down_features"] if include_features else None,
+    )
+    if cluster_ids is not None:
+        wanted = {str(c) for c in cluster_ids}
+        bundles = {k: v for k, v in bundles.items() if str(k) in wanted}
+
+    client_kwargs = {"model": model, "max_tokens": max_tokens}
+    if temperature is not None:
+        client_kwargs["temperature"] = temperature
+    api_key = _api_key_for_model(model)
+    if api_key:
+        client_kwargs["api_key"] = api_key
+
+    result = analyze_screen(
+        screen_name=screen_name,
+        cluster_to_bundle_map=bundles,
+        client=create_client(**client_kwargs),
+        run_dir=run_dir,
+        screen_context_path=screen_context_path,
+        mode=mode,
+        mcp=mcp,
+        include_features=include_features,
+    )
+    result["run_dir"] = run_dir
+
+    return result
+
+
+def _resolution_label(leiden_resolution):
+    """Render a resolution the way ``format_cluster_anndata`` names its obs column."""
+    value = float(leiden_resolution)
+
+    return str(int(value)) if value.is_integer() else str(value)
+
+
+def _extreme_feature_names(rank_row, eligible_row, feature_names, n_features):
+    """Return the comma-joined highest- and lowest-ranked eligible feature names."""
+    indices = np.flatnonzero(eligible_row)
+    if indices.size == 0:
+        return "", ""
+
+    order = indices[np.argsort(rank_row[indices], kind="stable")]
+    # a narrow eligible set is split down the middle so up and down never overlap
+    take = (
+        min(n_features, order.size // 2) if order.size < 2 * n_features else n_features
+    )
+    if take == 0:
+        return "", ""
+
+    up = ",".join(feature_names[i] for i in order[: -take - 1 : -1])
+    down = ",".join(feature_names[i] for i in order[:take])
+
+    return up, down
+
+
+def _section(mapping, key):
+    """Return a nested mapping section, treating a missing or null section as empty."""
+    return (mapping or {}).get(key) or {}
+
+
+def _channel_names(screen, config):
+    """Return the phenotype channel names from config, then screen.yaml."""
+    channels = _section(config, "phenotype").get("channel_names")
+    if channels:
+        return [str(c) for c in channels]
+
+    phenotype = _section(screen, "phenotype")
+    if phenotype.get("channel_names"):
+        return [str(c) for c in phenotype["channel_names"]]
+
+    return [
+        str(channel["biological_name"])
+        for channel in phenotype.get("channels") or []
+        if isinstance(channel, dict) and channel.get("biological_name")
+    ]
+
+
+def _control_text(values, fallback_key, default):
+    """Render a control list from screen.yaml, falling back to the config control key."""
+    if values:
+        return ", ".join(str(v) for v in values)
+    if fallback_key:
+        keys = (
+            fallback_key if isinstance(fallback_key, (list, tuple)) else [fallback_key]
+        )
+        return ", ".join(str(k) for k in keys)
+
+    return default
+
+
+def _screen_name(screen, cluster_dir):
+    """Return a file-safe screen label, falling back to the cluster directory's identity."""
+    name = _section(screen, "experiment").get("screen_title") or _cluster_dir_label(
+        cluster_dir
+    )
+
+    return re.sub(r"[^0-9A-Za-z_.-]+", "_", str(name)).strip("_") or "brieflow_screen"
+
+
+def _cluster_dir_label(cluster_dir):
+    """Return ``<cell_class>_<channel_combo>`` for a resolution directory.
+
+    The tree is ``cluster/<combo>/[<compartment>/]<cell_class>/<res>``, so the
+    channel combo is the segment below the cluster root rather than a fixed
+    offset from the end.
+    """
+    parts = Path(cluster_dir).resolve().parts
+    if len(parts) < 3:
+        return "brieflow_screen"
+
+    roots = [i for i, part in enumerate(parts[:-2]) if part == "cluster"]
+
+    return f"{parts[-2]}_{parts[roots[-1] + 1] if roots else parts[-3]}"
+
+
+def _api_key_for_model(model):
+    """Return the API key for the model's provider, or None to let the client look it up."""
+    model_lower = str(model).lower()
+    for prefix, env_var in PROVIDER_KEY_ENV.items():
+        if model_lower.startswith(prefix):
+            return os.getenv(env_var)
+
+    return None

--- a/workflow/lib/cluster/mozzarellm_io.py
+++ b/workflow/lib/cluster/mozzarellm_io.py
@@ -18,7 +18,6 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 
-from lib.aggregate.cell_data_utils import control_mask
 
 CLUSTER_GROUP_PREFIX = "cluster_group_"
 
@@ -47,7 +46,6 @@ PROVIDER_KEY_ENV = {
 def cluster_table_from_h5ad(
     h5ad_path,
     leiden_resolution,
-    control_key=None,
     n_features=5,
     fdr_threshold=None,
     cluster_ids=None,
@@ -58,14 +56,13 @@ def cluster_table_from_h5ad(
     highest and lowest in the ``percentile_rank`` layer, named by
     ``var["feature_name"]`` rather than by index so the model sees real feature
     names. When ``fdr_threshold`` is given and the h5ad carries a bootstrap
-    ``fdr`` layer, only features below that threshold are eligible.
+    ``fdr`` layer, only features below that threshold are eligible. Control
+    perturbations stay in the table; mozzarellm recognizes them by name.
 
     Args:
         h5ad_path (str | Path): Cluster h5ad from ``rule format_cluster_anndata``.
         leiden_resolution (int | float | str): Resolution whose
             ``cluster_group_{res}`` column supplies the cluster assignments.
-        control_key (str | list, optional): Control identifier; matching
-            perturbations are dropped. Defaults to None (keep everything).
         n_features (int, optional): Features per direction. Defaults to 5.
         fdr_threshold (float, optional): Keep only features with an FDR below
             this value. Defaults to None (no FDR filter).
@@ -115,8 +112,6 @@ def cluster_table_from_h5ad(
     )
 
     table = table[table["cluster"].notna()]
-    if control_key is not None:
-        table = table[~control_mask(table["gene_symbol"], control_key)]
     table["cluster"] = table["cluster"].astype(int)
     if cluster_ids is not None:
         table = table[table["cluster"].isin([int(c) for c in cluster_ids])]
@@ -339,7 +334,6 @@ def run_mozzarellm(
     cluster_table = cluster_table_from_h5ad(
         h5ad_path,
         leiden_resolution,
-        control_key=_section(config, "aggregate").get("control_key"),
         n_features=n_features,
         fdr_threshold=fdr_threshold,
         cluster_ids=cluster_ids,

--- a/workflow/lib/phenotype/extract_phenotype_second_objs.py
+++ b/workflow/lib/phenotype/extract_phenotype_second_objs.py
@@ -354,9 +354,9 @@ def remove_border(labels, mask, dilate=2):
 foci_features = {
     "foci_count": lambda r: count_labels(r.intensity_image),
     "foci_area": lambda r: (r.intensity_image > 0).sum(),
-    "foci_area_ratio": lambda r: (r.intensity_image > 0).sum() / r.area
-    if r.area > 0
-    else 0,
+    "foci_area_ratio": lambda r: (
+        (r.intensity_image > 0).sum() / r.area if r.area > 0 else 0
+    ),
 }
 
 


### PR DESCRIPTION
The `visualization/` Streamlit app was written against the TIFF/TSV output layout, so pointing it at a `--zarr` run showed empty filters, untitled plot groups and no montages. This makes it format-aware so one app serves both output modes.

## What zarr mode actually changes

Only the *path shape* changes for preprocess/sbs/phenotype outputs — eval plots and tables stay PNG/TSV, and merge/aggregate/cluster outputs keep flat `get_filename` names in both modes. The one real format change is montages.

## Audit

| Assumption in the visualizer | zarr3 reality | Fix |
|---|---|---|
| `CONFIG_PATH` is a single YAML file | the runner passes `config/config.yml config/config_zarr.yml` to `snakemake --configfile`, which deep-merges them; the visualizer only read the first, so it never saw `image_format: zarr` | `src/config.py` splits `CONFIG_PATH` and deep-merges in order, mirroring snakemake; adds `get_image_format()` |
| `FileSystem.extract_plate_id` reads a `P-\d+` filename prefix | `get_data_output_path(..., img_fmt="zarr")` nests the location as directories: `sbs/eval/mapping/1/mapping_overview.tsv` | falls back to `parse_nested_location()`, which recovers the location chain from the directories below an `eval`/`tsvs`/`parquets` anchor |
| `FileSystem.extract_well_id` reads a `W-[A-Z]\d+` prefix | zarr splits the well into `row`/`col` directories (`.../1/A/1/0/bases.tsv`) | same fallback, rejoining `row + col` |
| `FileSystem.extract_metric_name` returns the part after the last `__` | zarr basenames are the bare metric (`mapping_overview.tsv`), so every metric came back `None` and the Metric filter was empty | falls back to the filename stem |
| `VisualizationRenderer` titles groups from `parse_filename` attrs | attrs are empty in zarr mode, leaving a dangling `"Metric - "` title | reuses `parse_nested_location`, and drops the separator when there are no attrs |
| `FileSystem.find_files` matches files by extension | a `.zarr` store is a *directory*, and a `.file_manifest` only lists the chunk files inside it | `extensions=["zarr"]` now resolves stores, collapsing manifest entries back to their innermost `.zarr` ancestor so the manifest fast path still works |
| montages are `{cell_class}__montages/{gene}/{sgrna}/CH-*__montage.png` plus `overlay_montage.tiff` | zarr mode writes one OME-Zarr crop per cell to `{cell_class}__examples.zarr/{gene}/{sgrna}/{idx}.zarr` (`aggregate.smk` `MONTAGE_OUTPUTS`); `__montages/` still exists but holds only `.crop_done` flags | `get_montage_root()` picks the right root, and a zarr branch reads each crop with `image_io.read_image` and labels channels from the store's omero metadata |
| tables are read with `pd.read_csv(sep="\t")` | still TSV today, but the pipeline writes parquet for well-level data | added `read_table()`, which dispatches on extension and routes parquet through the pipeline's own `parquet_io.read_parquet` |
| page 4 shows one config file | the run merged two | shows each merged file |
| page 1 globs `*_stats.txt` at the output root | nothing in this repo writes that file, in either mode | no change; the page already degrades to an info message |

Running against real small_test output surfaced three more path assumptions that are **independent of the image format** but blocked the app on any run defining compartments:

| Assumption | Reality | Fix |
|---|---|---|
| cluster dirs are `channel_combo/cell_class/leiden_resolution` | they are `channel_combo/[compartment_combo/]cell_class/leiden_resolution`, so `cell_class` was picking up the compartment and every filter matched nothing | levels are named by depth (`CLUSTER_DIR_LEVELS`); `cluster_size_charts` and the mozzarellm lookups locate directories from the loaded row's own path / a recursive glob instead of rebuilding a fixed-depth path |
| feature table is `CeCl-{cc}_ChCo-{ch}__features_genes.tsv` | aggregate writes `CeCl-{cc}_ChCo-{ch}_CmCo-{cm}__features_genes.tsv` | the compartment segment is included when the run has one |
| cell class options are the hardcoded `["all", "Mitotic", "Interphase"]` | `"all"` is not the `"All"` sentinel `apply_filter` honours, so the default selection filtered every row away and `cluster_table` raised on an empty frame | options come from the loaded data, with `"All"` as the no-filter sentinel |

## How tested

Both modes of `tests/small_test_analysis` were run end to end on the cluster (partition 20, 16 cores, 64G) and every page exercised headlessly with `streamlit.testing.v1.AppTest` plus function-level assertions.

- `run_brieflow.sh --zarr` — 3786/3786 steps, 34m52s. All five pages render with no exception: Quality Control 108 elements / 11 tables / 24 images, Cluster Analysis 11 elements / 2 tables, Screen Overview 10 elements / 2 tables, Analysis Overview 9 elements, Pipeline Stats degrades to its info message (no stats file is produced by this repo). Selecting a cluster and gene renders the OME-Zarr montage crops with channel captions `DAPI, COXIV, CENPA, WGA` read from the store metadata.
- `run_brieflow.sh` (TIFF) — 3783/3783 steps, 33m22s. Same five pages pass with identical counts, and the montage path renders the same four channel captions from PNGs, confirming no regression on the default output mode.
- Function level, against both real outputs: 25 zarr-nested eval files all resolve a plate and a metric name; `sbs/tsvs/1/A/1/0/alignment_metrics.tsv` parses to `{plate: 1, row: A, col: 1, tile: 0}` and well `A1`; montage crops resolve identically through the filesystem glob and through a generated 3207-entry `.file_manifest`.
- Secondary line: a synthetic fixture mimicking both output trees (built before the real data was reachable) also passes all five pages and the same assertions in both modes, covering the no-compartment 3-level cluster tree that small_test does not produce.

## Known gaps

- No mozzarellm output exists in small_test, so the LLM cluster panel and the `CB-Real__pie_chart.png` enrichment chart are exercised only for their "not found" path. The rewritten `find_mozzarellm_dirs` glob needs a real screen with mozzarellm results to confirm.
- small_test has a single plate and a single cell class, so the plate filter and the cell class filter are each exercised with one value. Multi-plate and Mitotic/Interphase behaviour needs real screen data.
- Wells are alphanumeric (`A1`) throughout small_test; the Opera Phenix `r02c05` convention that `split_well` supports is untested here end to end.
- When a channel combo spans more than one compartment combo, the feature table picks the first compartment in the loaded frame. Real screens with multiple compartment combos per channel combo may want an explicit compartment filter.
- The zarr montage view shows every crop stacked vertically; a real screen writes more crops per guide than small_test, so this may want a grid or a cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Z1SYzZJjRrSmDyDCWc4g4
