### PR TITLE
feat(merge): seed RANSAC for reproducible tile alignment

### DIFF
--- a/workflow/lib/merge/hash.py
+++ b/workflow/lib/merge/hash.py
@@ -274,7 +274,8 @@ def evaluate_match(
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
         # Use matching triangles to define transformation
-        model = RANSACRegressor(**(ransac_kwargs or {}))
+        # Seed random_state=0 by default for reproducibility; caller can override via ransac_kwargs.
+        model = RANSACRegressor(**{"random_state": 0, **(ransac_kwargs or {})})
         model.fit(X, Y)  # Fit the RANSAC model to the matching centers
 
     rotation = model.estimator_.coef_  # Extract rotation matrix
@@ -551,9 +552,9 @@ def prioritize(well_locations_0, well_locations_1, matches):
         warnings.filterwarnings("ignore")
         # allow testing with subset of tiles
         if a.shape[0] == a.shape[1]:
-            model = RANSACRegressor(min_samples=1)
+            model = RANSACRegressor(min_samples=1, random_state=0)
         else:
-            model = RANSACRegressor()
+            model = RANSACRegressor(random_state=0)
         model.fit(a, b)  # Fit the RANSAC model to the matching coordinates
 
     # Predict coordinates for the first set and calculate distances to the second set


### PR DESCRIPTION
# feat(merge): seed RANSAC for reproducible tile alignment

## Motivation

`sklearn.linear_model.RANSACRegressor` is a randomized estimator. Left unseeded, its RANSAC sampling draws differently on each run, so brieflow's tile-alignment and merge results are nondeterministic run-to-run. This makes merges near-impossible to reproduce or diff bit-for-bit across pipeline runs, which undermines verification of the merge step.

## What changed

`workflow/lib/merge/hash.py` — all three `RANSACRegressor(...)` construction sites now seed `random_state=0` by default:

1. `evaluate_match` (~L278): `RANSACRegressor(**{"random_state": 0, **(ransac_kwargs or {})})` — seed by default, caller can still override via `ransac_kwargs`.
2. `prioritize` (~L555): `RANSACRegressor(min_samples=1, random_state=0)`
3. `prioritize` (~L557): `RANSACRegressor(random_state=0)`

## Tradeoff

Seeding fixes the RNG to a single deterministic path. This is the intended behavior for reproducible pipelines; any caller that genuinely wants stochastic sampling can override at the `evaluate_match` site through `ransac_kwargs` (e.g. `{"random_state": None}`). The two `prioritize` sites take no kwargs, so their seed is fixed — this is acceptable because `prioritize` is a coarse site-prediction step, and determinism there is the desired property.

## Config wiring already present upstream (investigation finding)

The config knob is already fully wired on `upstream/zarr3`, so no rule/script changes are needed here:

- `workflow/rules/merge.smk` (L53): `ransac_random_state=config.get("merge", {}).get("ransac_random_state")`
- `workflow/scripts/merge/fast_alignment.py` (L122-133): builds `ransac_kwargs = {"random_state": <config value>}` (dropped if `None`) and forwards it via `evaluate_kwargs["ransac_kwargs"]` into `evaluate_match`.

So the config → `snakemake.params` → `ransac_kwargs` → `evaluate_match` path was already in place; the **missing piece was the library default**. Before this change, if `merge.ransac_random_state` was unset in config, `ransac_kwargs` dropped out to empty and `RANSACRegressor()` ran unseeded. This PR makes the default deterministic while preserving the config override.

Note that the config wiring only reaches the `evaluate_match` site. The two `prioritize` sites are not parameterized and were unreachable by the config knob — the in-library default seed is the only way to make them deterministic. Extending config wiring to `prioritize` is possible as a follow-up but was left out to keep this PR minimal.

## Usage — how to override the seed

The default seed (`random_state=0`) needs no configuration — merges are reproducible out of the box. To pin a different seed at the `evaluate_match` site, set it under the `merge` block of your analysis `config.yml`:

```yaml
merge:
  ransac_random_state: 42   # overrides the default 0 at the evaluate_match site
```

To restore the old stochastic behavior, pass `ransac_kwargs={"random_state": None}` when calling `evaluate_match` directly.

## Independence

This PR is independent of and does not depend on:

- The performance PR `perf/zarr3-snakemake` (cheeseman-lab/brieflow#268)  — that branch deliberately excludes RANSAC seeding; this seeding was carved out to stand alone. 
- The illumination-correction (IC) seed PR (cheeseman-lab/brieflow#269) — a separate determinism fix in a different module.