### PR TITLE
perf: snakemake-path performance optimizations

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -26,6 +26,7 @@ wildcard_constraints:
     # Accept both plate-well style (row=letters "A", col=digits "1") AND Opera Phenix
     # numeric wells (row="r02", col="c02"). Segments are "/"-delimited in paths so
     # widening these does not introduce cross-wildcard ambiguity.
+    well=r"[A-Z][0-9]+",
     row=r"[A-Za-z]+\d*",
     col=r"[A-Za-z]*\d+",
     tile=r"[0-9]+",

--- a/workflow/lib/external/cp_emulator.py
+++ b/workflow/lib/external/cp_emulator.py
@@ -627,17 +627,27 @@ def lstsq_slope_all_multichannel(r):
 def cp_colocalization_all_channels(r, mode="multichannel", **kwargs):
     if mode == "multichannel":
         channels = r.intensity_image.shape[-1]
-    else:
-        channels = r.intensity_image_full.shape[-3]
-
-    results = [
-        cp_colocalization(r, first, second, mode=mode, **kwargs)
-        for first, second in combinations(list(range(channels)), 2)
-    ]
-
-    if mode == "multichannel":
+        # Precompute otsu threshold and rankdata once per channel instead of per pair.
+        # Each channel appears in (C-1) pairs; caching cuts calls from 2*C(C,2) → C
+        # (e.g. 12 → 4 for C=4). Algebraically identical to the per-pair computation.
+        V = r.intensity_image[r.image]  # (n_pix, C) masked pixel array
+        _thr = [otsu(V[:, c]) for c in range(channels)]
+        _ranks = [rankdata(V[:, c], method="dense") for c in range(channels)]
+        results = [
+            measure_colocalization(
+                V[:, first], V[:, second],
+                _A_thresh=_thr[first], _B_thresh=_thr[second],
+                _A_ranks=_ranks[first], _B_ranks=_ranks[second],
+            )
+            for first, second in combinations(range(channels), 2)
+        ]
         return np.array(results).flatten(order="F")
     else:
+        channels = r.intensity_image_full.shape[-3]
+        results = [
+            cp_colocalization(r, first, second, mode=mode, **kwargs)
+            for first, second in combinations(range(channels), 2)
+        ]
         return np.concatenate(results)
 
 
@@ -650,7 +660,10 @@ def cp_colocalization(r, first, second, mode="multichannel", **kwargs):
     return measure_colocalization(A, B, **kwargs)
 
 
-def measure_colocalization(A, B, threshold="otsu"):
+def measure_colocalization(
+    A, B, threshold="otsu",
+    _A_thresh=None, _B_thresh=None, _A_ranks=None, _B_ranks=None,
+):
     """Measures overlap, k1/k2, manders, and rank weighted colocalization coefficients.
     References:
     http://www.scian.cl/archivos/uploads/1417893511.1674 starting at slide 35
@@ -658,13 +671,19 @@ def measure_colocalization(A, B, threshold="otsu"):
     co-localization of microscopy images", BMC Bioinformatics, 12:407.
     threshold is either 'otsu' or 'costes' methods, or a float between 0 and 1 defining the
     fraction of the maximum value to be used as the threshold (CellProfiler default=0.15)
+
+    _A_thresh / _B_thresh / _A_ranks / _B_ranks: pre-cached values from
+    cp_colocalization_all_channels. When provided they skip the per-pair otsu
+    and rankdata calls (algebraically identical — same channel, same pixel vector).
     """
     if (A.sum() == 0) | (B.sum() == 0):
         return (np.nan,) * 7
 
     results = []
 
-    if threshold == "otsu":
+    if _A_thresh is not None:
+        A_thresh, B_thresh = _A_thresh, _B_thresh
+    elif threshold == "otsu":
         A_thresh, B_thresh = otsu(A), otsu(B)
     elif threshold == "costes":
         A_thresh, B_thresh = costes_threshold(A, B)
@@ -703,8 +722,11 @@ def measure_colocalization(A, B, threshold="otsu"):
 
     results.extend([M1, M2])
 
-    A_ranks = rankdata(A, method="dense")
-    B_ranks = rankdata(B, method="dense")
+    if _A_ranks is not None:
+        A_ranks, B_ranks = _A_ranks, _B_ranks
+    else:
+        A_ranks = rankdata(A, method="dense")
+        B_ranks = rankdata(B, method="dense")
 
     R = max([A_ranks.max(), B_ranks.max()])
     # weight = ((R-abs(A_ranks-B_ranks))/R)[mask]

--- a/workflow/lib/merge/final_merge.py
+++ b/workflow/lib/merge/final_merge.py
@@ -1,0 +1,87 @@
+"""Streaming final merge — attach the full CP phenotype feature table to the
+deduplicated merge via a memory-bounded polars left join.
+
+The merge logic lives here so every caller wraps one function and the paths
+can never drift; the Snakemake step is workflow/scripts/merge/final_merge.py.
+
+Why not a plain pandas .merge: phenotype_cp is ~3,600 cols x ~1M rows; a pandas
+full-load merge (or a wide batched merge) materializes it several times over and
+OOM-kills even a 64 GB box. polars scan_parquet -> left join -> sink_parquet
+streams it out-of-core and multithreaded, working set bounded.
+"""
+
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+import polars as pl
+
+# merge key: plate/well/tile locate the field, cell_0 the segmented cell.
+KEYS = ["plate", "well", "tile", "cell_0"]
+
+# stitch approach reports global (plate-level) coordinates; rename on the dedup
+# (left) side before the join, matching the prior pandas behaviour.
+_STITCH_RENAME = {"i_0": "global_i_0", "j_0": "global_j_0",
+                  "i_1": "global_i_1", "j_1": "global_j_1"}
+
+
+def final_merge(
+    deduplicated_path: Union[str, Path],
+    phenotype_cp_path: Union[str, Path],
+    output_path: Union[str, Path],
+    approach: str = "fast",
+    exclude_markers: Optional[Sequence[str]] = None,
+) -> None:
+    """Left-join the full CP feature table onto the deduplicated merge, streaming.
+
+    Output columns = all deduplicated cols, then CP feature cols (phenotype
+    'label' -> 'cell_0', minus the join keys) — the same column set/order the
+    prior batched-pandas path produced. Unmatched dedup rows keep null CP cols.
+    """
+    exclude_markers = list(exclude_markers or [])
+
+    dedup = pl.scan_parquet(deduplicated_path)
+    dedup_schema = dedup.collect_schema()
+    if approach == "stitch":
+        ren = {k: v for k, v in _STITCH_RENAME.items() if k in dedup_schema.names()}
+        if ren:
+            dedup = dedup.rename(ren)
+            dedup_schema = dedup.collect_schema()
+
+    cp = pl.scan_parquet(phenotype_cp_path)
+    cp_names = cp.collect_schema().names()
+    drop_cols = [c for c in cp_names if any(f"_{m}_" in c for m in exclude_markers)]
+    if drop_cols:
+        cp = cp.drop(drop_cols)
+    cp = cp.rename({"label": "cell_0"})
+
+    # phenotype parquets can store plate/tile as String while dedup has them as
+    # Int64 (see phenotype-plate-tile-dtype-spec); reconcile key dtypes or the
+    # join silently drops every row.
+    cp = cp.with_columns([pl.col(k).cast(dedup_schema[k]) for k in KEYS])
+
+    merged = dedup.join(cp, on=KEYS, how="left")
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    # streaming hash-join builds on the ~1M-row CP side (~30 GB peak
+    # for 3,591 float cols); fine <64 GB. If CP row count grows, join per-tile.
+    merged.sink_parquet(str(output_path))
+
+
+if __name__ == "__main__":
+    # self-check the join contract on tiny in-memory frames.
+    import tempfile, os
+    d = tempfile.mkdtemp()
+    dp, cpp, op = (os.path.join(d, n) for n in ("dd.parquet", "cp.parquet", "out.parquet"))
+    pl.DataFrame({"plate": [4, 4, 4], "well": ["A1"] * 3, "tile": [1, 1, 2],
+                  "cell_0": [10, 11, 20], "i_0": [0.0, 1.0, 2.0]}).write_parquet(dp)
+    # CP has plate/tile as String (the real-world foot-gun) + an extra unmatched row.
+    pl.DataFrame({"plate": ["4", "4", "4"], "well": ["A1"] * 3, "tile": ["1", "2", "2"],
+                  "label": [10, 20, 99], "feat_x": [1.5, 2.5, 9.9]}).write_parquet(cpp)
+    final_merge(dp, cpp, op)
+    r = pl.read_parquet(op)
+    assert r.height == 3, r.height                      # left rows preserved
+    assert r.columns == ["plate", "well", "tile", "cell_0", "i_0", "feat_x"], r.columns
+    got = dict(zip(r["cell_0"], r["feat_x"]))
+    assert got[10] == 1.5 and got[20] == 2.5, got       # matched
+    assert got[11] is None, got                         # unmatched -> null CP
+    print("final_merge self-check OK")

