### PR TITLE
feat(preprocess): seedable IC-field sampling for reproducibility

### DIFF
--- a/workflow/lib/shared/illumination_correction.py
+++ b/workflow/lib/shared/illumination_correction.py
@@ -25,6 +25,7 @@ def calculate_ic_field(
     threading: bool = False,
     slicer: slice = slice(None),
     sample_fraction: float = 1.0,
+    random_seed: int = None,
 ) -> np.ndarray:
     """Calculate illumination correction field for use with the apply_ic_field.
 
@@ -43,6 +44,7 @@ def calculate_ic_field(
         threading (bool, optional): Whether to use threading for parallel processing. Defaults to False.
         slicer (slice, optional): Slice object to select specific parts of the images.
         sample_fraction (float, optional): Fraction of images to sample for calculation. Defaults to 1.0 (100% of images).
+        random_seed (int, optional): Seed for the file-subsample RNG. None (default) keeps the prior nondeterministic sampling; set an int for a reproducible IC field.
 
     Returns:
         np.ndarray: The calculated illumination correction field.
@@ -50,7 +52,7 @@ def calculate_ic_field(
     # Randomly sample a subset of files if sample_fraction is less than 1.0
     if sample_fraction < 1.0:
         sample_size = int(len(files) * sample_fraction)
-        files = random.sample(files, sample_size)
+        files = random.Random(random_seed).sample(files, sample_size)
 
     # Initialize data variable
     data = read_image(files[0])[slicer] / len(files)

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -121,6 +121,7 @@ rule calculate_ic_sbs:
     params:
         threading=True,
         sample_fraction=config.get("preprocess", {}).get("sample_fraction", 1),
+        random_seed=config.get("preprocess", {}).get("ic_random_seed", None),
     script:
         "../scripts/preprocess/calculate_ic_field.py"
 
@@ -139,6 +140,7 @@ rule calculate_ic_phenotype:
     params:
         threading=True,
         sample_fraction=config.get("preprocess", {}).get("sample_fraction", 1),
+        random_seed=config.get("preprocess", {}).get("ic_random_seed", None),
     script:
         "../scripts/preprocess/calculate_ic_field.py"
 

--- a/workflow/scripts/preprocess/calculate_ic_field.py
+++ b/workflow/scripts/preprocess/calculate_ic_field.py
@@ -6,6 +6,7 @@ ic_field = calculate_ic_field(
     snakemake.input,
     threading=snakemake.params.threading,
     sample_fraction=snakemake.params.sample_fraction,
+    random_seed=snakemake.params.random_seed,
 )
 
 # Save IC field (supports both TIFF and Zarr based on output path)


### PR DESCRIPTION
# feat(preprocess): seedable IC-field sampling for reproducibility

## Motivation

When `preprocess.sample_fraction < 1.0`, `calculate_ic_field` subsamples the input tiles to compute the illumination-correction (IC) field. That subsampling uses the module-global `random` RNG with no seed, so a different subset of tiles is drawn on every run. Because the IC field is derived from that subset, the field — and every downstream corrected intensity — changes run-to-run. In practice this produces **2-5% per-channel run-to-run differences in corrected intensities**, which is the root cause of previously-observed intensity drift between otherwise-identical runs.

A reproducible IC field is a prerequisite for reproducible corrected intensities, which in turn matters for any comparison across runs (QC, benchmarking, debugging apparent regressions).

## What changed

- `calculate_ic_field` (`workflow/lib/shared/illumination_correction.py`) gains a `random_seed: int = None` parameter. The subsample line now draws from a local `random.Random(random_seed)` instead of the global `random` module, so a fixed seed yields a bit-identical file subset (and thus a bit-identical IC field).
- `workflow/scripts/preprocess/calculate_ic_field.py` passes `random_seed=snakemake.params.random_seed`.
- `rule calculate_ic_sbs` and `rule calculate_ic_phenotype` (`workflow/rules/preprocess.smk`) read the seed from config as `config.get("preprocess", {}).get("ic_random_seed", None)`.

## Default preserves current behavior

`random_seed` defaults to `None`, and `random.Random(None)` seeds from system entropy — identical to the prior unseeded `random.sample` behavior. If `preprocess.ic_random_seed` is not set in config, nothing changes. Reproducibility is strictly opt-in via setting an integer seed.

## Usage — how to set the seed

Add `ic_random_seed` under the `preprocess` block of your analysis `config.yml` (the same block that holds `sample_fraction`). Any integer makes the IC-field tile subsample reproducible across runs:

```yaml
preprocess:
  sample_fraction: 0.25   # subsampling is only active when < 1.0
  ic_random_seed: 0       # any fixed int -> reproducible IC field; omit/null = current unseeded behavior
```

Both `calculate_ic_sbs` and `calculate_ic_phenotype` pick it up automatically. When calling `calculate_ic_field` directly (e.g. a notebook or the direct runner), pass it as a keyword:

```python
ic_field = calculate_ic_field(files, threading=True, sample_fraction=0.25, random_seed=0)
```

## Verification

Verified on the **real small-test dataset** (`tests/small_test_analysis`), not a synthetic fixture. Using the 3 converted phenotype tiles for well A1 (`P-1_W-A1_T-{2,5,141}`, each `(4, 2400, 2400)`) as input to `calculate_ic_field` at `sample_fraction=0.67` (subsamples 2 of 3 tiles, so the seed decides which pair):

- **Seeded is reproducible:** two `calculate_ic_field(files, threading=True, sample_fraction=0.67, random_seed=0)` calls returned bit-identical fields (`np.array_equal` → `True`).
- **Unseeded is not:** 8 draws with `random_seed=None` produced **3 distinct** IC fields — directly reproducing the run-to-run drift this PR fixes.

The matching pytest selection (`-k "ic or illumination or preprocess"`) passes (3 passed, 1 skipped).

## Independence from the perf PR

This PR is based directly on `upstream/zarr3` and is independent of the IC-field **parallelization** perf PR (cheeseman-lab/brieflow#268, branch `perf/zarr3-snakemake`), which adds an orthogonal `n_jobs` parameter (parallel per-channel median filter). This change touches only the `random_seed` sampling machinery — none of the parallelization, batched accumulate, or `smooth` wiring is included.

At integration time there is one expected **trivial signature merge** on `calculate_ic_field`: both PRs add a keyword-only parameter after `sample_fraction` (`random_seed` here, `n_jobs` in the perf PR). The two params are non-overlapping; resolving the merge is just keeping both new arguments in the signature and both call-site kwargs.

---

Supersedes #269 and #284; all three share the same head commit and content. The head branch now lives at `up/feat-ic-random-seed`. The `up/` prefix marks branches cut from upstream and intended for contribution here, keeping them distinguishable from this fork's long-lived local development branches. No review had been left on either predecessor, so nothing is lost.
