### PR TITLE
Per-process GPU leasing for concurrent cellpose-SAM jobs (from zarr3-jannu)

### DIFF
--- a/workflow/lib/shared/segment_cellpose.py
+++ b/workflow/lib/shared/segment_cellpose.py
@@ -31,6 +31,7 @@ for incompatible model/version combinations.
 import fcntl
 import os
 import sys
+import threading
 import time
 
 import numpy as np
@@ -57,76 +58,6 @@ except (AttributeError, ValueError):
     CELLPOSE_VERSION = (3, 0)
 
 CELLPOSE_4X = CELLPOSE_VERSION >= (4, 0)
-
-
-# Per-process GPU lease (cached): both Cellpose models in a segmentation job share
-# the one leased device, and the lock is held for the process lifetime.
-_LEASED_DEVICE = None
-_LEASE_FH = None
-
-
-def _select_gpu_device(gpu: bool):
-    """Lease one CUDA device for this process so concurrent jobs don't collide.
-
-    The segment_sbs/segment_phenotype rules declare ``resources: gpu=1`` and the
-    runner gates concurrency to ``--resources gpu=BRIEFLOW_GPU_COUNT``. Cellpose,
-    however, otherwise places every model on ``cuda:0`` (``assign_device`` default),
-    so all concurrent segmentation jobs pile onto a single device and OOM while the
-    other GPUs sit idle.
-
-    Each cpsam job needs nearly a whole 16 GB card, so statistical spreading
-    (``pid % N``) still OOMs whenever two concurrent jobs hash to the same GPU.
-    Instead, atomically lease a device via a non-blocking ``flock`` over N lock
-    files: with the scheduler gating to N concurrent jobs and N cards, every job
-    gets a distinct GPU and there are zero co-located jobs. The lock is held by an
-    open fd for the process lifetime and released automatically on exit (even on
-    SIGKILL), so leases never go stale across runs.
-
-    Returns a ``torch.device`` to pass to ``CellposeModel(device=...)``, or ``None``
-    to let Cellpose pick (CPU, single GPU, or CUDA unavailable).
-    """
-    global _LEASED_DEVICE, _LEASE_FH
-    if not gpu or not torch.cuda.is_available():
-        return None
-    visible = torch.cuda.device_count()
-    if visible <= 1:
-        return None
-    if _LEASED_DEVICE is not None:
-        return _LEASED_DEVICE
-    # Prefer the operator-declared count (matches the scheduler's gpu gate),
-    # clamped to the devices actually visible to this process.
-    try:
-        declared = int(os.environ.get("BRIEFLOW_GPU_COUNT", "0"))
-    except ValueError:
-        declared = 0
-    n = min(visible, declared) if declared > 0 else visible
-    # The lock dir MUST be a fixed absolute path shared by every segmentation
-    # job on the node — NOT tempfile.gettempdir(), because snakemake sets a
-    # distinct per-job TMPDIR, which would split workers across different lock
-    # dirs and defeat the lease (jobs then collide on the same GPU and OOM).
-    # /var/tmp is node-local (flock-reliable, unlike NFS) and constant per-job.
-    lock_dir = os.environ.get("BRIEFLOW_GPU_LOCK_DIR") or "/var/tmp/brieflow_gpu_locks"
-    os.makedirs(lock_dir, exist_ok=True)
-    # Block until one of the N GPUs is free: try each slot non-blocking, and if
-    # all are held, sleep and retry. This caps concurrent GPU jobs at N even when
-    # the scheduler launches more — brieflow's flow.sh emits TWO `--resources`
-    # flags (`--resources gpu=N` then `--resources mem_mb=…`), and argparse keeps
-    # only the last, so `gpu=N` is clobbered and never gates gpu jobs. The lease
-    # is therefore the real concurrency limiter. The lock is held by an open fd
-    # for the process lifetime and released automatically on exit (even SIGKILL).
-    while True:
-        for i in range(n):
-            cand = open(os.path.join(lock_dir, f"gpu{i}.lock"), "w")
-            try:
-                fcntl.flock(cand, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
-                cand.close()
-                continue
-            _LEASE_FH = cand
-            _LEASED_DEVICE = torch.device(f"cuda:{i}")
-            return _LEASED_DEVICE
-        # All GPUs busy — wait for one to free (pid-jittered to avoid a herd).
-        time.sleep(0.25 + (os.getpid() % 100) / 200.0)
 
 
 def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
@@ -170,8 +101,7 @@ def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
             f"Upgrade with: uv pip install cellpose==4.0.4 torch==2.7.0 torchvision==0.22.0"
         )
 
