### PR TITLE
Enumerate num_nuclei in the metadata column lists

### DIFF
--- a/tests/small_test_analysis/config/cell_data_metadata_cols.tsv
+++ b/tests/small_test_analysis/config/cell_data_metadata_cols.tsv
@@ -47,6 +47,7 @@ cytoplasm_bounds_0
 cytoplasm_bounds_1
 cytoplasm_bounds_2
 cytoplasm_bounds_3
+num_nuclei
 cell_stage
 row
 col

--- a/workflow/lib/phenotype/constants.py
+++ b/workflow/lib/phenotype/constants.py
@@ -50,6 +50,7 @@ DEFAULT_METADATA_COLS = [
     "cytoplasm_bounds_1",
     "cytoplasm_bounds_2",
     "cytoplasm_bounds_3",
+    "num_nuclei",
     "row",
     "col",
 ]

--- a/workflow/scripts/aggregate/format_singlecell_anndata.py
+++ b/workflow/scripts/aggregate/format_singlecell_anndata.py
@@ -4,7 +4,11 @@ import numpy as np
 import pandas as pd
 import anndata as ad
 
-from lib.aggregate.cell_data_utils import load_metadata_cols, control_mask
+from lib.aggregate.cell_data_utils import (
+    load_metadata_cols,
+    control_mask,
+    is_reserved_metadata_col,
+)
 
 # Parameters
 metadata_cols_fp = snakemake.params.metadata_cols_fp
@@ -94,8 +98,12 @@ metadata_cols = [MERGE_DATASET_RENAMES.get(c, c) for c in metadata_cols]
 # Split obs (metadata) and feature columns.
 # Any non-numeric column not in metadata_cols is also moved to obs automatically.
 non_numeric_cols = [c for c in df.columns if not pd.api.types.is_numeric_dtype(df[c])]
+# Reserved metadata (num_nuclei, offset_*) is numeric but is not a feature
+reserved_cols = [c for c in df.columns if is_reserved_metadata_col(c)]
 obs_cols = list(
-    dict.fromkeys([c for c in metadata_cols if c in df.columns] + non_numeric_cols)
+    dict.fromkeys(
+        [c for c in metadata_cols if c in df.columns] + non_numeric_cols + reserved_cols
+    )
 )
 feature_cols = [c for c in df.columns if c not in obs_cols]
 


### PR DESCRIPTION
Follow-up to #261. That PR was merged nine minutes before its last commit landed on the branch, so this carries that one commit, unchanged (cherry-picked from `e14f408`):

- `num_nuclei` added to `DEFAULT_METADATA_COLS` (`lib/phenotype/constants.py`) and to the small_test `cell_data_metadata_cols.tsv`.
- `format_singlecell_anndata.py` now includes reserved metadata columns (`is_reserved_metadata_col`) in `obs`, so `num_nuclei` and the pre-existing `offset_x`/`offset_y` no longer land in `var`.

Verified on the #261 branch: small_test tiff + zarr green, `num_nuclei` in `obs` of both single-cell h5ads with identical distributions, aggregate parquets unchanged. Only the AnnData rules re-run since `metadata_cols_fp` is a param, not an input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Z1SYzZJjRrSmDyDCWc4g4