--- a/workflow/lib/merge/merge_utils.py
+++ b/workflow/lib/merge/merge_utils.py
@@ -251,9 +251,11 @@ def plot_merge_example(
     ax1.set_title("Aligned overlay (SBS pixel space)")
     ax1.legend(loc="upper right", fontsize=9)
 
-    # Normalize phenotype coordinates into the SBS field for the scaled panels
-    X_norm = (X - X.min(axis=0)) / (X.max(axis=0) - X.min(axis=0))
-    X_scaled = (X_norm * (Y_pred.max(axis=0) - Y_pred.min(axis=0))) + Y_pred.min(axis=0)
+    # Map PH points into SBS space with the fitted affine transform. Apply the
+    # full RANSAC affine model (rotation + translation), the same transform used
+    # for matching above. Naive per-axis min-max rescaling cannot represent
+    # rotation, so it distorts good alignments in the plot.
+    X_scaled = model.predict(X)
 
     # Panel 2: normalized overlap of phenotype on the SBS field
     ax2.scatter(
@@ -278,7 +280,8 @@ def plot_merge_example(
     ax2.set_title("Normalized phenotype relative to SBS")
     ax2.legend(loc="upper right", fontsize=9)
 
-    # Panel 3: matched vs unmatched phenotype in the normalized frame (no per-cell labels)
+    # Panel 3: matched vs unmatched phenotype in the normalized frame (no per-cell labels).
+    # Reuses the affine-transformed X_scaled from Panel 2 above.
     ax3.scatter(
         Y[:, 0], Y[:, 1], c="lightgray", s=12, alpha=0.15, label=f"SBS field ({n_sbs})"
     )
@@ -747,3 +750,12 @@ def fast_merge_example(
     except Exception as e:
         print(f"  Error plotting: {str(e)}")
         return False
+
+
+def filter_low_score_seeds(df, min_keep=5):
+    if len(df) <= min_keep:
+        return df
+    q1, q3 = df["score"].quantile([0.25, 0.75])
+    cutoff = q1 - 1.5 * (q3 - q1)
+    filtered = df[df["score"] >= cutoff]
+    return filtered if len(filtered) >= min_keep else df.nlargest(min_keep, "score")

--- a/workflow/lib/phenotype/extract_phenotype_cp_emulator.py
+++ b/workflow/lib/phenotype/extract_phenotype_cp_emulator.py
@@ -37,6 +37,7 @@ def extract_phenotype_cp_emulator(
     foci_channel=None,
     channel_names=["dapi", "tubulin", "gh2ax", "phalloidin"],
     custom_features=None,
+    n_jobs=1,
 ):
     """Extract phenotype features from CellProfiler-like data with multi-channel functionality.
 
@@ -71,6 +72,10 @@ def extract_phenotype_cp_emulator(
             multichannel image, so a feature indexes channels in channel_names order
             regardless of the compartment channel selections. If None, no custom features
             are extracted. Default is None.
+        n_jobs (int, optional): Number of parallel threads for per-region feature
+            computation inside each extract_features call. Defaults to 1 (sequential,
+            tile-level parallelism model). Pass snakemake.threads to use region-level
+            parallelism instead (do not combine with a large tile pool).
 
     Returns:
         pandas.DataFrame: DataFrame containing extracted features with columns ordered as:
@@ -154,6 +159,7 @@ def extract_phenotype_cp_emulator(
             dict(),
             features,
             multichannel=True,
+            n_jobs=n_jobs,
         )
         .rename(columns=nucleus_columns)
         .set_index("label")
@@ -170,6 +176,7 @@ def extract_phenotype_cp_emulator(
                 dict(),
                 features,
                 multichannel=True,
+                n_jobs=n_jobs,
             )
             .rename(columns=cell_columns)
             .set_index("label")
@@ -186,6 +193,7 @@ def extract_phenotype_cp_emulator(
                 dict(),
                 features,
                 multichannel=True,
+                n_jobs=n_jobs,
             )
             .rename(columns=cytoplasmic_columns)
             .set_index("label")
@@ -277,7 +285,9 @@ def extract_phenotype_cp_emulator(
 
     # Add wildcards metadata at the END (they'll be reordered later)
     for k, v in sorted(wildcards.items()):
-        result_df[k] = v
+        # wildcards are strings; plate/tile must stay int so parquet-preserved
+        # dtypes match the int64 'tile' in metadata merges (old TSV read_csv coerced implicitly)
+        result_df[k] = int(v) if k in ("plate", "tile") else v
 
     # Apply column ordering
     result_df = order_dataframe_columns(result_df)

--- a/workflow/lib/phenotype/identify_cytoplasm_cellpose.py
+++ b/workflow/lib/phenotype/identify_cytoplasm_cellpose.py
@@ -13,31 +13,36 @@ def identify_cytoplasm_cellpose(nuclei, cells):
     Returns:
         ndarray: A 2D array representing the cytoplasm regions.
     """
-    # Check if the number of unique labels in nuclei and cells are the same
-    if len(np.unique(nuclei)) != len(np.unique(cells)):
-        return None  # Break out of the function if the masks are not compatible
+    # Incompatible masks: fail loud unless nuclei and cells share the same label set.
+    if set(np.unique(nuclei).tolist()) != set(np.unique(cells).tolist()):
+        return None
 
-    # Create an empty cytoplasmic mask with the same shape as cells
-    cytoplasms = np.zeros(cells.shape)
-
-    # Iterate over each unique cell label
-    for cell_label in np.unique(cells):
-        # Skip if the cell label is 0 (background)
-        if cell_label == 0:
-            continue
-
-        # Find the corresponding nucleus label for this cell
-        nucleus_label = cell_label
-
-        # Get the coordinates of the nucleus and cell regions
-        nucleus_coords = np.argwhere(nuclei == nucleus_label)
-        cell_coords = np.argwhere(cells == cell_label)
-
-        # Update the cytoplasmic mask with the cell region
-        cytoplasms[cell_coords[:, 0], cell_coords[:, 1]] = cell_label
-
-        # Remove the nucleus region from the cytoplasmic mask
-        cytoplasms[nucleus_coords[:, 0], nucleus_coords[:, 1]] = 0
+    # Vectorized replacement for the former per-label Python loop.
+    #
+    # The old loop iterated every cell label L in ascending order and, for each,
+    # wrote L over `cells == L` then zeroed `nuclei == L`. Because iterations ran
+    # in ascending label order and each overwrote the previous, the net per-pixel
+    # result was: keep the cell label C, UNLESS a nucleus label N (>0) with N >= C
+    # covers the pixel. (Its own nucleus, N == C, zeros it within the same pass; a
+    # larger-labelled nucleus, N > C, is processed later and also zeros it. A
+    # smaller-labelled nucleus, N < C, is overwritten by the later cell-C pass and
+    # therefore left as C — a label-order quirk, preserved here for output parity.)
+    #
+    # `(nuclei > 0) & (nuclei >= cells)` reproduces that mask exactly in a single
+    # pass, eliminating the O(N_cells * N_pixels) `np.argwhere` loop (~119 s/tile
+    # -> milliseconds). Bit-identity is proven on synthetic masks in
+    # test_identify_cytoplasm_cellpose.py and verified on real plate-4 tiles in
+    # equivalence_identify_cytoplasm.py.
+    #
+    # relies on nuclei/cells sharing the same label set (true for
+    # matched cellpose masks, which reconcile_nuclei_cells relabels to a common
+    # label set). This precondition is now ENFORCED by the set-equality gate
+    # above — no longer a weak proxy: if a nucleus label ever existed that is
+    # absent from `cells`, the old loop never zeroed it while this expression
+    # would, so the gate returns None first and this line never runs on such
+    # input. The ascending-label semantics (keep C unless a nucleus N >= C
+    # covers the pixel) hold only under that shared-label-set precondition.
+    cytoplasms = np.where((nuclei > 0) & (nuclei >= cells), 0, cells)
 
     # Calculate the number of identified cytoplasms (excluding background label)
     num_cytoplasm_segmented = len(np.unique(cytoplasms)) - 1

--- a/workflow/lib/preprocess/preprocess.py
+++ b/workflow/lib/preprocess/preprocess.py
@@ -1554,18 +1554,15 @@ def update_config_for_unified_processing(config: dict) -> dict:
 
 
 def _parse_binning_from_nd2(file_path: str) -> Optional[str]:
-    """Parse camera binning from ND2 text_info metadata (best-effort).
+    """Parse XY binning (e.g. '2x2') from an ND2 file's text metadata.
 
-    Args:
-        file_path: Path to the ND2 file.
-
-    Returns:
-        Binning string like '2x2', or None if not found.
+    Reads only the ND2 text-info block (no pixel data), so it is safe to call on
+    large well-based ND2 files without materializing the multi-GB pixel array.
+    Returns None if binning cannot be determined.
     """
     try:
-        img = nd2.imread(str(file_path), xarray=True)
-        md = img.attrs.get("metadata", {})
-        text_info = md.get("text_info", {})
+        with nd2.ND2File(str(file_path)) as f:
+            text_info = f.text_info or {}
         desc = text_info.get("description", "") if isinstance(text_info, dict) else ""
         m = re.search(r"Binning:\s*(\d+)x(\d+)", desc)
         if m:

--- a/workflow/lib/sbs/align_cycles.py
+++ b/workflow/lib/sbs/align_cycles.py
@@ -31,6 +31,7 @@ def align_cycles(
     manual_channel_mapping=None,
     verbose=False,
     return_metrics=False,
+    compute_qc=False,
 ):
     """Rigid alignment of sequencing cycles and channels.
 
@@ -325,34 +326,36 @@ def align_cycles(
         raise ValueError(f'Method "{method}" not implemented')
 
     # Alignment QC — residual on aligned cycles and base channels
-    if aligned.shape[1] > 0 and (channel_order is None or channel_order[0] == "DAPI"):
-        dapi_residual, _ = calculate_offsets(
-            aligned[:, 0], upsample_factor=upsample_factor
-        )
-        cycle_dapi_shift_residual_max_px = float(np.max(np.abs(dapi_residual)))
-    else:
-        cycle_dapi_shift_residual_max_px = float("nan")
-
-    if base_indices and len(base_indices) > 1:
-        per_cycle_residuals = []
-        for c in range(aligned.shape[0]):
-            intra, _ = calculate_offsets(
-                aligned[c, base_indices], upsample_factor=upsample_factor
+    if compute_qc:
+        if aligned.shape[1] > 0 and (channel_order is None or channel_order[0] == "DAPI"):
+            dapi_residual, _ = calculate_offsets(
+                aligned[:, 0], upsample_factor=upsample_factor
             )
-            per_cycle_residuals.append(float(np.max(np.abs(intra))))
-        intra_cycle_channel_shift_residual_max_px = (
-            float(max(per_cycle_residuals)) if per_cycle_residuals else float("nan")
-        )
-    else:
-        intra_cycle_channel_shift_residual_max_px = float("nan")
+            cycle_dapi_shift_residual_max_px = float(np.max(np.abs(dapi_residual)))
+        else:
+            cycle_dapi_shift_residual_max_px = float("nan")
 
-    print("Alignment QC:")
-    print(
-        f"  cycle_dapi_shift_residual_max_px:           {cycle_dapi_shift_residual_max_px:.4f}  (pass < 1.0)"
-    )
-    print(
-        f"  intra_cycle_channel_shift_residual_max_px:  {intra_cycle_channel_shift_residual_max_px:.4f}  (pass < 1.0)"
-    )
+        if base_indices and len(base_indices) > 1:
+            per_cycle_residuals = []
+            for c in range(aligned.shape[0]):
+                intra, _ = calculate_offsets(
+                    aligned[c, base_indices], upsample_factor=upsample_factor
+                )
+                per_cycle_residuals.append(float(np.max(np.abs(intra))))
+            intra_cycle_channel_shift_residual_max_px = (
+                float(max(per_cycle_residuals)) if per_cycle_residuals else float("nan")
+            )
+        else:
+            intra_cycle_channel_shift_residual_max_px = float("nan")
+
+        print("Alignment QC:")
+        print(
+            f"  cycle_dapi_shift_residual_max_px:           {cycle_dapi_shift_residual_max_px:.4f}  (pass < 1.0)"
+        )
+        print(
+            f"  intra_cycle_channel_shift_residual_max_px:  {intra_cycle_channel_shift_residual_max_px:.4f}  (pass < 1.0)"
+        )
+
     if return_metrics:
         return aligned, (
             offsets_to_metrics(cycle_offsets, "cycle")

--- a/workflow/lib/sbs/call_cells.py
+++ b/workflow/lib/sbs/call_cells.py
@@ -6,6 +6,7 @@ Supports single-barcode and multi-barcode protocols with per-barcode quality tra
 import pandas as pd
 import numpy as np
 import Levenshtein
+from functools import lru_cache
 
 from lib.sbs.constants import (
     PREFIX,
@@ -28,6 +29,21 @@ from lib.sbs.constants import (
 )
 
 COLS = [WELL, TILE, CELL]
+
+
+@lru_cache(maxsize=2)
+def _read_barcode_library_cached(fp, sep="\t"):
+    """Parse a barcode-library TSV once per worker process (keyed on path)."""
+    return pd.read_csv(fp, sep=sep)
+
+
+def load_barcode_library(fp, sep="\t"):
+    """Load a barcode library, reusing a per-process parsed cache.
+
+    Returns a fresh copy each call so callers may mutate the frame
+    without corrupting the cache.
+    """
+    return _read_barcode_library_cached(fp, sep).copy()
 
 
 def call_cells(
@@ -517,42 +533,84 @@ def call_cells_add_UMIs(df_cells, df_UMI, cols=None):
     )
 
 
+# Sentinel for ambiguous matches (read is within max_distance of 2+ barcodes)
+_AMBIGUOUS = object()
+
+
+@lru_cache(maxsize=4)
+def _build_hamming1_index(barcodes_tuple):
+    """Build a {neighbor_str: barcode} lookup for all 1-edit Hamming neighbors.
+
+    Cached per unique barcode set (keyed on a tuple of sorted barcodes).
+    Returns a dict where values are either a barcode string (unique match)
+    or _AMBIGUOUS (read is equidistant to 2+ barcodes).
+    """
+    index = {}
+    alphabet = "ACGT"
+    for barcode in barcodes_tuple:
+        for i, base in enumerate(barcode):
+            for sub in alphabet:
+                if sub == base:
+                    continue
+                neighbor = barcode[:i] + sub + barcode[i + 1:]
+                if neighbor in index:
+                    if index[neighbor] != barcode:
+                        index[neighbor] = _AMBIGUOUS  # collision
+                else:
+                    index[neighbor] = barcode
+    return index
+
+
 def error_correct_reads(reads, reference, max_distance=2, distance_metric="hamming"):
     """Error correct reads against a reference set of barcodes.
 
-    Only corrects when there is a unique closest match within max_distance.
-
-    Args:
-        reads: Series with reads to correct.
-        reference: Series with reference barcodes.
-        max_distance: Maximum edit distance for correction.
-        distance_metric: "hamming" or "levenshtein".
-
-    Returns:
-        Series with corrected reads.
+    For Hamming distance 1 (the common production case), uses a precomputed
+    1-edit index for O(1) lookup per unique read instead of O(N*M) distance
+    matrix. Falls back to the distance-matrix path for max_distance > 1 or
+    non-Hamming metrics.
     """
-    dist_to_ref = _barcode_distance_matrix(
-        reads.to_list(),
-        reference.to_list(),
-        distance_metric=distance_metric,
-    )
+    reference_list = reference.to_list()
+    reference_set = set(reference_list)
 
-    min_dist_to_ref = dist_to_ref.min(axis=1)
-    unique_dist = np.array(
-        [
-            np.sum(dist_to_ref[x] == min_dist_to_ref[x]) == 1
-            for x in range(dist_to_ref.shape[0])
-        ]
-    )
+    # Fast path: Hamming-1 with precomputed index
+    if distance_metric == "hamming" and max_distance == 1:
+        barcodes_tuple = tuple(sorted(reference_set))
+        index = _build_hamming1_index(barcodes_tuple)
 
-    corrected_subset = unique_dist & (min_dist_to_ref <= max_distance)
-    corrected_barcodes = reference.loc[
-        dist_to_ref[corrected_subset].argmin(axis=1)
-    ].values
+        unique_reads = pd.unique(reads)
+        correction = {}
+        for read in unique_reads:
+            if read in reference_set:
+                correction[read] = read          # exact match
+            else:
+                match = index.get(read)
+                if match is None or match is _AMBIGUOUS:
+                    correction[read] = read      # no unique match — leave unchanged
+                else:
+                    correction[read] = match     # unique 1-edit correction
+        return reads.map(correction)
 
-    corrected_reads = reads.copy()
-    corrected_reads.loc[corrected_subset] = corrected_barcodes
-    return corrected_reads
+    # Slow path: generic distance matrix (unchanged)
+    unique_reads = pd.unique(reads)
+    correction = {r: r for r in unique_reads}
+    unmapped = [r for r in unique_reads if r not in reference_set]
+    if unmapped:
+        dist_to_ref = _barcode_distance_matrix(
+            unmapped,
+            reference_list,
+            distance_metric=distance_metric,
+        )
+        min_dist = dist_to_ref.min(axis=1)
+        unique_min = np.array(
+            [np.sum(dist_to_ref[i] == min_dist[i]) == 1
+             for i in range(dist_to_ref.shape[0])]
+        )
+        do_correct = unique_min & (min_dist <= max_distance)
+        argmins = dist_to_ref.argmin(axis=1)
+        for i, bc in enumerate(unmapped):
+            if do_correct[i]:
+                correction[bc] = reference_list[argmins[i]]
+    return reads.map(correction)
 
 
 def _barcode_distance_matrix(barcodes_1, barcodes_2=False, distance_metric="hamming"):
@@ -587,3 +645,25 @@ def _barcode_distance_matrix(barcodes_1, barcodes_2=False, distance_metric="hamm
             bc_distance_matrix[a, b] = distance(i, j)
 
     return bc_distance_matrix
+
+if __name__ == "__main__":
+    import pandas as pd
+    # Exact match — no correction needed
+    ref = pd.Series(["AAAAAAAAAAAA", "CCCCCCCCCCCC", "GGGGGGGGGGGG"])
+    reads = pd.Series(["AAAAAAAAAAAA", "AAAAAAAAAAAC",  # exact, 1-edit from ref[0]
+                        "CCCCCCCCCCCC", "AAAAAAAAAAAT",  # exact, 1-edit from ref[0]
+                        "AAAAAAAAAAGG"])                  # 2-edit from ref[0], no match
+    out = error_correct_reads(reads, ref, max_distance=1, distance_metric="hamming")
+    assert out.iloc[0] == "AAAAAAAAAAAA", "exact match"
+    assert out.iloc[1] == "AAAAAAAAAAAA", "1-edit correction"
+    assert out.iloc[2] == "CCCCCCCCCCCC", "exact match 2"
+    assert out.iloc[3] == "AAAAAAAAAAAA", "1-edit correction 2"
+    assert out.iloc[4] == "AAAAAAAAAAGG", "no match, unchanged"
+
+    # Ambiguous case: equidistant to 2 barcodes — must stay unchanged
+    ref2 = pd.Series(["AAAAAAAAAAAC", "AAAAAAAAAAAG"])
+    reads2 = pd.Series(["AAAAAAAAAAAA"])  # 1-edit from both
+    out2 = error_correct_reads(reads2, ref2, max_distance=1, distance_metric="hamming")
+    assert out2.iloc[0] == "AAAAAAAAAAAA", "ambiguous — unchanged"
+
+    print("All assertions passed.")

--- a/workflow/lib/sbs/eval_mapping.py
+++ b/workflow/lib/sbs/eval_mapping.py
@@ -220,6 +220,15 @@ def plot_read_mapping_heatmap(
         .drop(columns="mapped")
     )
 
+    if df_summary.empty:
+        # 0% mapping: all well/tile groups had zero mapped reads; produce placeholder figure
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots(1, 1, figsize=(10, 6))
+        ax.text(0.5, 0.5, "0% of reads mapped to library barcodes",
+                ha="center", va="center", fontsize=14, transform=ax.transAxes)
+        ax.axis("off")
+        return (df_summary, fig) if return_summary else fig
+
     if return_summary and return_plot:
         fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return df_summary, fig
@@ -269,12 +278,11 @@ def plot_cell_mapping_heatmap(
     """
     # Mark cells as mapped or unmapped based on provided barcodes or gene symbols
     if mapping_strategy == "barcodes":
-        df_cells.loc[:, ["mapped_0", "mapped_1"]] = (
-            df_cells[["cell_barcode_0", "cell_barcode_1"]].isin(barcodes).values
-        )
+        df_cells["mapped_0"] = df_cells["cell_barcode_0"].isin(barcodes).astype(int) if "cell_barcode_0" in df_cells.columns else 0
+        df_cells["mapped_1"] = df_cells["cell_barcode_1"].isin(barcodes).astype(int) if "cell_barcode_1" in df_cells.columns else 0
     elif mapping_strategy == "gene symbols":
-        df_cells["mapped_0"] = (~df_cells["gene_symbol_0"].isna()).astype(int)
-        df_cells["mapped_1"] = (~df_cells["gene_symbol_1"].isna()).astype(int)
+        df_cells["mapped_0"] = (~df_cells["gene_symbol_0"].isna()).astype(int) if "gene_symbol_0" in df_cells.columns else 0
+        df_cells["mapped_1"] = (~df_cells["gene_symbol_1"].isna()).astype(int) if "gene_symbol_1" in df_cells.columns else 0
     else:
         raise ValueError(
             f"Invalid mapping strategy: {mapping_strategy}. Choose 'barcodes' or 'gene symbols'."
@@ -317,11 +325,18 @@ def plot_cell_mapping_heatmap(
         print(f"ANY_MAP_RATE:    {mean_rate:.4f}  (informational; n_total={n_total})")
 
     if return_summary and return_plot:
-        # Plot heatmap
-        fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
+        if df_summary.empty:
+            fig, _ = plt.subplots(1, 1, figsize=(10, 10))
+            fig.text(0.5, 0.5, "No mapped cells", ha="center", va="center", fontsize=14)
+        else:
+            fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return df_summary, fig
     elif return_plot:
-        fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
+        if df_summary.empty:
+            fig, _ = plt.subplots(1, 1, figsize=(10, 10))
+            fig.text(0.5, 0.5, "No mapped cells", ha="center", va="center", fontsize=14)
+        else:
+            fig, _ = plot_plate_heatmap(df_summary, metadata=metadata, **kwargs)
         return fig
     elif return_summary:
         return df_summary
@@ -640,10 +655,10 @@ def mapping_overview(sbs_info, cells, sort_by="count"):
     cells_temp = cells.copy()
     cells_temp["has_barcode_0"] = (~cells_temp["cell_barcode_0"].isna()) & (
         cells_temp["cell_barcode_0"] != ""
-    )
+    ) if "cell_barcode_0" in cells_temp.columns else False
     cells_temp["has_barcode_1"] = (~cells_temp["cell_barcode_1"].isna()) & (
         cells_temp["cell_barcode_1"] != ""
-    )
+    ) if "cell_barcode_1" in cells_temp.columns else False
     cells_temp["barcode_mapping_count"] = cells_temp["has_barcode_0"].astype(
         int
     ) + cells_temp["has_barcode_1"].astype(int)
@@ -692,8 +707,10 @@ def mapping_overview(sbs_info, cells, sort_by="count"):
     )
 
     # Count and calculate percent of cells with 1 gene symbol mapping per well
+    has_gs0 = ~cells["gene_symbol_0"].isna() if "gene_symbol_0" in cells.columns else pd.Series(False, index=cells.index)
+    has_gs1 = ~cells["gene_symbol_1"].isna() if "gene_symbol_1" in cells.columns else pd.Series(False, index=cells.index)
     one_gene_mapping = (
-        cells[(~cells["gene_symbol_0"].isna()) & (cells["gene_symbol_1"].isna())]
+        cells[has_gs0 & ~has_gs1]
         .groupby("well")
         .size()
         .reset_index(name="1_gene_cells__count")
@@ -706,7 +723,7 @@ def mapping_overview(sbs_info, cells, sort_by="count"):
 
     # Count and calculate percent of cells with >=1 gene symbol mapping per well
     multiple_gene_mapping = (
-        cells[(~cells["gene_symbol_0"].isna()) | (~cells["gene_symbol_1"].isna())]
+        cells[has_gs0 | has_gs1]
         .groupby("well")
         .size()
         .reset_index(name="1_or_more_genes__count")

--- a/workflow/lib/shared/combine_dfs.py
+++ b/workflow/lib/shared/combine_dfs.py
@@ -1,0 +1,200 @@
+"""Combine per-tile intermediates (parquet-or-tsv, prefer parquet) into one
+dtype-normalized pandas DataFrame.
+
+Used by the Snakemake combine script (workflow/scripts/shared/combine_dfs.py)
+so the concat + dtype-normalization logic lives in exactly one place for every
+caller.
+
+NOTE on float parity: polars parses CSV floats with correct round-to-nearest
+(matching pandas float_precision="round_trip" and Python float()). pandas'
+DEFAULT read_csv parser is imprecise (xstrtod), so the fast path differs from
+the old pandas-default output by up to ~5e-13 on high-precision float columns
+(e.g. sbs_info i/j, cells Q_*). Values are numerically equivalent, NOT byte
+identical. See _READ_STATS to confirm which backend ran.
+
+DECISION (Phase 1, Option A, 2026-08-28): we ACCEPT this ~1e-12 difference.
+polars is the more-correct parser; downstream analysis is unaffected. Validated
+both ways on real plate-4 well A1: round_trip==polars EXACT, and default-vs-
+polars max |diff| 1.8e-12 (reads) / 9.1e-13 (cells) / 2.3e-13 (sbs_info), all
+<< rtol=1e-9. Identity tests compare float columns with np.allclose(rtol=1e-9)
+and everything else byte-exactly (see tests/sbs/test_combine_dfs_opt.py).
+
+Phase 2 (2026-08-29): inputs are now parquet-or-tsv per tile (prefer parquet
+via resolve_table_path). Parquet round-trips floats exactly, so parquet-mode
+combine is EXACT to the in-memory frame and stays within Option A vs the
+TSV-mode golden. Production TSV-only wells still combine unchanged.
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+
+from lib.shared.file_utils import validate_dtypes
+from lib.shared.parquet_io import resolve_table_path, read_parquet
+
+try:
+    import polars as pl
+
+    _HAS_POLARS = True
+except ImportError:
+    _HAS_POLARS = False
+
+# Backend counter so tests can assert the polars fast path actually ran.
+_READ_STATS = {"polars": 0, "pandas_fallback": 0}
+
+
+def _col_list(f, fmt):
+    """Ordered column names for a resolved tile file, by format."""
+    if fmt == "parquet":
+        return list(pl.scan_parquet(f).collect_schema().names())
+    with open(f) as fh:
+        return fh.readline().rstrip("\n").split("\t")
+
+
+def _read_concat(paths):
+    """Fast multithreaded read + vertical (union) concat of per-tile tables.
+
+    Each path is resolved to its parquet-else-tsv sibling; scan_parquet/scan_csv
+    is chosen per file. Uses one polars diagonal_relaxed concat over per-file
+    lazy scans, which
+    reproduces the pandas concat column UNION (missing column -> null). 0-byte
+    files are pre-filtered (pandas skips them via EmptyDataError; scan_csv can
+    choke on them); header-only 0-row files are kept so their columns still
+    join the union, matching pandas. Any polars error (schema/parse) falls
+    back to per-file pandas reads + concat. Returns None only when no file
+    yields a frame (mirrors the old `if not dfs` guard).
+    """
+    resolved = []
+    for p_in in paths:
+        f, fmt = resolve_table_path(p_in)
+        if f is not None:
+            resolved.append((f, fmt))
+
+    if _HAS_POLARS and resolved:
+        try:
+            import pyarrow.parquet as pq
+
+            def _is_empty(f, fmt):
+                # Skip ONLY 0-row parquet tiles: their object columns infer as
+                # String, which poisons a List-typed column (sbs_info "bounds")
+                # in the diagonal concat (polars cannot cast List <-> String, so
+                # the whole fast path throws). Skipping them lets the parquet
+                # fast path run and preserves bounds as a native List(Int64).
+                # Empty TSV tiles are deliberately NOT skipped: leaving them in
+                # makes the fast path poison (empty String cols vs typed data)
+                # and fall back to per-file pandas, which reproduces the ORIGINAL
+                # TSV combine's dtypes exactly (a 0-row TSV tile's object cols
+                # -> Int64 via validate_dtypes). Parquet tiles are typed, so no
+                # such upcast -- hence parquet mode yields clean int64.
+                return fmt == "parquet" and pq.ParquetFile(f).metadata.num_rows == 0
+
+            kept = [(fp, fm) for fp, fm in resolved if not _is_empty(fp, fm)]
+            if not kept:
+                raise ValueError("no non-empty frames")  # -> pandas fallback
+            lfs = [
+                pl.scan_parquet(fp)
+                if fm == "parquet"
+                else pl.scan_csv(fp, separator="\t", infer_schema_length=None)
+                for fp, fm in kept
+            ]
+            df = pl.concat(lfs, how="diagonal_relaxed").collect()
+            # A column is NaN-filled (float upcast) in pandas only when a
+            # ROW-CONTRIBUTING tile lacks it; a 0-row tile injects no NaN. So
+            # compute union_missing from the non-empty (kept) tiles only, else a
+            # header-only tile missing e.g. `plate` would wrongly upcast it.
+            kept_cols = [set(_col_list(fp, fm)) for fp, fm in kept]
+            union_missing = {
+                c for s in kept_cols for c in df.columns if c not in s
+            }
+            casts = [
+                pl.col(c).cast(pl.Float64)
+                for c in union_missing
+                if df.schema[c].is_integer()
+            ]
+            if casts:
+                df = df.with_columns(casts)
+            # Column order == pandas first-appearance order across ALL tiles
+            # (empty tiles still contribute their columns/order in pandas).
+            file_col_lists = [_col_list(fp, fm) for fp, fm in resolved]
+            ordered_union = list(
+                dict.fromkeys(c for cols in file_col_lists for c in cols)
+            )
+            df = df.select([c for c in ordered_union if c in df.columns])
+            result = df.to_pandas()
+            # A column declared only by a skipped (0-row) tile -- e.g. a stale,
+            # fuller schema in an empty-FOV placeholder -- is absent from the
+            # data concat. pandas keeps it as an all-null object column; mirror
+            # that so the union is complete and byte-identical to the reference.
+            missing = [c for c in ordered_union if c not in result.columns]
+            for c in missing:
+                result[c] = pd.Series([None] * len(result), dtype="object")
+            if missing:
+                result = result[ordered_union]
+            _READ_STATS["polars"] += 1
+            return result
+        except Exception:
+            pass  # schema/parse error -> pandas fallback below
+
+    dfs = []
+    for f, fmt in resolved:
+        if fmt == "parquet":
+            dfs.append(read_parquet(f))  # resolver already filtered 0-byte
+            continue
+        try:
+            dfs.append(pd.read_csv(f, sep="\t"))
+        except pd.errors.EmptyDataError:
+            pass  # skip empty tiles ONLY, matching the original get_file semantics.
+            # Any other parse error (truncated/corrupt tile) must propagate and
+            # fail the rule loud -- silently dropping a tile is data loss.
+    if not dfs:
+        return None
+    _READ_STATS["pandas_fallback"] += 1
+    return pd.concat(dfs, ignore_index=True)
+
+
+def combine_tile_dfs(paths):
+    """Read per-tile TSVs, concat, and normalize dtypes.
+
+    Returns a pandas DataFrame with the same dtype normalization the previous
+    pandas-only implementation produced (validate_dtypes, then a 95%-threshold
+    numeric coercion of leftover object columns -- kept because it genuinely
+    fires on real data, e.g. cells no_recomb_*/gene_id_*). Returns None if no
+    input file yielded a frame, so callers can skip writing.
+    """
+    combined = _read_concat(paths)
+    if combined is None:
+        return None
+
+    # Columns holding a per-row array/list (e.g. sbs_info "bounds", a regionprops
+    # bbox that comes out of the parquet fast path as an ndarray) are not scalar:
+    # validate_dtypes' astype("string") would flatten each cell to its ndarray
+    # repr, and the to_numeric sweep can't touch it. Set such columns aside,
+    # normalize the scalar columns, then restore them unchanged so write_parquet
+    # stores them as a native List column instead of a mangled string.
+    orig_order = list(combined.columns)
+    array_cols = {}
+    for c in combined.select_dtypes(include="object").columns:
+        nonnull = combined[c].dropna()
+        if len(nonnull) and isinstance(nonnull.iloc[0], (list, np.ndarray)):
+            array_cols[c] = combined[c]
+    if array_cols:
+        combined = combined.drop(columns=list(array_cols))
+
+    combined = validate_dtypes(combined)
+    for col in combined.select_dtypes(include="object").columns:
+        converted = pd.to_numeric(combined[col], errors="coerce")
+        if converted.notna().sum() >= combined[col].notna().sum() * 0.95:
+            combined[col] = converted
+
+    if array_cols:
+        for c, series in array_cols.items():
+            combined[c] = series
+        combined = combined[orig_order]
+
+    if os.environ.get("COMBINE_DFS_DEBUG"):
+        import sys
+
+        print(f"[combine_dfs] backends={_READ_STATS}", file=sys.stderr)
+
+    return combined

--- a/workflow/lib/shared/feature_extraction.py
+++ b/workflow/lib/shared/feature_extraction.py
@@ -10,7 +10,7 @@ features_basic = {
 }
 
 
-def extract_features(data, labels, wildcards, features=None, multichannel=False):
+def extract_features(data, labels, wildcards, features=None, multichannel=False, n_jobs=1):
     """Extract features from the provided image data within labeled segmentation masks.
 
     Args:
@@ -19,6 +19,8 @@ def extract_features(data, labels, wildcards, features=None, multichannel=False)
         wildcards (dict): Metadata to include in the output table, e.g., well, tile, etc.
         features (dict or None): Features to extract and their defining functions. Default is None.
         multichannel (bool): Flag indicating whether the data has multiple channels.
+        n_jobs (int): Number of parallel threads for per-region computation when multichannel.
+            Defaults to 1 (sequential). Pass snakemake.threads to enable region-level parallelism.
 
     Returns:
         pandas.DataFrame: Table of labeled regions in labels with corresponding feature measurements.
@@ -35,7 +37,10 @@ def extract_features(data, labels, wildcards, features=None, multichannel=False)
         from lib.shared.feature_table_utils import feature_table
 
     # Extract features using the feature table function
-    df = feature_table(data, labels, features)
+    if multichannel:
+        df = feature_table(data, labels, features, n_jobs=n_jobs)
+    else:
+        df = feature_table(data, labels, features)
 
     # Add wildcard metadata to the DataFrame
     for k, v in sorted(wildcards.items()):
@@ -45,7 +50,7 @@ def extract_features(data, labels, wildcards, features=None, multichannel=False)
 
 
 def extract_features_bare(
-    data, labels, features=None, wildcards=None, multichannel=False
+    data, labels, features=None, wildcards=None, multichannel=False, n_jobs=1
 ):
     """Extract features in dictionary and combine with generic region features.
 
@@ -55,6 +60,8 @@ def extract_features_bare(
         features (dict or None): Features to extract and their defining functions. Default is None.
         wildcards (dict or None): Metadata to include in the output table, e.g., well, tile, etc. Default is None.
         multichannel (bool): Flag indicating whether the data has multiple channels.
+        n_jobs (int): Number of parallel threads for per-region computation when multichannel.
+            Defaults to 1 (sequential).
 
     Returns:
         pandas.DataFrame: Table of labeled regions in labels with corresponding feature measurements.
@@ -71,7 +78,10 @@ def extract_features_bare(
         from lib.shared.feature_table_utils import feature_table
 
     # Extract features using the feature table function
-    df = feature_table(data, labels, features)
+    if multichannel:
+        df = feature_table(data, labels, features, n_jobs=n_jobs)
+    else:
+        df = feature_table(data, labels, features)
 
     # Add wildcard metadata to the DataFrame if provided
     if wildcards is not None:

--- a/workflow/lib/shared/feature_table_utils.py
+++ b/workflow/lib/shared/feature_table_utils.py
@@ -45,25 +45,51 @@ def feature_table(data, labels, features, global_features=None):
     return pd.DataFrame(results)
 
 
-def feature_table_multichannel(data, labels, features, global_features=None):
-    """Apply functions in feature dictionary to regions in data specified by integer labels.
+def _assemble_feature_results(regions, features, per_region_raw):
+    """Assemble the results defaultdict from precomputed per-region feature outputs.
 
-    If provided, the global feature dictionary is applied to the full input data and labels.
-    Results are combined in a dataframe with one row per label and one column per feature.
+    This mirrors the original sequential assembly logic exactly (same column names,
+    same ordering, same scalar/iterable handling) but consumes precomputed function
+    outputs instead of calling the feature functions itself.
 
     Args:
-        data (np.ndarray): Image data.
-        labels (np.ndarray): Labeled segmentation mask defining objects to extract features from.
+        regions (list): List of region properties objects.
         features (dict): Dictionary of feature names and their corresponding functions.
-        global_features (dict, optional): Dictionary of global feature names and their corresponding functions.
+        per_region_raw (list): per_region_raw[region_index][feature_index] holds the raw
+            output of features[feature_index] applied to regions[region_index].
 
     Returns:
-        pd.DataFrame: DataFrame containing extracted features with one row per label and one column per feature.
+        collections.defaultdict: Mapping of column name to list of values.
     """
-    # Extract regions from the labeled segmentation mask
-    regions = regionprops_multichannel(labels, intensity_image=data)
+    feats = list(features.keys())
+    n = len(regions)
+    results = defaultdict(list)
 
-    # Initialize a defaultdict to store feature values
+    for fi, feature in enumerate(feats):
+        result_0 = per_region_raw[0][fi]
+        if isinstance(result_0, Iterable):
+            if len(result_0) == 1:
+                results[feature] = [per_region_raw[ri][fi][0] for ri in range(n)]
+            else:
+                for ri in range(n):
+                    for index, value in enumerate(per_region_raw[ri][fi]):
+                        results[f"{feature}_{index}"].append(value)
+        else:
+            results[feature] = [per_region_raw[ri][fi] for ri in range(n)]
+
+    return results
+
+
+def _feature_table_multichannel_sequential(regions, features):
+    """Sequential per-region feature computation (identical to the original loop).
+
+    Args:
+        regions (list): List of region properties objects.
+        features (dict): Dictionary of feature names and their corresponding functions.
+
+    Returns:
+        collections.defaultdict: Mapping of column name to list of values.
+    """
     results = defaultdict(list)
 
     # Loop through each feature and compute features for each region
@@ -82,6 +108,73 @@ def feature_table_multichannel(data, labels, features, global_features=None):
         else:
             # If the result is not iterable, apply the function to each region and append the result to the corresponding feature list
             results[feature] = list(map(func, regions))
+
+    return results
+
+
+def _compute_region_features(region, funcs):
+    """Apply every feature function to a single region.
+
+    Args:
+        region: A region properties object.
+        funcs (list): List of feature functions.
+
+    Returns:
+        list: Raw output of each function applied to the region, in order.
+    """
+    return [func(region) for func in funcs]
+
+
+def feature_table_multichannel(
+    data, labels, features, global_features=None, n_jobs=-1
+):
+    """Apply functions in feature dictionary to regions in data specified by integer labels.
+
+    If provided, the global feature dictionary is applied to the full input data and labels.
+    Results are combined in a dataframe with one row per label and one column per feature.
+
+    The per-region feature computation is parallelized with joblib threads. The mahotas
+    (haralick, pftas, zernike) and scipy feature functions are C-extensions that release
+    the GIL, so threading achieves real speedup. Setting ``n_jobs=1`` reproduces the
+    original sequential behavior bit-for-bit; on any joblib error the function falls back
+    to the sequential path.
+
+    Args:
+        data (np.ndarray): Image data.
+        labels (np.ndarray): Labeled segmentation mask defining objects to extract features from.
+        features (dict): Dictionary of feature names and their corresponding functions.
+        global_features (dict, optional): Dictionary of global feature names and their corresponding functions.
+        n_jobs (int, optional): Number of parallel threads for per-region computation.
+            Defaults to -1 (all available cores). n_jobs=1 runs sequentially.
+
+    Returns:
+        pd.DataFrame: DataFrame containing extracted features with one row per label and one column per feature.
+    """
+    # Extract regions from the labeled segmentation mask
+    regions = regionprops_multichannel(labels, intensity_image=data)
+
+    # 0-region guard — original indexed regions[0] and raised IndexError
+    if len(regions) == 0:
+        results = defaultdict(list)
+        if global_features:
+            for feature, func in global_features.items():
+                results[feature] = func(data, labels)
+        return pd.DataFrame(results)
+
+    if n_jobs == 1:
+        results = _feature_table_multichannel_sequential(regions, features)
+    else:
+        try:
+            from joblib import Parallel, delayed
+
+            funcs = list(features.values())
+            per_region_raw = Parallel(n_jobs=n_jobs, prefer="threads")(
+                delayed(_compute_region_features)(region, funcs) for region in regions
+            )
+            results = _assemble_feature_results(regions, features, per_region_raw)
+        except Exception:
+            # Fall back to the sequential implementation on any joblib/threading error
+            results = _feature_table_multichannel_sequential(regions, features)
 
     # If global features are provided, compute them and add them to the results
     if global_features:

--- a/workflow/lib/shared/illumination_correction.py
+++ b/workflow/lib/shared/illumination_correction.py
@@ -25,6 +25,7 @@ def calculate_ic_field(
     threading: bool = False,
     slicer: slice = slice(None),
     sample_fraction: float = 1.0,
+    n_jobs: int = 1,
 ) -> np.ndarray:
     """Calculate illumination correction field for use with the apply_ic_field.
 
@@ -43,6 +44,9 @@ def calculate_ic_field(
         threading (bool, optional): Whether to use threading for parallel processing. Defaults to False.
         slicer (slice, optional): Slice object to select specific parts of the images.
         sample_fraction (float, optional): Fraction of images to sample for calculation. Defaults to 1.0 (100% of images).
+        n_jobs (int, optional): Parallel workers for the file-accumulate reads and the per-channel
+            median filter. 1 (default) = serial (identical to prior behavior); >1 parallelizes
+            (bit-identical — read order preserved, float summation order unchanged).
 
     Returns:
         np.ndarray: The calculated illumination correction field.
@@ -57,13 +61,20 @@ def calculate_ic_field(
 
     # Accumulate images using threading or sequential processing, averaging them
     if threading:
-        # Accumulate results in parallel and combine them
-        results = Parallel(n_jobs=-1, require="sharedmem")(
-            delayed(accumulate_image)(file, slicer, np.zeros_like(data), len(files))
-            for file in files[1:]
-        )
-        for result in results:
-            data += result  # Aggregate results from parallel processing
+        # Parallel READ, in-order SUM. Reads (disk-bound) run concurrently in
+        # batches; the += stays in file order so the accumulator is byte-identical
+        # to the sequential path (float summation order preserved). Replaces the
+        # old np.zeros_like-per-file path that peaked at ~n_files*655MB (OOM).
+        N = len(files)
+        rest = files[1:]
+        batch = 16
+        read_frame = lambda f: read_image(f)[slicer]
+        for i in range(0, len(rest), batch):
+            imgs = Parallel(n_jobs=n_jobs, backend="threading")(
+                delayed(read_frame)(f) for f in rest[i : i + batch]
+            )
+            for img in imgs:
+                data += img / N
     else:
         for file in files[1:]:
             data = accumulate_image(file, slicer, data, len(files))
@@ -76,12 +87,17 @@ def calculate_ic_field(
         smooth = int(np.sqrt((data.shape[-1] * data.shape[-2]) / (np.pi * 20)))
 
     selem = morphology.disk(smooth)
-    median_filter = applyIJ(skimage.filters.median)
 
-    # Apply median filter with warning suppression
+    # Apply median filter with warning suppression.
+    # n_jobs>1 parallelizes across channel frames (bit-identical to the serial path).
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        smoothed = median_filter(data, selem, behavior="rank")
+        if n_jobs == 1:
+            smoothed = applyIJ(skimage.filters.median)(data, selem, behavior="rank")
+        else:
+            smoothed = applyIJ_parallel(
+                skimage.filters.median, data, footprint=selem, behavior="rank", n_jobs=n_jobs
+            )
 
     # Rescale channels if requested
     if rescale:

--- a/workflow/lib/shared/parquet_io.py
+++ b/workflow/lib/shared/parquet_io.py
@@ -22,6 +22,7 @@ Usage:
 from pathlib import Path
 from typing import Optional, Sequence, Union
 
+import numpy as np
 import pandas as pd
 
 try:
@@ -47,7 +48,7 @@ def read_parquet(
                 lf = lf.select(columns)
             return lf.collect().to_pandas()
         except (pl.exceptions.SchemaError, pl.exceptions.ComputeError):
-            # Mixed types in columns — fall back to pandas which is more lenient
+            # Mixed types in columns --- fall back to pandas which is more lenient
             return pd.read_parquet(path, columns=columns)
     else:
         return pd.read_parquet(path, columns=columns)
@@ -67,17 +68,50 @@ def read_parquets(
 
     if _HAS_POLARS:
         try:
-            lf = pl.scan_parquet(paths)
+            lf = pl.scan_parquet(paths, missing_columns="insert")
             if columns is not None:
                 lf = lf.select(columns)
             return lf.collect().to_pandas()
-        except pl.exceptions.SchemaError:
-            # Schema mismatch across files — fall back to per-file reads
+        except (pl.exceptions.SchemaError, pl.exceptions.ComputeError):
+            # Schema/type mismatch across files --- fall back to per-file reads
             dfs = [read_parquet(p, columns=columns) for p in paths]
             return pd.concat(dfs, ignore_index=True)
     else:
         dfs = [pd.read_parquet(p, columns=columns) for p in paths]
         return pd.concat(dfs, ignore_index=True)
+
+
+def resolve_table_path(path):
+    """Resolve a per-tile intermediate path to the on-disk file to read,
+    preferring parquet over its tsv sibling.
+
+    `path` may be given with either a .parquet or .tsv suffix. Checks the
+    .parquet sibling first, then .tsv. A file counts only if it exists AND is
+    non-empty (size > 0), matching the 0-byte skip semantics of the combine
+    fallback. Returns (str_path, "parquet"|"tsv") or (None, None) if neither
+    sibling has content.
+    """
+    base = Path(path)
+    for suffix, fmt in ((".parquet", "parquet"), (".tsv", "tsv")):
+        cand = base.with_suffix(suffix)
+        if cand.exists() and cand.stat().st_size > 0:
+            return str(cand), fmt
+    return None, None
+
+
+def read_table(path):
+    """Read a per-tile intermediate as a pandas DataFrame, preferring parquet
+    over its tsv sibling (via resolve_table_path). Raises FileNotFoundError if
+    neither sibling has content. parquet -> read_parquet(); tsv -> pd.read_csv
+    (sep tab)."""
+    resolved, fmt = resolve_table_path(path)
+    if resolved is None:
+        raise FileNotFoundError(
+            f"No non-empty parquet or tsv sibling found for {path}"
+        )
+    if fmt == "parquet":
+        return read_parquet(resolved)
+    return pd.read_csv(resolved, sep="\t")
 
 
 def write_parquet(
@@ -89,6 +123,20 @@ def write_parquet(
     Uses polars for faster writes when available, falls back to pandas.
     """
     if _HAS_POLARS:
+        # polars stringifies object columns whose cells are numpy arrays
+        # (e.g. sbs_info "bounds", a per-cell bbox that round-trips out of a
+        # parquet List column as an ndarray). Convert those to python lists so
+        # polars infers a proper List type instead of str(ndarray), keeping the
+        # combined table byte-consistent with the per-tile parquet files.
+        obj_cols = df.select_dtypes(include="object").columns
+        if len(obj_cols):
+            df = df.copy()
+            for c in obj_cols:
+                nonnull = df[c].dropna()
+                if len(nonnull) and isinstance(nonnull.iloc[0], np.ndarray):
+                    df[c] = df[c].map(
+                        lambda x: x.tolist() if isinstance(x, np.ndarray) else x
+                    )
         pl.from_pandas(df).write_parquet(str(path))
     else:
         df.to_parquet(path, index=False)

--- a/workflow/lib/shared/segment_cellpose.py
+++ b/workflow/lib/shared/segment_cellpose.py
@@ -29,6 +29,7 @@ for incompatible model/version combinations.
 """
 
 import sys
+from functools import lru_cache
 
 import numpy as np
 import pandas as pd
@@ -55,7 +56,31 @@ except (AttributeError, ValueError):
 CELLPOSE_4X = CELLPOSE_VERSION >= (4, 0)
 
 
-def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
+def select_gpu_device():
+    """Return the CUDA device with the most free VRAM across all visible GPUs.
+
+    Called once per segment job at startup so concurrent jobs naturally
+    spread across physical GPUs rather than all piling onto cuda:0.
+    """
+    import torch
+    if not torch.cuda.is_available():
+        return None
+    n = torch.cuda.device_count()
+    if n == 0:
+        return None
+    if n == 1:
+        return torch.device('cuda:0')
+    free = [torch.cuda.mem_get_info(i)[0] for i in range(n)]
+    return torch.device(f'cuda:{free.index(max(free))}')
+
+
+# batch_size only changes how many 224px patches share a forward pass, not the result;
+# 32 feeds the idle A100 VRAM. Override via cellpose_kwargs batch_size if needed.
+_SEG_BATCH_SIZE = 32
+
+
+@lru_cache(maxsize=8)  # per-worker process: build each Cellpose model once, reuse across tiles
+def create_cellpose_model(model_type: str, gpu: bool = False, device=None) -> CellposeModel:
     r"""Create a CellposeModel with version-aware initialization.
 
     Handles differences between Cellpose 3.x and 4.x APIs and validates
@@ -75,6 +100,10 @@ def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
     Raises:
         ValueError: If model_type is incompatible with installed Cellpose version.
     """
+    # Select best available GPU device when gpu=True and no explicit device given
+    if gpu and device is None:
+        device = select_gpu_device()
+
     # Check if model_type is a custom model path (contains path separators)
     is_custom_model = model_type is not None and (
         "/" in model_type or "\\" in model_type
@@ -99,12 +128,12 @@ def create_cellpose_model(model_type: str, gpu: bool = False) -> CellposeModel:
     # Version-aware initialization
     # Custom model paths use pretrained_model parameter in both versions
     if CELLPOSE_4X:
-        return CellposeModel(pretrained_model=model_type, gpu=gpu)
+        return CellposeModel(pretrained_model=model_type, gpu=gpu, device=device)
     elif is_custom_model:
         # For Cellpose 3.x with custom models, use pretrained_model
-        return CellposeModel(pretrained_model=model_type, gpu=gpu)
+        return CellposeModel(pretrained_model=model_type, gpu=gpu, device=device)
     else:
-        return CellposeModel(model_type=model_type, gpu=gpu)
+        return CellposeModel(model_type=model_type, gpu=gpu, device=device)
 
 
 def segment_cellpose(
@@ -378,16 +407,21 @@ def estimate_diameters(
     diam_nuclear = float(diam_nuclear)
     print(f"Estimated nuclear diameter: {diam_nuclear:.1f} pixels")
 
-    # Find optimal cell diameter using explicit SizeModel
+    # Find optimal cell diameter.
     print("Estimating cell diameters...")
-    model_cyto = CellposeModel(model_type=cellpose_model, gpu=gpu)
-    size_model_cyto = SizeModel(
-        cp_model=model_cyto,
-        pretrained_size=cellpose_models.size_model_path(cellpose_model),
-    )
-    diam_cell, _ = size_model_cyto.eval(rgb, channels=channels)
-    diam_cell = np.maximum(5.0, diam_cell)
-    diam_cell = float(diam_cell)
+    is_custom_model = "/" in cellpose_model or "\\" in cellpose_model
+    model_cyto = create_cellpose_model(cellpose_model, gpu=gpu)
+    if is_custom_model:
+        # Custom models have no companion SizeModel (_size.npy). Use the mean
+        # diameter of the model's training labels instead.
+        diam_cell = float(np.maximum(5.0, model_cyto.diam_labels))
+    else:
+        size_model_cyto = SizeModel(
+            cp_model=model_cyto,
+            pretrained_size=cellpose_models.size_model_path(cellpose_model),
+        )
+        diam_cell, _ = size_model_cyto.eval(rgb, channels=channels)
+        diam_cell = float(np.maximum(5.0, diam_cell))
     print(f"Estimated cell diameter: {diam_cell:.1f} pixels")
 
     return diam_nuclear, diam_cell
@@ -443,6 +477,9 @@ def segment_cellpose_rgb(
         nuclei_kwargs = kwargs.copy()
     if cell_kwargs is None:
         cell_kwargs = kwargs.copy()
+
+    nuclei_kwargs.setdefault("batch_size", _SEG_BATCH_SIZE)
+    cell_kwargs.setdefault("batch_size", _SEG_BATCH_SIZE)
 
     counts = {}
 
@@ -541,6 +578,7 @@ def segment_cellpose_nuclei_rgb(
 
     # Segment nuclei using CellposeModel from the RGB image
     # Pass only blue channel (DAPI) for nuclei segmentation
+    kwargs.setdefault("batch_size", _SEG_BATCH_SIZE)
     nuclei, _, _ = model.eval(rgb[2], diameter=nuclei_diameter, **kwargs)
 
     # Print the number of nuclei found before and after removing edges

--- a/workflow/rules/merge.smk
+++ b/workflow/rules/merge.smk
@@ -81,6 +81,10 @@ if merge_approach == "fast":
             warp_degree=config.get("merge", {}).get("warp_degree"),
             warp_iterations=config.get("merge", {}).get("warp_iterations"),
             warp_smoothing=config.get("merge", {}).get("warp_smoothing"),
+        threads: 1
+        resources:
+            mem_mb=8000,  # tune: holds full well phenotype+sbs info
+            runtime=20,   # minutes
         script:
             "../scripts/merge/fast_merge.py"
 
@@ -347,6 +351,7 @@ rule final_merge:
         MERGE_OUTPUTS_MAPPED["final_merge"][0],
     params:
         approach=config.get("merge", {}).get("approach", "fast"),
+        exclude_markers=config.get("merge", {}).get("exclude_markers"),
     script:
         "../scripts/merge/final_merge.py"
 

--- a/workflow/rules/phenotype.smk
+++ b/workflow/rules/phenotype.smk
@@ -9,6 +9,8 @@ rule apply_ic_field_phenotype:
         ancient(PREPROCESS_OUTPUTS["calculate_ic_phenotype"]),
     output:
         PHENOTYPE_OUTPUTS_MAPPED["apply_ic_field_phenotype"],
+    group:
+        "phenotype_tile"
     script:
         "../scripts/phenotype/apply_ic_field_phenotype.py"
 
@@ -22,6 +24,8 @@ rule align_phenotype:
         PHENOTYPE_OUTPUTS_MAPPED["align_phenotype"][1],  # alignment metrics TSV
     params:
         config=lambda wildcards: get_alignment_params(wildcards, config),
+    group:
+        "phenotype_tile"
     script:
         "../scripts/phenotype/align_phenotype.py"
 
@@ -34,6 +38,13 @@ rule segment_phenotype:
         PHENOTYPE_OUTPUTS_MAPPED["segment_phenotype"],
     params:
         config=lambda wildcards: get_segmentation_params("phenotype", config),
+    group:
+        "phenotype_tile"
+    threads: 4
+    resources:
+        gpu=1,
+        mem_mb=16000,  # tune: cellpose model + image
+        runtime=60,    # minutes
     script:
         "../scripts/shared/segment.py"
 
@@ -49,6 +60,8 @@ rule identify_cytoplasm:
         PHENOTYPE_OUTPUTS_MAPPED["identify_cytoplasm"],
     params:
         segment_cells=config.get("phenotype", {}).get("segment_cells", True),
+    group:
+        "phenotype_tile"
     script:
         "../scripts/phenotype/identify_cytoplasm_cellpose.py"
 
@@ -62,6 +75,8 @@ rule extract_phenotype_info:
         PHENOTYPE_OUTPUTS["align_phenotype"][1],
     output:
         PHENOTYPE_OUTPUTS_MAPPED["extract_phenotype_info"],
+    group:
+        "phenotype_tile"
     script:
         "../scripts/shared/extract_phenotype_minimal.py"
 
@@ -166,6 +181,13 @@ rule extract_phenotype_cp:
         cp_method=config.get("phenotype", {}).get("cp_method"),
         segment_cells=config.get("phenotype", {}).get("segment_cells", True),
         custom_features=config.get("phenotype", {}).get("custom_features"),
+    group:
+        "phenotype_tile"
+    threads: 4
+    resources:
+        mem_mb=8000,   # tune: widest table in memory
+        runtime=30,    # minutes
+    # thread-cap: set OMP_NUM_THREADS={threads} in cluster profile
     script:
         "../scripts/phenotype/extract_phenotype.py"
 
@@ -200,6 +222,11 @@ rule merge_phenotype:
         segment_cells=config.get("phenotype", {}).get("segment_cells", True),
     output:
         PHENOTYPE_OUTPUTS_MAPPED["merge_phenotype_cp"],
+    threads: 4
+    resources:
+        mem_mb=8000,   # tune: holds full well phenotype_cp
+        runtime=20,    # minutes
+    # thread-cap: polars uses POLARS_MAX_THREADS (not OMP); set POLARS_MAX_THREADS={threads} in cluster profile
     script:
         "../scripts/phenotype/merge_phenotype.py"
 

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -121,6 +121,7 @@ rule calculate_ic_sbs:
     params:
         threading=True,
         sample_fraction=config.get("preprocess", {}).get("sample_fraction", 1),
+    threads: config.get("preprocess", {}).get("ic_n_jobs", 8)
     script:
         "../scripts/preprocess/calculate_ic_field.py"
 
@@ -139,6 +140,7 @@ rule calculate_ic_phenotype:
     params:
         threading=True,
         sample_fraction=config.get("preprocess", {}).get("sample_fraction", 1),
+    threads: config.get("preprocess", {}).get("ic_n_jobs", 8)
     script:
         "../scripts/preprocess/calculate_ic_field.py"
 

--- a/workflow/rules/sbs.smk
+++ b/workflow/rules/sbs.smk
@@ -118,6 +118,8 @@ rule segment_sbs:
         SBS_OUTPUTS_MAPPED["segment_sbs"],
     params:
         config=lambda wildcards: get_segmentation_params("sbs", config),
+    resources:
+        gpu=1,
     script:
         "../scripts/shared/segment.py"
 

--- a/workflow/scripts/aggregate/generate_feature_table.py
+++ b/workflow/scripts/aggregate/generate_feature_table.py
@@ -1,6 +1,7 @@
 import gc
 import math
 
+import polars as pl
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pyarrow.dataset as ds
@@ -97,16 +98,8 @@ print(f"Processing data in {num_batches} batch(es), ~{chunk_size} rows per batch
 aligned_output = snakemake.output[0]
 writer = None
 
-# Accumulators for per-construct data collected across batches
-construct_cell_counts = {}  # {construct_id: count}
-construct_gene_map = {}  # {construct_id: gene_name}
-construct_control_map = {}  # {construct_id: control_name_col value (for control id)}
-construct_feature_sums = {}  # {construct_id: [sum of features]}
-construct_feature_counts = {}  # {construct_id: count for averaging}
-# For median, we need all values - store them
-construct_feature_values = {}  # {construct_id: list of feature arrays}
-construct_group_map = {}  # {construct_id: group label}
-
+# Construct-level medians are computed lazily from the aligned parquet with
+# polars after the batch loop, so no per-construct accumulators are needed here.
 # Process each batch
 for batch_idx, indices in enumerate(subset_indices):
     print(
@@ -183,25 +176,6 @@ for batch_idx, indices in enumerate(subset_indices):
     del aligned_table, aligned_batch
     gc.collect()
 
-    # Accumulate construct-level data for median computation
-    print(f"Accumulating construct statistics for batch {batch_idx + 1}...")
-    for construct_id in metadata[pert_id_col].unique():
-        mask = metadata[pert_id_col].values == construct_id
-        construct_features = features[mask]
-        gene_name = metadata.loc[mask, pert_col].iloc[0]
-        control_name = metadata.loc[mask, control_name_col].iloc[0]
-
-        if construct_id not in construct_cell_counts:
-            construct_cell_counts[construct_id] = 0
-            construct_gene_map[construct_id] = gene_name
-            construct_control_map[construct_id] = control_name
-            construct_feature_values[construct_id] = []
-            if group_cols:
-                construct_group_map[construct_id] = group_labels[mask].iloc[0]
-
-        construct_cell_counts[construct_id] += mask.sum()
-        construct_feature_values[construct_id].append(construct_features)
-
     # Clean up batch data
     del metadata, features
     gc.collect()
@@ -211,42 +185,29 @@ if writer is not None:
     writer.close()
 print(f"\nSaved aligned cell data to: {aligned_output}")
 
-# TABLE 1: Construct-level table (one row per sgRNA)
+# TABLE 1: Construct-level table (one row per sgRNA).
+# Computed lazily from the aligned parquet — avoids holding all cell feature
+# vectors in memory across batches.
 print("\n=== Creating construct-level table ===")
 
-construct_rows = []
-for construct_id in construct_cell_counts.keys():
-    # Concatenate all feature arrays for this construct
-    all_features = np.vstack(construct_feature_values[construct_id])
-    # Compute median across all cells; nanmedian because per-well filtering drops
-    # different columns in different wells, so the unified schema carries NaN for
-    # columns absent from a construct's well
-    median_features = np.nanmedian(all_features, axis=0)
+# Lazily aggregate construct-level medians from the aligned parquet with polars.
+# control_name_col drives the control/gene split below; carry it through the
+# aggregation when it is a column distinct from the ones already selected.
+_carry_control = control_name_col not in (pert_id_col, pert_col)
+agg_exprs = [pl.first(pert_col).alias(pert_col), pl.len().alias("cell_count")]
+if _carry_control:
+    agg_exprs.append(pl.first(control_name_col).alias(control_name_col))
+agg_exprs += [pl.median(c).alias(c) for c in feature_cols]
 
-    row = {
-        pert_id_col: construct_id,
-        pert_col: construct_gene_map[construct_id],
-        control_name_col: construct_control_map[construct_id],
-        "cell_count": construct_cell_counts[construct_id],
-    }
-    for i, col in enumerate(feature_cols):
-        row[col] = median_features[i]
-    construct_rows.append(row)
+lf = pl.scan_parquet(aligned_output)
+construct_agg = lf.group_by(pert_id_col).agg(agg_exprs).collect().to_pandas()
 
-# Free memory from accumulated features
-del construct_feature_values
-gc.collect()
-
-construct_table = pd.DataFrame(construct_rows)
-
-# Reorder columns: sgRNA, gene, cell_count, features
-# Dedupe preserving order; control_name_col must survive for the control filter below
-construct_columns = list(
-    dict.fromkeys(
-        [pert_id_col, pert_col, control_name_col, "cell_count"] + feature_cols
-    )
-)
-construct_table = construct_table[construct_columns]
+construct_columns = [pert_id_col, pert_col]
+if _carry_control:
+    construct_columns.append(control_name_col)
+construct_columns += ["cell_count"] + feature_cols
+construct_table = construct_agg[construct_columns].copy()
+construct_table["cell_count"] = construct_table["cell_count"].astype(int)
 
 print(f"Construct table shape: {construct_table.shape}")
 
@@ -299,24 +260,12 @@ if pseudogene_patterns:
     # Import the pseudo-gene grouping function
     from lib.aggregate.bootstrap import create_pseudogene_groups
 
-    if group_cols:
-        pseudogene_groups = []
-        construct_groups = construct_table[pert_id_col].map(construct_group_map)
-        for group_label in sorted(construct_groups.dropna().unique()):
-            group_pseudogenes, _ = create_pseudogene_groups(
-                construct_table[construct_groups == group_label],
-                pseudogene_patterns,
-                pert_col,
-                seed=42,
-            )
-            for pseudogene_group in group_pseudogenes:
-                pseudogene_group["pseudogene_id"] += f"{GROUP_KEY_SEP}{group_label}"
-            pseudogene_groups.extend(group_pseudogenes)
-    else:
-        # Create pseudo-gene groups from construct table
-        pseudogene_groups, remaining_constructs = create_pseudogene_groups(
-            construct_table, pseudogene_patterns, pert_col, seed=42
-        )
+    # Group labels are already folded into pert_col/pert_id_col during batch
+    # processing (a construct's identity is perturbation x group), so pseudo-gene
+    # grouping operates on the construct table directly without a separate group map.
+    pseudogene_groups, remaining_constructs = create_pseudogene_groups(
+        construct_table, pseudogene_patterns, pert_col, seed=42
+    )
 
     pseudogene_rows = []
 

--- a/workflow/scripts/merge/fast_merge.py
+++ b/workflow/scripts/merge/fast_merge.py
@@ -44,16 +44,20 @@ warp_kwargs = {
     if v is not None
 } or None
 
+# Pre-group cell tables by tile once (O(n) instead of O(n_alignments * n_cells)).
+phenotype_by_tile = dict(tuple(phenotype_info.groupby("tile")))
+sbs_by_tile = dict(tuple(sbs_info.groupby("tile")))
+_empty_ph = phenotype_info.iloc[0:0]
+_empty_sbs = sbs_info.iloc[0:0]
+
 # Merge cells across well
 merge_data = []
-for index, alignment_row in fast_alignment_filtered.iterrows():
-    # Determine tiles and sites for merging
+for _index, alignment_row in fast_alignment_filtered.iterrows():
     phenotype_tile = alignment_row["tile"]
     sbs_site = alignment_row["site"]
 
-    # Filter phenotype and sbs info to the relevant well and tile for merging
-    phenotype_info_filtered = phenotype_info[phenotype_info["tile"] == phenotype_tile]
-    sbs_info_filtered = sbs_info[sbs_info["tile"] == sbs_site]
+    phenotype_info_filtered = phenotype_by_tile.get(phenotype_tile, _empty_ph)
+    sbs_info_filtered = sbs_by_tile.get(sbs_site, _empty_sbs)
 
     # Merge cells for row of alignment data
     alignment_row_merge = merge_triangle_hash(

--- a/workflow/scripts/merge/final_merge.py
+++ b/workflow/scripts/merge/final_merge.py
@@ -1,33 +1,11 @@
-import pandas as pd
+from lib.merge.final_merge import final_merge
 
-from lib.shared.file_utils import validate_dtypes
-from lib.shared.parquet_io import read_parquet, write_parquet
-
-# Load deduplicated merge data (global_i_*/global_j_* already attached in format_merge)
-merge_deduplicated = validate_dtypes(read_parquet(snakemake.input[0]))
-
-approach = snakemake.params.approach
-
-# Load full feature data
-cp_phenotype = validate_dtypes(read_parquet(snakemake.input[1]))
-
-# Merge full CP data on deduplicated
-merged_final = merge_deduplicated.merge(
-    cp_phenotype.rename(columns={"label": "cell_0"}),
-    how="left",
-    on=["plate", "well", "tile", "cell_0"],
+# Thin wrapper over the shared streaming merge so every caller uses identical
+# logic (see lib/merge/final_merge.py).
+final_merge(
+    deduplicated_path=snakemake.input[0],
+    phenotype_cp_path=snakemake.input[1],
+    output_path=snakemake.output[0],
+    approach=snakemake.params.approach,
+    exclude_markers=snakemake.params.exclude_markers,
 )
-
-# Rename coordinate columns to global naming convention only for stitch approach
-if approach == "stitch":
-    merged_final = merged_final.rename(
-        columns={
-            "i_0": "global_i_0",
-            "j_0": "global_j_0",
-            "i_1": "global_i_1",
-            "j_1": "global_j_1",
-        }
-    )
-
-# Save final merged dataset
-write_parquet(merged_final, snakemake.output[0])

--- a/workflow/scripts/phenotype/extract_phenotype.py
+++ b/workflow/scripts/phenotype/extract_phenotype.py
@@ -1,5 +1,15 @@
 from lib.shared.image_io import read_image
 import pandas as pd
+from lib.shared.parquet_io import write_parquet
+
+# Cap BLAS/OMP threads to match Snakemake's reserved CPU budget.
+# Without this, numpy/OpenBLAS spawns threads across all cores regardless
+# of --cores, causing oversubscription when many tiles run concurrently.
+try:
+    from threadpoolctl import threadpool_limits
+    threadpool_limits(limits=snakemake.threads)
+except ImportError:
+    pass
 
 # foci_channel_index intentionally omitted — extract_phenotype_cp_emulator handles foci_channel=None
 for _param_name in ["cp_method", "channel_names"]:
@@ -58,6 +68,7 @@ elif cp_method == "cp_emulator":
         channel_names=snakemake.params.channel_names,
         wildcards=wc,
         custom_features=load_custom_features(custom_feature_definitions),
+        n_jobs=snakemake.threads,
     )
 else:
     raise ValueError(
@@ -78,5 +89,5 @@ phenotype_cp["num_nuclei"] = (
     cell_labels.map(nuclei_per_cell["num_nuclei"]).fillna(1).astype(int)
 )
 
-# save phenotype cp
-phenotype_cp.to_csv(snakemake.output[0], index=False, sep="\t")
+# Save phenotype cp
+write_parquet(phenotype_cp, snakemake.output[0])

--- a/workflow/scripts/phenotype/merge_phenotype.py
+++ b/workflow/scripts/phenotype/merge_phenotype.py
@@ -1,8 +1,4 @@
-import pandas as pd
-from joblib import Parallel, delayed
-
-from lib.shared.file_utils import read_tsv_safe
-from lib.shared.parquet_io import write_parquet
+from lib.shared.parquet_io import read_parquets, write_parquet
 
 
 # Validate required params
@@ -10,12 +6,10 @@ if getattr(snakemake.params, "channel_names", None) is None:
     raise ValueError("Required config parameter 'channel_names' is not set")
 
 
-# Load, concatenate, and save the phenotype CellProfiler data
-arr_reads = Parallel(n_jobs=snakemake.threads)(
-    delayed(read_tsv_safe)(file) for file in snakemake.input
-)
-valid_dfs = [df for df in arr_reads if not df.empty]
-phenotype_cp = pd.concat(valid_dfs) if valid_dfs else pd.DataFrame()
+# Load and concatenate the per-tile phenotype CellProfiler parquets.
+# read_parquets uses polars scan+concat with a pandas fallback on schema
+# mismatch across tiles; it returns an empty DataFrame for an empty input list.
+phenotype_cp = read_parquets(list(snakemake.input))
 write_parquet(phenotype_cp, snakemake.output[0])
 
 

--- a/workflow/scripts/preprocess/calculate_ic_field.py
+++ b/workflow/scripts/preprocess/calculate_ic_field.py
@@ -6,6 +6,7 @@ ic_field = calculate_ic_field(
     snakemake.input,
     threading=snakemake.params.threading,
     sample_fraction=snakemake.params.sample_fraction,
+    n_jobs=snakemake.threads,
 )
 
 # Save IC field (supports both TIFF and Zarr based on output path)

--- a/workflow/scripts/sbs/call_cells.py
+++ b/workflow/scripts/sbs/call_cells.py
@@ -3,18 +3,17 @@
 Supports both single-barcode and multi-barcode protocols.
 """
 
-import pandas as pd
-
-from lib.sbs.call_cells import call_cells
+from lib.sbs.call_cells import call_cells, load_barcode_library
+from lib.shared.parquet_io import read_table, write_parquet
 
 # Get configuration from params
 params = snakemake.params.config
 
-# Load reads data
-reads_data = pd.read_csv(snakemake.input[0], sep="\t")
+# Load reads data (parquet in a fresh DAG; read_table resolves parquet-or-tsv)
+reads_data = read_table(snakemake.input[0])
 
 # Load barcode library
-df_barcode_library = pd.read_csv(params["df_barcode_library_fp"], sep="\t")
+df_barcode_library = load_barcode_library(params["df_barcode_library_fp"])
 
 # Choose calling method based on barcode_type parameter
 barcode_type = params.get("barcode_type", "simple")
@@ -52,4 +51,4 @@ else:
     )
 
 # Save cells data
-cells_data.to_csv(snakemake.output[0], index=False, sep="\t")
+write_parquet(cells_data, snakemake.output[0])

--- a/workflow/scripts/sbs/call_reads.py
+++ b/workflow/scripts/sbs/call_reads.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from lib.sbs.call_reads import call_reads
+from lib.shared.parquet_io import write_parquet
 from lib.shared.image_io import read_image
 
 # Load bases data
@@ -31,4 +32,4 @@ reads_data = call_reads(
 )
 
 # Save reads data
-reads_data.to_csv(snakemake.output[0], index=False, sep="\t")
+write_parquet(reads_data, snakemake.output[0])

--- a/workflow/scripts/sbs/eval_mapping.py
+++ b/workflow/scripts/sbs/eval_mapping.py
@@ -34,9 +34,10 @@ else:
     barcodes = get_barcode_list(df_barcode_library)
 
 # Load SBS processing files
-reads = read_parquets(snakemake.input.reads_paths)
+# eval reads only need these cols (barcode match + well/tile/cell grouping).
+reads = read_parquets(snakemake.input.reads_paths, columns=["cell", "well", "tile", "barcode", "Q_min", "peak"])
 cells = read_parquets(snakemake.input.cells_paths)
-sbs_info = read_parquets(snakemake.input.sbs_info_paths)
+sbs_info = read_parquets(snakemake.input.sbs_info_paths, columns=["well", "tile", "cell"])
 
 # Load metadata for spatial heatmap plotting
 metadata = pd.concat(

--- a/workflow/scripts/shared/combine_dfs.py
+++ b/workflow/scripts/shared/combine_dfs.py
@@ -1,28 +1,14 @@
 import pandas as pd
-from joblib import Parallel, delayed
 
-from lib.shared.file_utils import validate_dtypes, read_tsv_safe
+from lib.shared.combine_dfs import combine_tile_dfs
 from lib.shared.parquet_io import write_parquet
 
-# Load and concatenate data
-all_dfs = Parallel(n_jobs=snakemake.threads)(
-    delayed(read_tsv_safe)(file) for file in snakemake.input
-)
-valid_dfs = [df for df in all_dfs if not df.empty]
-combined_df = (
-    pd.concat(valid_dfs).reset_index(drop=True) if valid_dfs else pd.DataFrame()
-)
-
-# Validate col types
-# Empty dfs can cause issues with dtype
-combined_df = validate_dtypes(combined_df)
-
-# Coerce numeric-looking object columns to numeric dtypes
-# Prevents schema mismatches (e.g. Int64 vs String) across parquets from different wells
-for col in combined_df.select_dtypes(include="object").columns:
-    converted = pd.to_numeric(combined_df[col], errors="coerce")
-    if converted.notna().sum() >= combined_df[col].notna().sum() * 0.95:
-        combined_df[col] = converted
+# Read per-tile TSVs, concat, and normalize dtypes (shared helper).
+combined_df = combine_tile_dfs(snakemake.input)
+# Helper returns None when no tile yielded a frame (all-empty well); snakemake
+# still requires output[0] be written, so fall back to an empty frame.
+if combined_df is None:
+    combined_df = pd.DataFrame()
 
 # Save the data based on output_type
 output_type = getattr(snakemake.params, "output_type", "parquet")

--- a/workflow/scripts/shared/eval_segmentation.py
+++ b/workflow/scripts/shared/eval_segmentation.py
@@ -24,7 +24,8 @@ segmentation_overview_df.to_csv(snakemake.output[0], sep="\t", index=False)
 
 
 # load cell data
-cells = read_parquets(snakemake.input.cells_paths)
+# plot_cell_density_heatmap only groups by well,tile.
+cells = read_parquets(snakemake.input.cells_paths, columns=["well", "tile"])
 
 # Load metadata for spatial heatmap plotting
 metadata = pd.concat(

--- a/workflow/scripts/shared/extract_phenotype_minimal.py
+++ b/workflow/scripts/shared/extract_phenotype_minimal.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from lib.shared.extract_phenotype_minimal import extract_phenotype_minimal
 from lib.shared.image_io import read_image
+from lib.shared.parquet_io import write_parquet
 
 # Load nuclei data
 nuclei_data = read_image(snakemake.input[0])
@@ -39,4 +40,8 @@ if len(snakemake.input) > 2:
     )
 
 # save minimal phenotype data
-phenotype_minimal.to_csv(snakemake.output[0], index=False, sep="\t")
+# Shared script: SBS sbs_info writes parquet; phenotype phenotype_info stays TSV.
+if str(snakemake.output[0]).endswith(".parquet"):
+    write_parquet(phenotype_minimal, snakemake.output[0])
+else:
+    phenotype_minimal.to_csv(snakemake.output[0], index=False, sep="\t")

--- a/workflow/targets/phenotype.smk
+++ b/workflow/targets/phenotype.smk
@@ -52,7 +52,7 @@ PHENOTYPE_OUTPUTS = {
         PHENOTYPE_FP / get_image_output_path(_tile, "updated_cytoplasms", PHENOTYPE_IMG_FMT, subdirectory="labels"),
     ],
     "extract_phenotype_cp": [
-        PHENOTYPE_FP / "tsvs" / get_data_output_path(_tile, "phenotype_cp", "tsv", PHENOTYPE_IMG_FMT),
+        PHENOTYPE_FP / "parquets" / get_data_output_path(_tile, "phenotype_cp", "parquet", PHENOTYPE_IMG_FMT),
     ],
     "extract_phenotype_second_objs": [
         PHENOTYPE_FP / "tsvs" / get_data_output_path(_tile, "phenotype_second_objs", "tsv", PHENOTYPE_IMG_FMT),
@@ -86,7 +86,7 @@ _phenotype_img_temp = None if PHENOTYPE_IMG_FMT == "zarr" else temp
 _phenotype_label_keep = directory if PHENOTYPE_IMG_FMT == "zarr" else None
 
 PHENOTYPE_OUTPUT_MAPPINGS = {
-    "apply_ic_field_phenotype": _phenotype_img_temp,
+    "apply_ic_field_phenotype": None,  # keep IC-corrected phenotype on disk (was temp) — avoids pre-seg recompute
     "align_phenotype": None,
     "segment_phenotype": [_phenotype_label_keep, _phenotype_label_keep, None, None],
     "identify_cytoplasm": _phenotype_label_keep,

--- a/workflow/targets/sbs.smk
+++ b/workflow/targets/sbs.smk
@@ -47,13 +47,13 @@ SBS_OUTPUTS = {
         SBS_FP / "tsvs" / get_data_output_path(_tile, "bases", "tsv", SBS_IMG_FMT),
     ],
     "call_reads": [
-        SBS_FP / "tsvs" / get_data_output_path(_tile, "reads", "tsv", SBS_IMG_FMT),
+        SBS_FP / "tsvs" / get_data_output_path(_tile, "reads", "parquet", SBS_IMG_FMT),
     ],
     "call_cells": [
-        SBS_FP / "tsvs" / get_data_output_path(_tile, "cells", "tsv", SBS_IMG_FMT),
+        SBS_FP / "tsvs" / get_data_output_path(_tile, "cells", "parquet", SBS_IMG_FMT),
     ],
     "extract_sbs_info": [
-        SBS_FP / "tsvs" / get_data_output_path(_tile, "sbs_info", "tsv", SBS_IMG_FMT),
+        SBS_FP / "tsvs" / get_data_output_path(_tile, "sbs_info", "parquet", SBS_IMG_FMT),
     ],
     "combine_reads": [
         SBS_FP / "parquets" / get_data_output_path(_well, "reads", "parquet", SBS_IMG_FMT),
@@ -91,12 +91,12 @@ _sbs_img_temp = None if SBS_IMG_FMT == "zarr" else temp
 _sbs_label_keep = directory if SBS_IMG_FMT == "zarr" else None
 
 SBS_OUTPUT_MAPPINGS = {
-    "align_sbs": None,
-    "log_filter": _sbs_img_temp,
-    "compute_standard_deviation": _sbs_img_temp,
-    "find_peaks": _sbs_img_temp,
-    "max_filter": _sbs_img_temp,
-    "apply_ic_field_sbs": _sbs_img_temp,
+    "align_sbs": None,  # keep on disk so apply_ic_field_sbs is never considered stale
+    "log_filter": None,  # keep pre-seg intermediate on disk (was temp) — avoids per-tile recompute sawtooth
+    "compute_standard_deviation": None,  # keep pre-seg intermediate on disk (was temp) — avoids per-tile recompute sawtooth
+    "find_peaks": None,  # keep pre-seg intermediate on disk (was temp) — avoids per-tile recompute sawtooth
+    "max_filter": None,  # keep pre-seg intermediate on disk (was temp) — avoids per-tile recompute sawtooth
+    "apply_ic_field_sbs": None,  # keep on disk to avoid re-running before segment_sbs
     "segment_sbs": [_sbs_label_keep, _sbs_label_keep, None, None],
     "extract_bases": None,
     "call_reads": None,


### PR DESCRIPTION
# perf: snakemake-path performance optimizations

Performance optimizations for the Snakemake execution path. Change preserves upstream behavior on both the Snakemake and direct-runner paths; where an intermediate format changes (TSV→parquet) upstream semantics (`num_nuclei` enumeration, secondary-object handling) are preserved.

## Why

On real screens (plate-scale, ~1M cells/well, ~3600 phenotype columns) several steps were the wall-clock bottleneck or OOM'd outright. These changes make the pipeline finish where it previously stalled, without altering scientific output (two intentional exceptions called out below).

Note that some changes led to a larger disk storage space footprint - refer to `*.smk` files due to intermediate/temp files being retained.

## What changed — before/after

| Area | Change | Before → After |
|---|---|---|
| **merge** | `final_merge` streams the wide phenotype join out-of-core with polars `scan_parquet → left join → sink_parquet` instead of a pandas full-load merge that OOM'd | **721s → 44s** (well A1, ~3600 cols × 1.06M rows) |
| **merge** | `fast_merge` groups tiles once instead of per-pair | **O(n²) → O(n)** |
| **segmentation** | `identify_cytoplasm` per-region loop → vectorized `np.where` (bit-identical masks) | **~357×** |
| **segmentation** | `lru_cache` the Cellpose model (built once per worker, not per tile), eval `batch_size=32`, multi-GPU `select_gpu_device` fan-out | model build amortized; GPU fan-out |
| **io** | Per-tile phenotype tables, sbs reads/`sbs_info`, and combine step migrated TSV→parquet via shared `parquet_io` + `combine_dfs` | write traffic **5.0× lower**, on-disk **2.7× smaller**, merge read-back **1.9× faster** |
| **sbs** | `align_sbs` error-correction uses an O(1) hamming-1 lookup index instead of O(n·library) scan; `call_cells`/`eval_mapping` project only needed columns and skip unused QC recompute | O(1) correction lookup |
| **phenotype** | `extract_phenotype_cp_emulator` gains per-object parallelism (`n_jobs`); callers cap BLAS threads so nested threadpools don't oversubscribe cores | parallel extraction, no oversubscription |
| **preprocess** | `calculate_ic_field` gains a tunable `n_jobs` (config `preprocess.ic_n_jobs`, default 8): batched memory-bounded accumulate reads + `applyIJ_parallel` median filter. **Bit-identical** to the serial path (read order + float summation order preserved) | parallel IC, OOM-free |
| **aggregate** | `generate_feature_table` computes construct-level medians lazily via `scan_parquet().group_by().median()` instead of accumulating every cell's feature vector across batches | O(1) memory aggregation |
| **scheduling** | `threads`/`resources`/`gpu` directives on sbs/phenotype/merge rules; pre-segmentation intermediates no longer marked `temp()` so a rerun before segmentation doesn't recompute the whole pre-seg chain (18 sbs + 15 phenotype intermediates); preprocess reads ND2 binning from the text-info block only (no multi-GB pixel materialization) | correct parallelism, no pre-seg recompute sawtooth |

## Behavior changes (intentional — please review)

1. **Aggregate pseudo-gene grouping (see #258).** The lazy polars aggregation folds group labels into the perturbation id, so grouped construct medians are preserved. The one change: pseudo-gene grouping now runs over the flat construct table rather than being split per group label. This is the most likely point of pushback — flagging it explicitly.
2. **IC-field `n_jobs` default.** The `calculate_ic_{sbs,phenotype}` rules now carry `threads: config.get("preprocess",{}).get("ic_n_jobs", 8)`; upstream previously hardcoded `n_jobs=-1` inside the function. Output is bit-identical; only the scheduler thread reservation changes.

## Deliberately excluded (separate future PRs)

- **IC-field reproducibility seeding** — `calculate_ic_field` subsamples tiles with an unseeded RNG. A `random_seed` knob will land as its own PR (kept separate from the parallelization here).
- **RANSAC determinism seeding** — seeding `RANSACRegressor` in the merge alignment path will land as its own PR.

## Testing

Full E2E on the small test dataset passed clean end-to-end (**3797/3797 steps, exit 0**), exercising the parquet migration and the polars aggregate path; parquet outputs verified (phenotype_cp, aggregate feature tables, `merge_final.parquet`) with no stray TSVs. Unit tests: 124 passed, 5 skipped.

Performance optimizations in this PR have not been tested with SLURM.

---

Supersedes #268 and #283; all three share the same head commit and content. The head branch now lives at `up/perf-zarr3`. The `up/` prefix marks branches cut from upstream and intended for contribution here, keeping them distinguishable from this fork's long-lived local development branches. No review had been left on either predecessor, so nothing is lost.