-    # Pin this job to one GPU (round-robin by pid) so concurrent segmentation
-    # jobs spread across all visible devices instead of all landing on cuda:0.
+    # Lease one GPU for this process so concurrent segmentation jobs spread across devices
     device = _select_gpu_device(gpu)
 
     # Version-aware initialization
@@ -636,3 +566,95 @@ def segment_cellpose_nuclei_rgb(
 
     # Return the segmented nuclei
     return nuclei
+
+
+DEFAULT_GPU_LOCK_DIR = "/var/tmp/brieflow_gpu_locks"
+
+_LEASE_LOCK = threading.Lock()
+_LEASED_DEVICE = None
+_LEASE_FH = None
+
+
+def _select_gpu_device(gpu: bool):
+    """Lease one CUDA device for this process so concurrent jobs don't collide.
+
+    The segment_sbs/segment_phenotype rules declare ``resources: gpu=1`` and the
+    runner gates concurrency to ``--resources gpu=BRIEFLOW_GPU_COUNT``. Cellpose,
+    however, otherwise places every model on ``cuda:0`` (``assign_device`` default),
+    so all concurrent segmentation jobs pile onto a single device and OOM while the
+    other GPUs sit idle.
+
+    Each cpsam job needs nearly a whole 16 GB card, so statistical spreading
+    (``pid % N``) still OOMs whenever two concurrent jobs hash to the same GPU.
+    Instead, atomically lease a device via a non-blocking ``flock`` over N lock
+    files: with the scheduler gating to N concurrent jobs and N cards, every job
+    gets a distinct GPU and there are zero co-located jobs. The lock is held by an
+    open fd for the process lifetime and released automatically on exit (even on
+    SIGKILL), so leases never go stale across runs.
+
+    The lock directory must be one fixed absolute path shared by every segmentation
+    process on the node, not ``tempfile.gettempdir()``: snakemake gives each job a
+    distinct TMPDIR, which would split workers across lock directories and defeat
+    the lease. ``/var/tmp`` is node-local, so ``flock`` is reliable there in a way
+    it is not on the shared filesystem, and it is stable across jobs and users.
+    An unusable lock directory (for instance one another user created without group
+    write permission) is not fatal: the lease is skipped and Cellpose picks a device
+    as it would without this function.
+
+    The first caller in a process wins the lease and every later caller reuses it,
+    so both Cellpose models in a segmentation job share the one leased device.
+
+    Args:
+        gpu (bool): Whether the caller asked for GPU inference.
+
+    Returns:
+        torch.device | None: The leased device to pass to ``CellposeModel(device=...)``,
+        or None to let Cellpose pick (CPU, a single visible GPU, CUDA unavailable, or
+        no usable lock directory).
+    """
+    global _LEASED_DEVICE, _LEASE_FH
+
+    if not gpu or not torch.cuda.is_available():
+        return None
+    visible = torch.cuda.device_count()
+    if visible <= 1:
+        return None
+
+    with _LEASE_LOCK:
+        if _LEASED_DEVICE is not None:
+            return _LEASED_DEVICE
+
+        # Prefer the operator-declared count, clamped to the devices this process can see
+        try:
+            declared = int(os.environ.get("BRIEFLOW_GPU_COUNT", "0"))
+        except ValueError:
+            declared = 0
+        n = min(visible, declared) if declared > 0 else visible
+
+        lock_dir = os.environ.get("BRIEFLOW_GPU_LOCK_DIR") or DEFAULT_GPU_LOCK_DIR
+        try:
+            os.makedirs(lock_dir, exist_ok=True)
+        except OSError:
+            return None
+
+        # Try each slot without blocking, and if every GPU is held, wait and retry
+        while True:
+            unusable = 0
+            for i in range(n):
+                try:
+                    cand = open(os.path.join(lock_dir, f"gpu{i}.lock"), "w")
+                except OSError:
+                    unusable += 1
+                    continue
+                try:
+                    fcntl.flock(cand, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError:
+                    cand.close()
+                    continue
+                _LEASE_FH = cand
+                _LEASED_DEVICE = torch.device(f"cuda:{i}")
+                return _LEASED_DEVICE
+            if unusable == n:
+                return None
+            # All GPUs busy, so wait for one to free, jittered by pid to avoid a herd
+            time.sleep(0.25 + (os.getpid() % 100) / 200.0)

--- a/workflow/lib/shared/segment_cellpose.py
+++ b/workflow/lib/shared/segment_cellpose.py
@@ -28,10 +28,14 @@ for incompatible model/version combinations.
 
 """
 
+import fcntl
+import os
 import sys
+import time
 
 import numpy as np
 import pandas as pd
+import torch
 
 import cellpose
 from cellpose.models import CellposeModel
@@ -53,6 +57,76 @@ except (AttributeError, ValueError):
     CELLPOSE_VERSION = (3, 0)
 
 CELLPOSE_4X = CELLPOSE_VERSION >= (4, 0)
+
+
+# Per-process GPU lease (cached): both Cellpose models in a segmentation job share
+# the one leased device, and the lock is held for the process lifetime.
+_LEASED_DEVICE = None
+_LEASE_FH = None
+
+
+def _select_gpu_device(gpu: bool):
+    """Lease one CUDA device for this process so concurrent jobs don't collide.
+
+    The segment_sbs/segment_phenotype rules declare ``resources: gpu=1`` and the
+    runner gates concurrency to ``--resources gpu=BRIEFLOW_GPU_COUNT``. Cellpose,
+    however, otherwise places every model on ``cuda:0`` (``assign_device`` default),
+    so all concurrent segmentation jobs pile onto a single device and OOM while the
+    other GPUs sit idle.
+
+    Each cpsam job needs nearly a whole 16 GB card, so statistical spreading
+    (``pid % N``) still OOMs whenever two concurrent jobs hash to the same GPU.
+    Instead, atomically lease a device via a non-blocking ``flock`` over N lock
+    files: with the scheduler gating to N concurrent jobs and N cards, every job
+    gets a distinct GPU and there are zero co-located jobs. The lock is held by an
+    open fd for the process lifetime and released automatically on exit (even on
+    SIGKILL), so leases never go stale across runs.
+
+    Returns a ``torch.device`` to pass to ``CellposeModel(device=...)``, or ``None``
+    to let Cellpose pick (CPU, single GPU, or CUDA unavailable).
+    """
+    global _LEASED_DEVICE, _LEASE_FH
+    if not gpu or not torch.cuda.is_available():
+        return None
+    visible = torch.cuda.device_count()
+    if visible <= 1:
+        return None
+    if _LEASED_DEVICE is not None:
+        return _LEASED_DEVICE
+    # Prefer the operator-declared count (matches the scheduler's gpu gate),
+    # clamped to the devices actually visible to this process.
+    try:
+        declared = int(os.environ.get("BRIEFLOW_GPU_COUNT", "0"))
+    except ValueError:
+        declared = 0
+    n = min(visible, declared) if declared > 0 else visible
+    # The lock dir MUST be a fixed absolute path shared by every segmentation
+    # job on the node — NOT tempfile.gettempdir(), because snakemake sets a
+    # distinct per-job TMPDIR, which would split workers across different lock
+    # dirs and defeat the lease (jobs then collide on the same GPU and OOM).
+    # /var/tmp is node-local (flock-reliable, unlike NFS) and constant per-job.
+    lock_dir = os.environ.get("BRIEFLOW_GPU_LOCK_DIR") or "/var/tmp/brieflow_gpu_locks"
+    os.makedirs(lock_dir, exist_ok=True)
+    # Block until one of the N GPUs is free: try each slot non-blocking, and if
+    # all are held, sleep and retry. This caps concurrent GPU jobs at N even when
+    # the scheduler launches more — brieflow's flow.sh emits TWO `--resources`
+    # flags (`--resources gpu=N` then `--resources mem_mb=…`), and argparse keeps
+    # only the last, so `gpu=N` is clobbered and never gates gpu jobs. The lease
+    # is therefore the real concurrency limiter. The lock is held by an open fd
+    # for the process lifetime and released automatically on exit (even SIGKILL).
+    while True:
+        for i in range(n):
+            cand = open(os.path.join(lock_dir, f"gpu{i}.lock"), "w")
+            try:
+                fcntl.flock(cand, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                cand.close()
+                continue
+            _LEASE_FH = cand
+            _LEASED_DEVICE = torch.device(f"cuda:{i}")
+            return _LEASED_DEVICE
+        # All GPUs busy — wait for one to free (pid-jittered to avoid a herd).
+        time.sleep(0.25 + (os.getpid() % 100) / 200.0)
 
 
 def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
@@ -96,15 +170,19 @@ def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
             f"Upgrade with: uv pip install cellpose==4.0.4 torch==2.7.0 torchvision==0.22.0"
         )
 
+    # Pin this job to one GPU (round-robin by pid) so concurrent segmentation
+    # jobs spread across all visible devices instead of all landing on cuda:0.
+    device = _select_gpu_device(gpu)
+
     # Version-aware initialization
     # Custom model paths use pretrained_model parameter in both versions
     if CELLPOSE_4X:
-        return CellposeModel(pretrained_model=model_type, gpu=gpu)
+        return CellposeModel(pretrained_model=model_type, gpu=gpu, device=device)
     elif is_custom_model:
         # For Cellpose 3.x with custom models, use pretrained_model
-        return CellposeModel(pretrained_model=model_type, gpu=gpu)
+        return CellposeModel(pretrained_model=model_type, gpu=gpu, device=device)
     else:
-        return CellposeModel(model_type=model_type, gpu=gpu)
+        return CellposeModel(model_type=model_type, gpu=gpu, device=device)
 
 
 def segment_cellpose(

--- a/workflow/rules/phenotype.smk
+++ b/workflow/rules/phenotype.smk
@@ -34,6 +34,8 @@ rule segment_phenotype:
         PHENOTYPE_OUTPUTS_MAPPED["segment_phenotype"],
     params:
         config=lambda wildcards: get_segmentation_params("phenotype", config),
+    resources:
+        gpu=1,
     script:
         "../scripts/shared/segment.py"
 

--- a/workflow/rules/sbs.smk
+++ b/workflow/rules/sbs.smk
@@ -118,6 +118,8 @@ rule segment_sbs:
         SBS_OUTPUTS_MAPPED["segment_sbs"],
     params:
         config=lambda wildcards: get_segmentation_params("sbs", config),
+    resources:
+        gpu=1,
     script:
         "../scripts/shared/segment.py"
 


### PR DESCRIPTION
Lands the useful half of the side branch `zarr3-jannu` (from the jannu screen) onto `zarr3`.

## What it does

Concurrent `segment_sbs` / `segment_phenotype` jobs on a multi-GPU node all construct their `CellposeModel` on `cuda:0`, because that is what Cellpose's `assign_device` picks by default. With cellpose-SAM each job wants most of a card, so they OOM against each other while the node's other GPUs sit idle.

`_select_gpu_device` gives each process its own card. It takes a non-blocking `flock` over one of N lock files (`gpu0.lock` … `gpuN-1.lock`) in a fixed node-local directory, and the index of the file it wins becomes the `torch.device` passed to every `CellposeModel(device=...)`. N is `min(torch.cuda.device_count(), BRIEFLOW_GPU_COUNT)`, falling back to the visible device count when that variable is unset; the directory defaults to `/var/tmp/brieflow_gpu_locks` and can be overridden with `BRIEFLOW_GPU_LOCK_DIR`. The lock is held open for the process lifetime, so the lease is released by the kernel when the process ends — including on `SIGKILL` — and the first caller's lease is cached and reused by the second model in the same job.

`resources: gpu=1` on the two segmentation rules is the scheduler-side half, so a run launched with `--resources gpu=N` gates concurrency to the same N the lease hands out.

## Behaviour when there is no GPU

`_select_gpu_device` returns `None` — the Cellpose default — whenever `gpu=False`, CUDA is unavailable, or only one device is visible. Under Slurm with `--gres=gpu:1`, `CUDA_VISIBLE_DEVICES` already narrows the process to one card, so the lease is a no-op there too and only engages when a single process really can see several GPUs. No lock file is created on any of those paths, and the small_test analysis (CPU-only) never touches the lock directory.

## Review of the original commit

Kept as-is: the flock design, the fixed node-local lock directory, the `BRIEFLOW_GPU_COUNT` clamp, and `resources: gpu=1`. Node-local is the right place: `flock` on the shared filesystem is not reliable, and the thing being arbitrated (the node's cards) is node-scoped. It does mean a lease is per-node, which is exactly what Slurm array jobs need — two array tasks that land on different nodes should not see each other's leases.

Lease staleness is a non-issue by construction. The lock lives on an open file descriptor, so the kernel drops it when the process dies however it dies; the zero-byte lock files persist but carry no state. Verified below with `kill -9`.

Changed, in a separate commit (`refactor(segment): house-style the GPU lease helper, make it thread-safe`):

- **Thread-safety bug.** The cached-lease check and assignment were an unguarded check-then-set on two module globals. Two threads in one process could each win a *different* lock file, and the second `_LEASE_FH = cand` would drop the first file object; the garbage collector then closes it and releases a lease that is still in use, so a later process can be handed a card someone is already computing on. Now under a `threading.Lock`.
- **Crash on a shared node.** `os.makedirs` / `open` were unguarded. `/var/tmp/brieflow_gpu_locks` is deliberately shared across users on the node, so whoever creates it first owns it; the next user's `open(..., "w")` raises `PermissionError` straight out of the segmentation job. An unusable lock directory now falls back to "no lease" (Cellpose picks the device), which is a degraded but correct run rather than a crash.
- House style: multi-line `#` blocks folded into single-line comments or moved into the docstring, the private helper moved below the public functions, and the stale `# Pin this job to one GPU (round-robin by pid)` comment corrected — the implementation stopped being pid round-robin when it became a lease.

No behaviour change beyond those two fixes. The `rules/*.smk` edits add only `resources:`, not a param, so nothing needs threading through `get_segmentation_params` and the small_test config builds unchanged.

## Deliberately left out

`zarr3-jannu` also carries `chore(deps): jannu-local env pins for cpsam on cu121 (torch 2.4.1, iohub 0.3.0a7)`, which edits `pyproject.toml` only. Those are environment pins for one screen's driver stack and would pin the whole project to cu121; they stay on the jannu screen and are not part of this PR.

## Verification

Repo-wide `ruff` with the repo's own config:

```
$ ruff format --check .
162 files already formatted
$ ruff check .
All checks passed!
```

Dry-runs from `tests/small_test_analysis`, both modes, DAG builds and the rule counts match:

```
=== TIFF ===   total  348
=== ZARR ===   segment_sbs 6 / segment_phenotype 6 / total 352
```

CPU gate, one Slurm job (partition 20, 16 cpus, 64G), `run_brieflow.sh` then `run_brieflow.sh --zarr`:

```
=== TIFF MODE start Thu 10 Sep 2026 02:09:14 PM EDT on c1b4 ===
=== TIFF MODE done Thu 10 Sep 2026 02:47:26 PM EDT ===
=== ZARR MODE start Thu 10 Sep 2026 02:47:26 PM EDT ===
=== ZARR MODE done Thu 10 Sep 2026 03:22:56 PM EDT ===
GATE_ALL_OK

3783 of 3783 steps (100%) done
3787 of 3787 steps (100%) done

JobID|JobName|State|Elapsed|NodeList
7988142|mdiberna_gpulease_gate|COMPLETED|01:13:48|c1b4
```

### GPU smoke test — not run on real GPUs

The intended job (`nvidia-A6000-20`, `--gres=gpu:2`; the limits page allows 2 GPUs per user on that partition) could not be submitted from the available head node:

```
$ sbatch gpu_smoke.sbatch
sbatch: error: Jobs submitted to this queue may be preempted.  For details, see
sbatch: error: https://clusterguide.wi.mit.edu/using-the-slurm-cluster/#submitting-slurm-gpu-jobs
sbatch: error: invalid partition specified: nvidia-A6000-20
sbatch: error: Batch job submission failed: Invalid partition name specified

$ sinfo -o "%P"
PARTITION
20
u20
```

That controller exposes only the CPU partitions, and the GPU head node needs an interactive login. **The lease has therefore not been exercised against real CUDA devices in this PR** — that is the one gap. The ready-to-run job is preserved at `/lab/ops_analysis_ssd/test_matteo/_gpulease_smoke/gpu_smoke.sbatch`.

What *was* exercised is the leasing mechanism itself, with `torch.cuda.is_available` / `device_count` stubbed and real concurrent processes contending over real `flock` calls:

```
=== phase 1: 4 concurrent processes, 4 fake GPUs ===
  A pid=2597220 -> cuda:0 cached_reuse=True
  B pid=2597221 -> cuda:1 cached_reuse=True
  C pid=2597222 -> cuda:2 cached_reuse=True
  D pid=2597223 -> cuda:3 cached_reuse=True
PHASE1 OK: 4 distinct devices, lease cached within each process
=== phase 2: same 4 slots re-leasable after the holders exited ===
  devices: ['cuda:1', 'cuda:3', 'cuda:2', 'cuda:0']
PHASE2 OK: all 4 leases were released on process exit
=== phase 3: BRIEFLOW_GPU_COUNT=1 clamps to one slot ===
PHASE3 OK: Y waited while X held the single declared slot
=== phase 4: unusable lock dir is a no-op, not a crash ===
PHASE4 OK: fell back to None instead of raising
FAKE_LEASE_ALL_OK
```

and the `SIGKILL` release path:

```
holder pid 2598601 leased: {"tag": "K1", "device": "cuda:0", "cached_same": true}
-- while it holds, a second process must NOT get the slot:
correctly blocked while holder alive
-- SIGKILLed the holder; retrying lease...
{"tag": "K2", "pid": 2598810, "device": "cuda:0", "cached_same": true}
SIGKILL_RELEASE_OK: slot reclaimed after kill -9
```

This covers distinctness, in-process caching, release on clean exit and on `SIGKILL`, the `BRIEFLOW_GPU_COUNT` clamp, and the permission fallback. It does not cover what only a real card can show: that `CellposeModel(device=torch.device("cuda:i"))` actually places the weights on device *i*, and that two cpsam jobs on one node stop OOMing. Worth running before this is relied on for a production screen.

## Open questions

1. **Nothing in this repo sets `BRIEFLOW_GPU_COUNT` or passes `--resources gpu=N`.** The docstring describes a runner that gates on it, but that runner is the jannu screen's local `flow.sh`; the shipped `analysis/flow.sh` emits `--resources mem_mb=…` and no gpu budget. So on the maintained lines `resources: gpu=1` is inert today and the lease alone limits concurrency (to the number of visible cards). Should the analysis-side runner grow a gpu budget, or should the docstring stop describing one?
2. **Array jobs.** A per-node lease is right for one node, but an array whose tasks share a node and whose tasks each requested `--gres=gpu:1` will each see one device and skip the lease entirely — correct, but it means the lease only ever fires for whole-node or multi-GPU allocations. Is that the intended deployment shape?
3. **The wait is unbounded.** If all N slots are held the caller spins forever with no log line. A timeout, or at least a message after some interval, would make a wedged run diagnosable. Left alone here to keep this PR behaviour-preserving.
4. `/var/tmp/brieflow_gpu_locks` is intentionally shared across users so that two users' jobs on one node do not both take `cuda:0`. That only works if the directory is group/world-writable; the fallback above keeps it from being fatal, but the arbitration silently degrades. A mode on creation, or a documented one-time setup, may be worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Z1SYzZJjRrSmDyDCWc4g4
